### PR TITLE
Database init fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test:lint": "eslint --ext ts src",
     "update": "yarn",
     "build": "tsc -p .",
-    "watch": "tsc -p . -w"
+    "watch": "tsc -p . -w",
+    "develop": "yarn build && yarn start"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "update": "yarn",
     "build": "tsc -p .",
     "watch": "tsc -p . -w",
-    "develop": "yarn build && yarn start"
+    "dev": "yarn build && yarn start"
   },
   "repository": {
     "type": "git",

--- a/src/events/klasaReady.ts
+++ b/src/events/klasaReady.ts
@@ -32,11 +32,12 @@ export default class extends Event {
 		}
 
 		try {
+			// IMPORTANT: DatabaseInit needs to run before all others so that the tables are prepared
+			await DatabaseInit.run(r);
 			Slotmachine.init().catch(error => this.client.emit(Events.Wtf, error));
 			this.client.giveaways.init().catch(error => this.client.emit(Events.Wtf, error));
 			this.initCleanupTask().catch(error => this.client.emit(Events.Wtf, error));
 			this.initPostStatsTask().catch(error => this.client.emit(Events.Wtf, error));
-			await DatabaseInit.run(r);
 		} catch (error) {
 			this.client.console.wtf(error);
 		}

--- a/src/events/klasaReady.ts
+++ b/src/events/klasaReady.ts
@@ -1,6 +1,8 @@
 import { Event } from 'klasa';
 import { Events } from '../lib/types/Enums';
 import { Slotmachine } from '../lib/util/Games/Slotmachine';
+import * as DatabaseInit from '../lib/util/DatabaseInit';
+import { r } from 'rethinkdb-ts';
 
 export default class extends Event {
 
@@ -34,6 +36,7 @@ export default class extends Event {
 			this.client.giveaways.init().catch(error => this.client.emit(Events.Wtf, error));
 			this.initCleanupTask().catch(error => this.client.emit(Events.Wtf, error));
 			this.initPostStatsTask().catch(error => this.client.emit(Events.Wtf, error));
+			await DatabaseInit.run(r);
 		} catch (error) {
 			this.client.console.wtf(error);
 		}

--- a/src/providers/rethinkdb.ts
+++ b/src/providers/rethinkdb.ts
@@ -1,6 +1,5 @@
 import { Provider, util } from 'klasa';
 import { MasterPool, r, TableChangeResult, WriteResult } from 'rethinkdb-ts';
-import * as DatabaseInit from '../lib/util/DatabaseInit';
 
 export default class RethinkDB extends Provider {
 
@@ -14,7 +13,6 @@ export default class RethinkDB extends Provider {
 		}, this.client.options.providers.rethinkdb);
 		this.pool = await r.connectPool(options);
 		await this.db.branch(this.db.dbList().contains(options.db), null, this.db.dbCreate(options.db)).run();
-		await DatabaseInit.run(this.db);
 	}
 
 	public async ping(): Promise<number> {


### PR DESCRIPTION
This PR moves databaseInit.run into `klasaReady` as it requires SG to be ready before running the database init.

**Note:** It also adds a `yarn develop` script to package.json that will run the `build && start` scripts to make it easier to develop on Skyra