### PR TITLE
Using dev config for lavalink setup

### DIFF
--- a/config.ts.example
+++ b/config.ts.example
@@ -5,6 +5,7 @@ import { RPoolConnectionOptions } from 'rethinkdb-ts';
 import { APIWebhookData } from './src/lib/types/DiscordAPI';
 
 const DEV = 'DEV' in process.env ? process.env.DEV === 'true' : !('PM2_HOME' in process.env);
+export const DEV_LAVALINK = true
 
 export const DATABASE_DEVELOPMENT: RPoolConnectionOptions = { db: 'test' };
 export const DATABASE_PRODUCTION: RPoolConnectionOptions = {

--- a/config.ts.example
+++ b/config.ts.example
@@ -5,7 +5,7 @@ import { RPoolConnectionOptions } from 'rethinkdb-ts';
 import { APIWebhookData } from './src/lib/types/DiscordAPI';
 
 const DEV = 'DEV' in process.env ? process.env.DEV === 'true' : !('PM2_HOME' in process.env);
-export const DEV_LAVALINK = true
+export const DEV_LAVALINK = 'DEV_LAVALINK' in process.env ? process.env.DEV_LAVALINK === 'true' : DEV;
 
 export const DATABASE_DEVELOPMENT: RPoolConnectionOptions = { db: 'test' };
 export const DATABASE_PRODUCTION: RPoolConnectionOptions = {

--- a/config.ts.example
+++ b/config.ts.example
@@ -4,7 +4,7 @@ import { KlasaClientOptions } from 'klasa';
 import { RPoolConnectionOptions } from 'rethinkdb-ts';
 import { APIWebhookData } from './src/lib/types/DiscordAPI';
 
-const DEV = 'DEV' in process.env ? process.env.DEV === 'true' : !('PM2_HOME' in process.env);
+export const DEV = 'DEV' in process.env ? process.env.DEV === 'true' : !('PM2_HOME' in process.env);
 export const DEV_LAVALINK = true
 
 export const DATABASE_DEVELOPMENT: RPoolConnectionOptions = { db: 'test' };

--- a/src/lib/SkyraClient.ts
+++ b/src/lib/SkyraClient.ts
@@ -58,7 +58,7 @@ export class SkyraClient extends KlasaClient {
 	public llrCollectors: Set<LongLivingReactionCollector> = new Set();
 
 	@enumerable(false)
-	public lavalink: Lavalink = DEV
+	public lavalink: Lavalink | null = DEV
 		? null
 		: new Lavalink({
 			send: async (guildID: string, packet: any) => {

--- a/src/lib/SkyraClient.ts
+++ b/src/lib/SkyraClient.ts
@@ -3,7 +3,7 @@ import { GatewayStorage, KlasaClient, KlasaClientOptions, Schema, util } from 'k
 import { BaseNodeOptions, Node as Lavalink } from 'lavalink';
 import { MasterPool, R } from 'rethinkdb-ts';
 import { Node } from 'veza';
-import { VERSION, WEBHOOK_ERROR } from '../../config';
+import { VERSION, WEBHOOK_ERROR, DEV } from '../../config';
 import { IPCMonitorStore } from './structures/IPCMonitorStore';
 import { MemberGateway } from './structures/MemberGateway';
 import { clientOptions } from './util/constants';
@@ -58,14 +58,16 @@ export class SkyraClient extends KlasaClient {
 	public llrCollectors: Set<LongLivingReactionCollector> = new Set();
 
 	@enumerable(false)
-	public lavalink: Lavalink = new Lavalink({
-		send: async (guildID: string, packet: any) => {
-			const guild = this.guilds.get(guildID);
-			if (guild) this.ws.shards.get(guild.shardID).send(packet);
-			else throw new Error('attempted to send a packet on the wrong shard');
-		},
-		...this.options.lavalink
-	});
+	public lavalink: Lavalink = DEV
+		? null
+		: new Lavalink({
+			send: async (guildID: string, packet: any) => {
+				const guild = this.guilds.get(guildID);
+				if (guild) this.ws.shards.get(guild.shardID).send(packet);
+				else throw new Error('attempted to send a packet on the wrong shard');
+			},
+			...this.options.lavalink
+		});
 
 	public ipc = new Node('skyra-master')
 		.on('client.connect', client => this.emit(Events.Verbose, `[IPC] Client Connected: ${client.name}`))

--- a/src/lib/SkyraClient.ts
+++ b/src/lib/SkyraClient.ts
@@ -3,7 +3,7 @@ import { GatewayStorage, KlasaClient, KlasaClientOptions, Schema, util } from 'k
 import { BaseNodeOptions, Node as Lavalink } from 'lavalink';
 import { MasterPool, R } from 'rethinkdb-ts';
 import { Node } from 'veza';
-import { VERSION, WEBHOOK_ERROR, DEV } from '../../config';
+import { VERSION, WEBHOOK_ERROR, DEV_LAVALINK } from '../../config';
 import { IPCMonitorStore } from './structures/IPCMonitorStore';
 import { MemberGateway } from './structures/MemberGateway';
 import { clientOptions } from './util/constants';
@@ -58,7 +58,7 @@ export class SkyraClient extends KlasaClient {
 	public llrCollectors: Set<LongLivingReactionCollector> = new Set();
 
 	@enumerable(false)
-	public lavalink: Lavalink | null = DEV
+	public lavalink: Lavalink | null = DEV_LAVALINK
 		? null
 		: new Lavalink({
 			send: async (guildID: string, packet: any) => {


### PR DESCRIPTION
This PR disables lavalink setup to run a development bot.

- [x] Creates a `DEV_LAVALINK` constant that will be used to enable/disable lavalink.
- [x] By default the config.example will have this set to true as most developers will need it for development