### PR TITLE
Unique role sets

### DIFF
--- a/src/commands/Admin/roleset.ts
+++ b/src/commands/Admin/roleset.ts
@@ -80,7 +80,7 @@ export default class extends SkyraCommand {
 			// Add any role that wasnt in the set that the user provided
 			// This will also remove any of the roles that user provided and were already in the set
 			const newroles = set.roles.map(id => roles.find(role => role.id === id) ? null : id).filter(id => id);
-			console.log(set.roles.length, newroles.length);
+
 			for (const role of roles) if (!set.roles.includes(role.id)) newroles.push(role.id);
 
 			return { name, roles: newroles };

--- a/src/commands/Admin/roleset.ts
+++ b/src/commands/Admin/roleset.ts
@@ -28,7 +28,7 @@ export default class extends SkyraCommand {
 			const { errors } = await message.guild.settings.update(GuildSettings.Roles.UniqueRoleSets, [{ name, roles }]);
 			if (errors.length) this.client.emit('error', errors.join('\n'));
 
-			return message.sendLocale(`COMMAND_ROLESET_CREATED`, [name, roles]);
+			return message.sendLocale(`COMMAND_ROLESET_CREATED`, [name, roles.map(role => role.name)]);
 		}
 
 		// The set does exist so we want to only ADD new roles in
@@ -45,7 +45,7 @@ export default class extends SkyraCommand {
 		const { errors } = await message.guild.settings.update(GuildSettings.Roles.UniqueRoleSets, newsets, { arrayAction: 'overwrite' });
 		if (errors.length) this.client.emit('error', errors.join('\n'));
 
-		return message.sendLocale('COMMAND_ROLESETS_ADDED', [name, roles]);
+		return message.sendLocale('COMMAND_ROLESETS_ADDED', [name, roles.map(role => role.name)]);
 	}
 
 	public async remove(message: KlasaMessage, [name, roles]: [string, Role[]]) {
@@ -64,7 +64,7 @@ export default class extends SkyraCommand {
 		const { errors } = await message.guild.settings.update(GuildSettings.Roles.UniqueRoleSets, newsets, { arrayAction: 'overwrite' });
 		if (errors.length) this.client.emit('error', errors.join('\n'));
 
-		return message.sendLocale('COMMAND_ROLESETS_REMOVED', [name, roles]);
+		return message.sendLocale('COMMAND_ROLESETS_REMOVED', [name, roles.map(role => role.name)]);
 	}
 
 	public async auto(message: KlasaMessage, [name, roles]: [string, Role[]]) {

--- a/src/commands/Admin/roleset.ts
+++ b/src/commands/Admin/roleset.ts
@@ -13,13 +13,18 @@ export default class extends SkyraCommand {
 			requiredPermissions: [],
 			runIn: ['text'],
 			subcommands: true,
-			usage: '<add|remove|list|auto:default> (name:name) <role:rolenames>',
+			usage: '<add|remove|list|auto:default> (name:name) (role:rolenames)',
 			usageDelim: ' '
 		});
 
 		this.createCustomResolver(`name`, async (arg, possible, message, [subcommand]) => {
 			if (!arg && subcommand === 'list') return undefined;
 			return this.client.arguments.get('string').run(arg, possible, message);
+		});
+
+		this.createCustomResolver(`rolenames`, async (arg, possible, message, [subcommand]) => {
+			if (!arg && subcommand === 'list') return undefined;
+			return this.client.arguments.get('rolenames').run(arg, possible, message);
 		});
 	}
 

--- a/src/commands/Admin/roleset.ts
+++ b/src/commands/Admin/roleset.ts
@@ -1,4 +1,3 @@
-import { Role } from 'discord.js';
 import { CommandStore, KlasaMessage } from 'klasa';
 import { SkyraCommand } from '../../lib/structures/SkyraCommand';
 import { GuildSettings } from '../../lib/types/settings/GuildSettings';
@@ -18,17 +17,17 @@ export default class extends SkyraCommand {
 		});
 	}
 
-	public async add(message: KlasaMessage, [name, roles]: [string, Role[]]) {
+	public async add(message: KlasaMessage, [name, ...roles]: [string, any]) {
 		// Get all rolesets from settings and check if there is an existing set with the name provided by the user
 		const allRolesets = message.guild.settings.get(GuildSettings.Roles.UniqueRoleSets) as GuildSettings.Roles.UniqueRoleSets;
 		const roleset = allRolesets.find(set => set.name === name);
 
 		// If it does not exist we need to create a brand new set
 		if (!roleset) {
-			const { errors } = await message.guild.settings.update(GuildSettings.Roles.UniqueRoleSets, [{ name, roles }]);
+			const { errors } = await message.guild.settings.update(GuildSettings.Roles.UniqueRoleSets, { name, roles: roles.map(role => role.id) });
 			if (errors.length) this.client.emit('error', errors.join('\n'));
 
-			return message.sendLocale(`COMMAND_ROLESET_CREATED`, [name, roles.map(role => role.name)]);
+			return message.sendLocale(`COMMAND_ROLESET_CREATED`, [name, roles.map(role => role.name).join(', ')]);
 		}
 
 		// The set does exist so we want to only ADD new roles in
@@ -45,10 +44,10 @@ export default class extends SkyraCommand {
 		const { errors } = await message.guild.settings.update(GuildSettings.Roles.UniqueRoleSets, newsets, { arrayAction: 'overwrite' });
 		if (errors.length) this.client.emit('error', errors.join('\n'));
 
-		return message.sendLocale('COMMAND_ROLESETS_ADDED', [name, roles.map(role => role.name)]);
+		return message.sendLocale('COMMAND_ROLESET_ADDED', [name, roles.map(role => role.name).join(', ')]);
 	}
 
-	public async remove(message: KlasaMessage, [name, roles]: [string, Role[]]) {
+	public async remove(message: KlasaMessage, [name, ...roles]: [string, any]) {
 		// Get all rolesets from settings and check if there is an existing set with the name provided by the user
 		const allRolesets = message.guild.settings.get(GuildSettings.Roles.UniqueRoleSets) as GuildSettings.Roles.UniqueRoleSets;
 		const roleset = allRolesets.find(set => set.name === name);
@@ -59,21 +58,38 @@ export default class extends SkyraCommand {
 		// The set does exist so we want to only REMOVE provided roles from it
 
 		// Create a new array that we can use to overwrite the existing one in settings
-		const newsets = allRolesets.map(set => set.name === name ? set : [{ name, roles: set.roles.filter((id: string) => !roles.find(role => role.id === id)) }]);
+		const newsets = allRolesets.map(set => set.name === name ? set : { name, roles: set.roles.filter((id: string) => !roles.find(role => role.id === id)) });
 
 		const { errors } = await message.guild.settings.update(GuildSettings.Roles.UniqueRoleSets, newsets, { arrayAction: 'overwrite' });
 		if (errors.length) this.client.emit('error', errors.join('\n'));
 
-		return message.sendLocale('COMMAND_ROLESETS_REMOVED', [name, roles.map(role => role.name)]);
+		return message.sendLocale('COMMAND_ROLESET_REMOVED', [name, roles.map(role => role.name).join(', ')]);
 	}
 
-	public async auto(message: KlasaMessage, [name, roles]: [string, Role[]]) {
+	public async auto(message: KlasaMessage, [name, ...roles]: [string, any]) {
 		// Get all rolesets from settings and check if there is an existing set with the name provided by the user
 		const allRolesets = message.guild.settings.get(GuildSettings.Roles.UniqueRoleSets) as GuildSettings.Roles.UniqueRoleSets;
 		const roleset = allRolesets.find(set => set.name === name);
-
+		// If this roleset does not exist we have to create it
 		if (!roleset) return this.add(message, [name, roles]);
-		return this.remove(message, [name, roles]);
+
+		// The role set exists
+
+		const newsets = allRolesets.map(set => {
+			if (set.name !== name) return set;
+			// Add any role that wasnt in the set that the user provided
+			// This will also remove any of the roles that user provided and were already in the set
+			const newroles = set.roles.map(id => roles.find(role => role.id === id) ? null : id).filter(id => id);
+			console.log(set.roles.length, newroles.length);
+			for (const role of roles) if (!set.roles.includes(role.id)) newroles.push(role.id);
+
+			return { name, roles: newroles };
+		});
+
+		const { errors } = await message.guild.settings.update(GuildSettings.Roles.UniqueRoleSets, newsets, { arrayAction: 'overwrite' });
+		if (errors.length) this.client.emit('error', errors.join('\n'));
+
+		return message.sendLocale(`COMMAND_ROLESET_UPDATED`, [name]);
 	}
 
 }

--- a/src/commands/Admin/roleset.ts
+++ b/src/commands/Admin/roleset.ts
@@ -28,6 +28,7 @@ export default class extends SkyraCommand {
 		});
 	}
 
+	// This subcommand will always ADD roles in to a existing set OR it will create a new set if that set does not exist
 	public async add(message: KlasaMessage, [name, roles]: [string, Role[]]) {
 		// Get all rolesets from settings and check if there is an existing set with the name provided by the user
 		const allRolesets = message.guild.settings.get(GuildSettings.Roles.UniqueRoleSets) as GuildSettings.Roles.UniqueRoleSets;
@@ -57,16 +58,11 @@ export default class extends SkyraCommand {
 		return message.sendLocale('COMMAND_ROLESET_ADDED', [name, roles.map(role => role.name).join(', ')]);
 	}
 
+	// This subcommand will always remove roles from a provided role set.
 	public async remove(message: KlasaMessage, [name, roles]: [string, Role[]]) {
 		// Get all rolesets from settings and check if there is an existing set with the name provided by the user
 		const allRolesets = message.guild.settings.get(GuildSettings.Roles.UniqueRoleSets) as GuildSettings.Roles.UniqueRoleSets;
-		const roleset = allRolesets.find(set => set.name === name);
-
-		// TODO: Kyra if name is a semi we can add this check in a custom resolver
-		if (!roleset) return message.sendLocale(`COMMAND_ROLESET_INVALID_NAME`, [name]);
-
 		// The set does exist so we want to only REMOVE provided roles from it
-
 		// Create a new array that we can use to overwrite the existing one in settings
 		const newsets = allRolesets.map(set => set.name === name ? set : { name, roles: set.roles.filter((id: string) => !roles.find(role => role.id === id)) });
 
@@ -76,6 +72,7 @@ export default class extends SkyraCommand {
 		return message.sendLocale('COMMAND_ROLESET_REMOVED', [name, roles.map(role => role.name).join(', ')]);
 	}
 
+	// This subcommand will run if a user doesnt type add or remove. The bot will then add AND remove based on whether that role is in the set already.
 	public async auto(message: KlasaMessage, [name, roles]: [string, Role[]]) {
 		// Get all rolesets from settings and check if there is an existing set with the name provided by the user
 		const allRolesets = message.guild.settings.get(GuildSettings.Roles.UniqueRoleSets) as GuildSettings.Roles.UniqueRoleSets;
@@ -102,6 +99,7 @@ export default class extends SkyraCommand {
 		return message.sendLocale(`COMMAND_ROLESET_UPDATED`, [name]);
 	}
 
+	// This subcommand will show the user a list of role sets and each role in that set.
 	public async list(message: KlasaMessage) {
 		// Get all rolesets from settings
 		const allRolesets = message.guild.settings.get(GuildSettings.Roles.UniqueRoleSets) as GuildSettings.Roles.UniqueRoleSets;

--- a/src/commands/Admin/roleset.ts
+++ b/src/commands/Admin/roleset.ts
@@ -1,0 +1,79 @@
+import { Role } from 'discord.js';
+import { CommandStore, KlasaMessage } from 'klasa';
+import { SkyraCommand } from '../../lib/structures/SkyraCommand';
+import { GuildSettings } from '../../lib/types/settings/GuildSettings';
+
+export default class extends SkyraCommand {
+
+	public constructor(store: CommandStore, file: string[], directory: string) {
+		super(store, file, directory, {
+			aliases: ['rs'],
+			description: language => language.get('COMMAND_ROLESET_DESCRIPTION'),
+			permissionLevel: 6,
+			requiredPermissions: [],
+			runIn: ['text'],
+			subcommands: true,
+			usage: '<add|remove|auto:default> <name:string> <role:rolename> [...]',
+			usageDelim: ' '
+		});
+	}
+
+	public async add(message: KlasaMessage, [name, roles]: [string, Role[]]) {
+		// Get all rolesets from settings and check if there is an existing set with the name provided by the user
+		const allRolesets = message.guild.settings.get(GuildSettings.Roles.UniqueRoleSets) as GuildSettings.Roles.UniqueRoleSets;
+		const roleset = allRolesets.find(set => set.name === name);
+
+		// If it does not exist we need to create a brand new set
+		if (!roleset) {
+			const { errors } = await message.guild.settings.update(GuildSettings.Roles.UniqueRoleSets, [{ name, roles }]);
+			if (errors.length) this.client.emit('error', errors.join('\n'));
+
+			return message.sendLocale(`COMMAND_ROLESET_CREATED`, [name, roles]);
+		}
+
+		// The set does exist so we want to only ADD new roles in
+
+		// Create a new array that we can use to overwrite the existing one in settings
+		const newsets = allRolesets.map(set => {
+			if (set.name !== name) return set;
+			const finalRoleIDs = [...set.roles];
+			for (const role of roles) if (!finalRoleIDs.includes(role.id)) finalRoleIDs.push(role.id);
+
+			return { name, roles: finalRoleIDs };
+		});
+
+		const { errors } = await message.guild.settings.update(GuildSettings.Roles.UniqueRoleSets, newsets, { arrayAction: 'overwrite' });
+		if (errors.length) this.client.emit('error', errors.join('\n'));
+
+		return message.sendLocale('COMMAND_ROLESETS_ADDED', [name, roles]);
+	}
+
+	public async remove(message: KlasaMessage, [name, roles]: [string, Role[]]) {
+		// Get all rolesets from settings and check if there is an existing set with the name provided by the user
+		const allRolesets = message.guild.settings.get(GuildSettings.Roles.UniqueRoleSets) as GuildSettings.Roles.UniqueRoleSets;
+		const roleset = allRolesets.find(set => set.name === name);
+
+		// TODO: Kyra if name is a semi we can add this check in a custom resolver
+		if (!roleset) return message.sendLocale(`COMMAND_ROLESET_INVALID_NAME`, [name]);
+
+		// The set does exist so we want to only REMOVE provided roles from it
+
+		// Create a new array that we can use to overwrite the existing one in settings
+		const newsets = allRolesets.map(set => set.name === name ? set : [{ name, roles: set.roles.filter((id: string) => !roles.find(role => role.id === id)) }]);
+
+		const { errors } = await message.guild.settings.update(GuildSettings.Roles.UniqueRoleSets, newsets, { arrayAction: 'overwrite' });
+		if (errors.length) this.client.emit('error', errors.join('\n'));
+
+		return message.sendLocale('COMMAND_ROLESETS_REMOVED', [name, roles]);
+	}
+
+	public async auto(message: KlasaMessage, [name, roles]: [string, Role[]]) {
+		// Get all rolesets from settings and check if there is an existing set with the name provided by the user
+		const allRolesets = message.guild.settings.get(GuildSettings.Roles.UniqueRoleSets) as GuildSettings.Roles.UniqueRoleSets;
+		const roleset = allRolesets.find(set => set.name === name);
+
+		if (!roleset) return this.add(message, [name, roles]);
+		return this.remove(message, [name, roles]);
+	}
+
+}

--- a/src/commands/Announcement/subscribe.ts
+++ b/src/commands/Announcement/subscribe.ts
@@ -18,17 +18,22 @@ export default class extends SkyraCommand {
 	public async run(message: KlasaMessage) {
 		const role = announcementCheck(message);
 		const allRoleSets = message.guild.settings.get(GuildSettings.Roles.UniqueRoleSets) as GuildSettings.Roles.UniqueRoleSets;
+
 		// Get all the role ids that the member has and remove the guild id so we dont assign the everyone role
-		let memberRoles = message.member.roles.map(r => r.id).filter(id => id !== message.guild.id);
+		const memberRolesSet = new Set(message.member.roles.keys());
+		// Remove the everyone role from the set
+		memberRolesSet.delete(message.guild.id);
+
 		// For each set that has the subscriber role remove all the roles from the set
 		for (const set of allRoleSets) {
 			if (!set.roles.includes(role.id)) continue;
-			memberRoles = memberRoles.filter(id => !set.roles.includes(id));
+			for (const id of set.roles) memberRolesSet.delete(id);
 		}
 
-		memberRoles.push(role.id);
+		// Add the subscriber role to the set
+		memberRolesSet.add(role.id);
 
-		await message.member.roles.set(memberRoles);
+		await message.member.roles.set([...memberRolesSet]);
 
 		return message.sendLocale('COMMAND_SUBSCRIBE_SUCCESS', [role.name]);
 	}

--- a/src/commands/Announcement/subscribe.ts
+++ b/src/commands/Announcement/subscribe.ts
@@ -18,17 +18,18 @@ export default class extends SkyraCommand {
 	public async run(message: KlasaMessage) {
 		const role = announcementCheck(message);
 		const allRoleSets = message.guild.settings.get(GuildSettings.Roles.UniqueRoleSets) as GuildSettings.Roles.UniqueRoleSets;
-
-		const memberRoles = message.member.roles.map(r => r.id);
-
+		// Get all the role ids that the member has and remove the guild id so we dont assign the everyone role
+		let memberRoles = message.member.roles.map(r => r.id).filter(id => id !== message.guild.id);
+		// For each set that has the subscriber role remove all the roles from the set
 		for (const set of allRoleSets) {
 			if (!set.roles.includes(role.id)) continue;
-			memberRoles.filter(id => !set.roles.includes(id));
+			memberRoles = memberRoles.filter(id => !set.roles.includes(id));
 		}
 
 		memberRoles.push(role.id);
 
 		await message.member.roles.set(memberRoles);
+
 		return message.sendLocale('COMMAND_SUBSCRIBE_SUCCESS', [role.name]);
 	}
 

--- a/src/commands/Announcement/subscribe.ts
+++ b/src/commands/Announcement/subscribe.ts
@@ -1,6 +1,7 @@
 import { CommandStore, KlasaMessage } from 'klasa';
 import { SkyraCommand } from '../../lib/structures/SkyraCommand';
 import { announcementCheck } from '../../lib/util/util';
+import { GuildSettings } from '../../lib/types/settings/GuildSettings';
 
 export default class extends SkyraCommand {
 
@@ -16,7 +17,18 @@ export default class extends SkyraCommand {
 
 	public async run(message: KlasaMessage) {
 		const role = announcementCheck(message);
-		await message.member.roles.add(role);
+		const allRoleSets = message.guild.settings.get(GuildSettings.Roles.UniqueRoleSets) as GuildSettings.Roles.UniqueRoleSets;
+
+		const memberRoles = message.member.roles.map(r => r.id);
+
+		for (const set of allRoleSets) {
+			if (!set.roles.includes(role.id)) continue;
+			memberRoles.filter(id => !set.roles.includes(id));
+		}
+
+		memberRoles.push(role.id);
+
+		await message.member.roles.set(memberRoles);
 		return message.sendLocale('COMMAND_SUBSCRIBE_SUCCESS', [role.name]);
 	}
 

--- a/src/commands/Management/roles.ts
+++ b/src/commands/Management/roles.ts
@@ -45,6 +45,9 @@ export default class extends SkyraCommand {
 			return this.list(message, rolesPublic);
 		}
 		const memberRoles = new Set(message.member.roles.keys());
+		// Remove the everyone role
+		memberRoles.delete(message.guild.id)
+
 		const filterRoles = new Set(roles);
 		const unlistedRoles = [];
 		const unmanageable = [];
@@ -68,13 +71,19 @@ export default class extends SkyraCommand {
 				addedRoles.push(role.name);
 
 				for (const set of allRoleSets) {
+					// If the set does not have the role being added skip to next set
 					if (!set.roles.includes(role.id)) continue;
+
 					for (const id of set.roles) {
+						// If this role is the role being added skip
 						if (role.id === id) continue;
 
 						if (memberRoles.has(id)) {
-							memberRoles.delete(role.id);
-							removedRoles.push(role.name);
+							// If the member has this role we need to delete it
+							memberRoles.delete(id);
+							// get to the role object so we can get the name of the role to show the user it was removed
+							const roleToRemove = message.guild.roles.get(id)
+							removedRoles.push(roleToRemove.name);
 						}
 					}
 				}
@@ -90,7 +99,7 @@ export default class extends SkyraCommand {
 			if (!message.guild.roles.has(rolesInitial)) message.guild.settings.reset(GuildSettings.Roles.Initial).catch(error => this.client.emit(Events.Wtf, error));
 			else if (message.member.roles.has(rolesInitial)) memberRoles.delete(rolesInitial);
 		}
-
+		console.log(`end`, memberRoles)
 		// Apply the roles
 		if (removedRoles.length || addedRoles.length) await message.member.roles.set([...memberRoles], message.language.get('COMMAND_ROLES_AUDITLOG'));
 

--- a/src/commands/Management/roles.ts
+++ b/src/commands/Management/roles.ts
@@ -99,7 +99,7 @@ export default class extends SkyraCommand {
 			if (!message.guild.roles.has(rolesInitial)) message.guild.settings.reset(GuildSettings.Roles.Initial).catch(error => this.client.emit(Events.Wtf, error));
 			else if (message.member.roles.has(rolesInitial)) memberRoles.delete(rolesInitial);
 		}
-		console.log(`end`, memberRoles)
+
 		// Apply the roles
 		if (removedRoles.length || addedRoles.length) await message.member.roles.set([...memberRoles], message.language.get('COMMAND_ROLES_AUDITLOG'));
 

--- a/src/commands/Management/roles.ts
+++ b/src/commands/Management/roles.ts
@@ -46,7 +46,7 @@ export default class extends SkyraCommand {
 		}
 		const memberRoles = new Set(message.member.roles.keys());
 		// Remove the everyone role
-		memberRoles.delete(message.guild.id)
+		memberRoles.delete(message.guild.id);
 
 		const filterRoles = new Set(roles);
 		const unlistedRoles = [];
@@ -82,7 +82,7 @@ export default class extends SkyraCommand {
 							// If the member has this role we need to delete it
 							memberRoles.delete(id);
 							// get to the role object so we can get the name of the role to show the user it was removed
-							const roleToRemove = message.guild.roles.get(id)
+							const roleToRemove = message.guild.roles.get(id);
 							removedRoles.push(roleToRemove.name);
 						}
 					}

--- a/src/commands/Management/roles.ts
+++ b/src/commands/Management/roles.ts
@@ -52,6 +52,8 @@ export default class extends SkyraCommand {
 		const removedRoles = [];
 		const { position } = message.guild.me.roles.highest;
 
+		const allRoleSets = message.guild.settings.get(GuildSettings.Roles.UniqueRoleSets) as GuildSettings.Roles.UniqueRoleSets;
+
 		for (const role of filterRoles) {
 			if (!role) continue;
 			if (!rolesPublic.includes(role.id)) {
@@ -64,6 +66,18 @@ export default class extends SkyraCommand {
 			} else {
 				memberRoles.add(role.id);
 				addedRoles.push(role.name);
+
+				for (const set of allRoleSets) {
+					if (!set.roles.includes(role.id)) continue;
+					for (const id of set.roles) {
+						if (role.id === id) continue;
+
+						if (memberRoles.has(id)) {
+							memberRoles.delete(role.id);
+							removedRoles.push(role.name);
+						}
+					}
+				}
 			}
 		}
 

--- a/src/events/rawGuildMemberUpdate.ts
+++ b/src/events/rawGuildMemberUpdate.ts
@@ -33,11 +33,14 @@ export default class extends Event {
 		const updatedRoleID = change.new_value[0].id;
 		const allRoleSets = guild.settings.get(GuildSettings.Roles.UniqueRoleSets) as GuildSettings.Roles.UniqueRoleSets;
 
+		let memberRoles = member.roles.map(role => role.id);
 		for (const set of allRoleSets) {
 			if (!set.roles.includes(updatedRoleID)) continue;
 
-			await member.roles.remove(set.roles.filter((id: string) => id !== updatedRoleID));
+			memberRoles = memberRoles.filter(id => !set.roles.includes(id) || id === updatedRoleID);
 		}
+
+		await member.roles.set(memberRoles);
 	}
 
 }

--- a/src/events/rawGuildMemberUpdate.ts
+++ b/src/events/rawGuildMemberUpdate.ts
@@ -26,7 +26,7 @@ export default class extends Event {
 			}
 		}) as AuditLogResult;
 
-		const entry = auditLogs.audit_log_entries.find(e => e.target_id === member.id && e.changes.find(c => c.key === '$add'));
+		const entry = auditLogs.audit_log_entries.find(e => e.target_id === member.id && e.changes.find(c => c.key === '$add' && c.new_value.length));
 		if (!entry) return;
 
 		const change = entry.changes.find(c => c.key === '$add' && c.new_value.length);

--- a/src/events/rawGuildMemberUpdate.ts
+++ b/src/events/rawGuildMemberUpdate.ts
@@ -1,5 +1,6 @@
 import { WSGuildMemberUpdate } from '../lib/types/DiscordAPI';
 import { Event, EventStore } from 'klasa';
+import { GuildSettings } from '../lib/types/settings/GuildSettings';
 
 export default class extends Event {
 
@@ -9,12 +10,43 @@ export default class extends Event {
 
 	public async run(data: WSGuildMemberUpdate): Promise<void> {
 		const guild = this.client.guilds.get(data.guild_id);
-		if (guild) {
-			guild.memberSnowflakes.add(data.user.id);
-			this.client.usertags.set(data.user.id, `${data.user.username}#${data.user.discriminator}`);
-			const member = guild.members.get(data.user.id);
-			// @ts-ignore
-			if (member) member._patch(data);
+		if (!guild) return;
+
+		guild.memberSnowflakes.add(data.user.id);
+		this.client.usertags.set(data.user.id, `${data.user.username}#${data.user.discriminator}`);
+		const member = guild.members.get(data.user.id);
+		// @ts-ignore
+		if (member) member._patch(data);
+
+		// Handle unique role sets
+		const auditLogs = await (this.client as any).api.guilds(data.guild_id, 'audit-logs').get({
+			query: {
+				limit: 10,
+				action_type: 25
+			}
+		});
+
+		for (const entry of auditLogs.audit_log_entries) {
+			if (entry.target_id !== member.id) continue;
+
+			for (const change of entry.changes) {
+				if (change.key !== '$add') continue;
+
+				const updatedRoleID = change.new_value.id;
+				const allRoleSets = guild.settings.get(GuildSettings.Roles.UniqueRoleSets) as GuildSettings.Roles.UniqueRoleSets;
+
+				for (const set of allRoleSets) {
+					if (!set.roles.includes(updatedRoleID)) continue;
+
+					await member.roles.remove(set.roles.filter((id: string) => id !== updatedRoleID));
+
+					// Once the first entry is found break out since we only want latest change
+					break;
+				}
+			}
+
+			// Break out after first is found because we only want the latest change
+			break;
 		}
 	}
 

--- a/src/events/rawGuildMemberUpdate.ts
+++ b/src/events/rawGuildMemberUpdate.ts
@@ -1,4 +1,4 @@
-import { WSGuildMemberUpdate, AuditLogResult, AuditLogEntry, Change } from '../lib/types/DiscordAPI';
+import { WSGuildMemberUpdate, AuditLogResult } from '../lib/types/DiscordAPI';
 import { Event, EventStore } from 'klasa';
 import { GuildSettings } from '../lib/types/settings/GuildSettings';
 

--- a/src/events/rawMessageReactionAdd.ts
+++ b/src/events/rawMessageReactionAdd.ts
@@ -49,37 +49,6 @@ export default class extends Event {
 		}
 	}
 
-	public async handleRoleChannel(parsed: LLRCData): Promise<void> {
-		const messageReaction = parsed.guild.settings.get(GuildSettings.Roles.MessageReaction) as GuildSettings.Roles.MessageReaction;
-		if (!messageReaction || messageReaction !== parsed.messageID) return;
-
-		const emoji = resolveEmoji(parsed.emoji);
-		if (!emoji) return;
-
-		const roleEntry = (parsed.guild.settings.get(GuildSettings.Roles.Reactions) as GuildSettings.Roles.Reactions)
-			.find(entry => entry.emoji === emoji);
-		if (!roleEntry) return;
-
-		try {
-			const member = await parsed.guild.members.fetch(parsed.userID);
-			if (member.roles.has(roleEntry.role)) return;
-
-			const memberRoles = member.roles.map(r => r.id);
-			const allRoleSets = member.guild.settings.get(GuildSettings.Roles.UniqueRoleSets) as GuildSettings.Roles.UniqueRoleSets;
-
-			for (const set of allRoleSets) {
-				if (!set.roles.includes(roleEntry.role)) continue;
-				memberRoles.filter(id => !set.roles.includes(id));
-			}
-
-			memberRoles.push(roleEntry.role);
-
-			await member.roles.set(memberRoles);
-		} catch (error) {
-			this.client.emit(Events.ApiError, error);
-		}
-	}
-
 	public async handleStarboard(parsed: LLRCData): Promise<void> {
 		try {
 			const channel = parsed.guild.settings.get(GuildSettings.Starboard.Channel) as GuildSettings.Starboard.Channel;

--- a/src/events/rawMessageReactionAdd.ts
+++ b/src/events/rawMessageReactionAdd.ts
@@ -66,7 +66,19 @@ export default class extends Event {
 
 		try {
 			const member = await parsed.guild.members.fetch(parsed.userID);
-			if (!member.roles.has(roleEntry.role)) await member.roles.add(roleEntry.role);
+			if (member.roles.has(roleEntry.role)) return;
+
+			const memberRoles = member.roles.map(r => r.id);
+			const allRoleSets = member.guild.settings.get(GuildSettings.Roles.UniqueRoleSets) as GuildSettings.Roles.UniqueRoleSets;
+
+			for (const set of allRoleSets) {
+				if (!set.roles.includes(roleEntry.role)) continue;
+				memberRoles.filter(id => !set.roles.includes(id));
+			}
+
+			memberRoles.push(roleEntry.role);
+
+			await member.roles.set(memberRoles);
 		} catch (error) {
 			this.client.emit(Events.ApiError, error);
 		}

--- a/src/events/roleReactionAdd.ts
+++ b/src/events/roleReactionAdd.ts
@@ -30,7 +30,7 @@ export default class extends Event {
 			// Conver the array into a set
 			const memberRoles = new Set(member.roles.keys());
 			// Remove the eveeryone role from the set
-			memberRoles.delete(parsed.guild.id)
+			memberRoles.delete(parsed.guild.id);
 
 			const allRoleSets = member.guild.settings.get(GuildSettings.Roles.UniqueRoleSets) as GuildSettings.Roles.UniqueRoleSets;
 
@@ -38,7 +38,7 @@ export default class extends Event {
 				// If the set doesnt have the role being added to the user skip
 				if (!set.roles.includes(roleEntry.role)) continue;
 				// For every role that the user has check if it is in this set and remove it
-				for (const id of memberRoles) if (set.roles.includes(id)) memberRoles.delete(id)
+				for (const id of memberRoles) if (set.roles.includes(id)) memberRoles.delete(id);
 			}
 
 			// Add the role to the set that the user has gained

--- a/src/events/roleReactionAdd.ts
+++ b/src/events/roleReactionAdd.ts
@@ -25,7 +25,26 @@ export default class extends Event {
 
 		try {
 			const member = await parsed.guild.members.fetch(parsed.userID);
-			if (!member.roles.has(roleEntry.role)) await member.roles.add(roleEntry.role);
+			if (member.roles.has(roleEntry.role)) return;
+
+			// Conver the array into a set
+			const memberRoles = new Set(member.roles.keys());
+			// Remove the eveeryone role from the set
+			memberRoles.delete(parsed.guild.id)
+
+			const allRoleSets = member.guild.settings.get(GuildSettings.Roles.UniqueRoleSets) as GuildSettings.Roles.UniqueRoleSets;
+
+			for (const set of allRoleSets) {
+				// If the set doesnt have the role being added to the user skip
+				if (!set.roles.includes(roleEntry.role)) continue;
+				// For every role that the user has check if it is in this set and remove it
+				for (const id of memberRoles) if (set.roles.includes(id)) memberRoles.delete(id)
+			}
+
+			// Add the role to the set that the user has gained
+			memberRoles.add(roleEntry.role);
+			// Set all the roles at once.
+			await member.roles.set([...memberRoles]);
 		} catch (error) {
 			this.client.emit(Events.ApiError, error);
 		}

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -266,6 +266,7 @@ export default class extends Language {
 		COMMAND_ROLESET_ADDED: (name, roles) => `The ${name} unique role set now has the following roles as well: ${roles}.`,
 		COMMAND_ROLESET_INVALID_NAME: name => `You can not remove the ${name} unique role set because it does not exist.`,
 		COMMAND_ROLESET_REMOVED: (name, roles) => `The ${name} unique role set will no longer include the following roles: ${roles}`,
+		COMMAND_ROLESET_UPDATED: name => `The ${name} unique role set has been updated.`,
 		COMMAND_SHUFFLE_DESCRIPTION: 'Randomizes the order of the songs in the queue.',
 		COMMAND_SHUFFLE_SUCCESS: amount => `${GREENTICK} Successfully randomized ${amount} songs.`,
 		COMMAND_SKIP_DESCRIPTION: `Skip the current song.`,

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -2874,10 +2874,10 @@ export default class extends Language {
 				? 's'
 				: ''}: ${removed.join(', ')}\n`
 			: ''}${added.length > 0
-				? `Added the role${added.length > 1
-					? 's'
-					: ''}: ${added.join(', ')}`
-				: ''}`,
+			? `Added the role${added.length > 1
+				? 's'
+				: ''}: ${added.join(', ')}`
+			: ''}`,
 		EVENTS_MESSAGE_UPDATE: 'Message Edited',
 		EVENTS_MESSAGE_DELETE: 'Message Deleted',
 		EVENTS_COMMAND: command => `Command Used: ${command}`,

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -261,6 +261,11 @@ export default class extends Language {
 		COMMAND_REMOVE_SUCCESS: song => `${GREENTICK} Removed the song **${song.title}** requested by **${song.requester}**.`,
 		COMMAND_RESUME_DESCRIPTION: `Resumes the current song.`,
 		COMMAND_RESUME_SUCCESS: `▶ Resumed.`,
+		COMMAND_ROLESET_DESCRIPTION: `Manage unique role sets.`,
+		COMMAND_ROLESET_CREATED: (name, roles) => `The ${name} unique role set has been created with the following roles: ${roles}`,
+		COMMAND_ROLESET_ADDED: (name, roles) => `The ${name} unique role set now has the following roles as well: ${roles}.`,
+		COMMAND_ROLESET_INVALID_NAME: name => `You can not remove the ${name} unique role set because it does not exist.`,
+		COMMAND_ROLESET_REMOVED: (name, roles) => `The ${name} unique role set will no longer include the following roles: ${roles}`,
 		COMMAND_SHUFFLE_DESCRIPTION: 'Randomizes the order of the songs in the queue.',
 		COMMAND_SHUFFLE_SUCCESS: amount => `${GREENTICK} Successfully randomized ${amount} songs.`,
 		COMMAND_SKIP_DESCRIPTION: `Skip the current song.`,
@@ -2868,10 +2873,10 @@ export default class extends Language {
 				? 's'
 				: ''}: ${removed.join(', ')}\n`
 			: ''}${added.length > 0
-			? `Added the role${added.length > 1
-				? 's'
-				: ''}: ${added.join(', ')}`
-			: ''}`,
+				? `Added the role${added.length > 1
+					? 's'
+					: ''}: ${added.join(', ')}`
+				: ''}`,
 		EVENTS_MESSAGE_UPDATE: 'Message Edited',
 		EVENTS_MESSAGE_DELETE: 'Message Deleted',
 		EVENTS_COMMAND: command => `Command Used: ${command}`,

--- a/src/lib/SkyraClient.ts
+++ b/src/lib/SkyraClient.ts
@@ -182,7 +182,8 @@ SkyraClient.defaultGuildSchema
 		.add('reactions', 'any', { array: true })
 		.add('removeInitial', 'Boolean')
 		.add('staff', 'Role')
-		.add('subscriber', 'Role'))
+		.add('subscriber', 'Role')
+		.add('uniqueRoleSets', 'any', { array: true }))
 	.add('selfmod', folder => folder
 		.add('attachment', 'Boolean', { 'default': false })
 		.add('attachmentMaximum', 'Integer', { 'default': 20, 'min': 0, 'max': 60 })

--- a/src/lib/types/DiscordAPI.ts
+++ b/src/lib/types/DiscordAPI.ts
@@ -112,3 +112,35 @@ export interface WSMessageReactionRemoveAll {
 	channel_id: string;
 	guild_id: string;
 }
+
+export interface AuditLogResult {
+	webhooks: any[];
+	users: User[];
+	audit_log_entries: AuditLogEntry[];
+}
+
+export interface AuditLogEntry {
+	target_id: string;
+	changes: Change[];
+	user_id: string;
+	id: string;
+	action_type: number;
+}
+
+export interface Change {
+	new_value: NewValue[];
+	key: string;
+}
+
+export interface NewValue {
+	name: string;
+	id: string;
+}
+
+export interface User {
+	username: string;
+	discriminator: string;
+	id: string;
+	avatar: string;
+	bot?: boolean;
+}

--- a/src/lib/types/settings/GuildSettings.ts
+++ b/src/lib/types/settings/GuildSettings.ts
@@ -94,6 +94,8 @@ export namespace GuildSettings {
 		export const Staff = 'roles.staff';
 		export type Subscriber = string;
 		export const Subscriber = 'roles.subscriber';
+		export type UniqueRoleSets = any[];
+		export const UniqueRoleSets = 'roles.uniqueRoleSets';
 	}
 
 	export namespace Selfmod {


### PR DESCRIPTION
This PR adds in the requested Unique Role Set feature. A unique role set is a set of roles where the user can only have one of them.

- [x] Adds `guild.settings.roles.uniqueRoleSets`
- [x] Adds a `s!roleset` command
- [x] Handles role removals in a raw memberUpdate event
- [x] Handles removing roles with roles command
- [x] Handles removing roles with subscribe command
- [x] Handles remvoing roles with role reaction add
- [x] All strings added to languages
- [x] Roleset Command tested!
- [x] Roles command tested
- [x] Subscribe command tested
- [x] Role reaction tested
- [x] Raw event tested