### PR TITLE
Add Aliases to Prune Command

### DIFF
--- a/src/commands/Moderation/prune.ts
+++ b/src/commands/Moderation/prune.ts
@@ -6,6 +6,7 @@ export default class extends SkyraCommand {
 
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
+			aliases: ['purge', 'nuke'],
 			cooldown: 5,
 			description: language => language.get('COMMAND_PRUNE_DESCRIPTION'),
 			extendedHelp: language => language.get('COMMAND_PRUNE_EXTENDED'),


### PR DESCRIPTION
This PR adds a few aliases to the `prune` command as most users will probably try to use one of these as well.

- [x] Add purge and nuke aliases to prune command