### PR TITLE
Fix Excessive @ in Play

### DIFF
--- a/src/commands/Music/play.ts
+++ b/src/commands/Music/play.ts
@@ -52,7 +52,7 @@ export default class extends MusicCommand {
 
 			const requester = await song.fetchRequester();
 			const member = requester ? await music.guild.members.fetch(requester.id).catch(() => null) : null;
-			const name = member ? member.displayName : requester ? requester.username : music.guild.language.get(`COMMAND_PLAY_UNKNOWN_USER`);
+			const name = member ? member.displayName : requester ? requester.username : music.guild.language.get(`UNKNOWN_USER`);
 
 			await music.channel.sendLocale('COMMAND_PLAY_NEXT', [song.title, name]);
 			await util.sleep(250);

--- a/src/commands/Music/play.ts
+++ b/src/commands/Music/play.ts
@@ -3,6 +3,7 @@ import { Track } from 'lavalink';
 import { Queue } from '../../lib/structures/music/Queue';
 import { MusicCommand } from '../../lib/structures/MusicCommand';
 import { Events } from '../../lib/types/Enums';
+import messageDelete from '../../events/messageDelete';
 
 export default class extends MusicCommand {
 
@@ -51,7 +52,7 @@ export default class extends MusicCommand {
 
 			const requester = await song.fetchRequester();
 			const member = requester ? await music.guild.members.fetch(requester.id).catch(() => null) : null;
-			const name = member ? member.displayName : requester ? requester.username : `Unknown user.`;
+			const name = member ? member.displayName : requester ? requester.username : music.guild.language.get(`COMMAND_PLAY_UNKNOWN_USER`);
 
 			await music.channel.sendLocale('COMMAND_PLAY_NEXT', [song.title, name]);
 			await util.sleep(250);

--- a/src/commands/Music/play.ts
+++ b/src/commands/Music/play.ts
@@ -3,7 +3,6 @@ import { Track } from 'lavalink';
 import { Queue } from '../../lib/structures/music/Queue';
 import { MusicCommand } from '../../lib/structures/MusicCommand';
 import { Events } from '../../lib/types/Enums';
-import messageDelete from '../../events/messageDelete';
 
 export default class extends MusicCommand {
 

--- a/src/commands/Music/play.ts
+++ b/src/commands/Music/play.ts
@@ -48,7 +48,11 @@ export default class extends MusicCommand {
 	public async play(music: Queue): Promise<void> {
 		while (music.length && music.channel) {
 			const [song] = music;
-			await music.channel.sendLocale('COMMAND_PLAY_NEXT', [song.title, await song.fetchRequester()]);
+			const requester = (await song.fetchRequester())!;
+			const member = await music.guild.members.fetch(requester).catch(() => null);
+			const name = member ? member.displayName : requester.username;
+
+			await music.channel.sendLocale('COMMAND_PLAY_NEXT', [song.title, name]);
 			await util.sleep(250);
 
 			try {

--- a/src/commands/Music/play.ts
+++ b/src/commands/Music/play.ts
@@ -48,9 +48,10 @@ export default class extends MusicCommand {
 	public async play(music: Queue): Promise<void> {
 		while (music.length && music.channel) {
 			const [song] = music;
-			const requester = (await song.fetchRequester())!;
-			const member = await music.guild.members.fetch(requester).catch(() => null);
-			const name = member ? member.displayName : requester.username;
+
+			const requester = await song.fetchRequester();
+			const member = requester ? await music.guild.members.fetch(requester.id).catch(() => null) : null;
+			const name = member ? member.displayName : requester ? requester.username : `Unknown user.`;
 
 			await music.channel.sendLocale('COMMAND_PLAY_NEXT', [song.title, name]);
 			await util.sleep(250);

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -244,6 +244,7 @@ export default class extends Language {
 		COMMAND_PLAY_DESCRIPTION: `Let's start the queue!`,
 		COMMAND_PLAY_END: `Looks like the queue ended here, I hope you enjoyed the session!`,
 		COMMAND_PLAY_NEXT: (title, requester) => `🎧 Playing: **${title}** as requested by: **${requester}**`,
+		COMMAND_PLAY_UNKNOWN_USER: `Unknown user.`,
 		COMMAND_PLAY_QUEUE_PAUSED: song => `There was a track going on! Playing it back! Now playing: ${song}!`,
 		COMMAND_PLAY_QUEUE_PLAYING: `${REDCROSS} Hey! The disk is already spinning!`,
 		COMMAND_PLAYING_DESCRIPTION: `Get information from the current song.`,

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -244,7 +244,6 @@ export default class extends Language {
 		COMMAND_PLAY_DESCRIPTION: `Let's start the queue!`,
 		COMMAND_PLAY_END: `Looks like the queue ended here, I hope you enjoyed the session!`,
 		COMMAND_PLAY_NEXT: (title, requester) => `🎧 Playing: **${title}** as requested by: **${requester}**`,
-		COMMAND_PLAY_UNKNOWN_USER: `Unknown user.`,
 		COMMAND_PLAY_QUEUE_PAUSED: song => `There was a track going on! Playing it back! Now playing: ${song}!`,
 		COMMAND_PLAY_QUEUE_PLAYING: `${REDCROSS} Hey! The disk is already spinning!`,
 		COMMAND_PLAYING_DESCRIPTION: `Get information from the current song.`,
@@ -2906,7 +2905,8 @@ export default class extends Language {
 		EVENTS_ERROR_WTF: `${REDCROSS} What a Terrible Failure! I am very sorry!`,
 		EVENTS_ERROR_STRING: (mention, message) => `${REDCROSS} Dear ${mention}, ${message}`,
 
-		CONST_USERS: 'Users'
+		CONST_USERS: 'Users',
+		UNKNOWN_USER: `Unknown user.`,
 	};
 
 	public async init() {

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -2906,7 +2906,7 @@ export default class extends Language {
 		EVENTS_ERROR_STRING: (mention, message) => `${REDCROSS} Dear ${mention}, ${message}`,
 
 		CONST_USERS: 'Users',
-		UNKNOWN_USER: `Unknown user.`,
+		UNKNOWN_USER: `Unknown user.`
 	};
 
 	public async init() {

--- a/src/languages/es-ES.ts
+++ b/src/languages/es-ES.ts
@@ -248,7 +248,6 @@ export default class extends Language {
 		COMMAND_PLAY_DESCRIPTION: `¡Empecemos la cola!`,
 		COMMAND_PLAY_END: `⏹ Del 1 al 10, siendo 1 la peor puntuación y 10 la mejor, ¿cómo valorarías la sesión? ¡Ya ha terminado!`,
 		COMMAND_PLAY_NEXT: (title, requester) => `🎧 Reproduciendo: **${title}**, pedida por: **${requester}**`,
-		COMMAND_PLAY_UNKNOWN_USER: `Usuario desconocido.`,
 		COMMAND_PLAY_QUEUE_PAUSED: song => `¡Había una canción pausada! ¡Reproduciéndolo ahora! Ahora reproduciendo: ${song}!`,
 		COMMAND_PLAY_QUEUE_PLAYING: `¡Ey! ¡El disco ya está girando!`,
 		COMMAND_PLAYING_DESCRIPTION: `Obtén información de la canción actual.`,
@@ -2533,7 +2532,8 @@ export default class extends Language {
 		EVENTS_ERROR_WTF: '¡Vaya fallo más terrible! ¡Lo siento!',
 		EVENTS_ERROR_STRING: (mention, message) => `Querido ${mention}, ${message}`,
 
-		CONST_USERS: 'Usuarios'
+		CONST_USERS: 'Usuarios',
+		UNKNOWN_USER: `Usuario desconocido.`
 	};
 
 	public async init() {

--- a/src/languages/es-ES.ts
+++ b/src/languages/es-ES.ts
@@ -248,6 +248,7 @@ export default class extends Language {
 		COMMAND_PLAY_DESCRIPTION: `¡Empecemos la cola!`,
 		COMMAND_PLAY_END: `⏹ Del 1 al 10, siendo 1 la peor puntuación y 10 la mejor, ¿cómo valorarías la sesión? ¡Ya ha terminado!`,
 		COMMAND_PLAY_NEXT: (title, requester) => `🎧 Reproduciendo: **${title}**, pedida por: **${requester}**`,
+		COMMAND_PLAY_UNKNOWN_USER: `Usuario desconocido.`,
 		COMMAND_PLAY_QUEUE_PAUSED: song => `¡Había una canción pausada! ¡Reproduciéndolo ahora! Ahora reproduciendo: ${song}!`,
 		COMMAND_PLAY_QUEUE_PLAYING: `¡Ey! ¡El disco ya está girando!`,
 		COMMAND_PLAYING_DESCRIPTION: `Obtén información de la canción actual.`,


### PR DESCRIPTION
This PR changes the @ in the play function to instead use the displayName or the username of the requester.

**Note:** No testing was able to be done because Lavalink.