### PR TITLE
WIP: Ignored channels for Message Log

### DIFF
--- a/src/events/messageDelete.ts
+++ b/src/events/messageDelete.ts
@@ -10,11 +10,11 @@ export default class extends Event {
 	public async run(message: KlasaMessage) {
 		if (message.partial || !message.guild || message.author!.id === this.client.user!.id) return;
 
-		const { guild } = message;
-		if (!guild!.settings.get(GuildSettings.Events.MessageDelete)) return;
+		const [messageDeleteLogEnabled, disabledChannelIDs] = message.guild.settings.pluck(GuildSettings.Events.MessageDelete, GuildSettings.Events.IgnoredChannelIDs);
+		if (!messageDeleteLogEnabled || disabledChannelIDs.includes(message.channel.id)) return;
 
 		const channel = message.channel as TextChannel;
-		this.client.emit(Events.GuildMessageLog, channel.nsfw ? MessageLogsEnum.NSFWMessage : MessageLogsEnum.Message, guild, () => new MessageEmbed()
+		this.client.emit(Events.GuildMessageLog, channel.nsfw ? MessageLogsEnum.NSFWMessage : MessageLogsEnum.Message, message.guild, () => new MessageEmbed()
 			.setColor(0xFFAB40)
 			.setAuthor(`${message.author!.tag} (${message.author!.id})`, message.author!.displayAvatarURL())
 			.setDescription(cutText(getContent(message) || '', 1900))

--- a/src/events/messageDelete.ts
+++ b/src/events/messageDelete.ts
@@ -10,7 +10,7 @@ export default class extends Event {
 	public async run(message: KlasaMessage) {
 		if (message.partial || !message.guild || message.author!.id === this.client.user!.id) return;
 
-		const [messageDeleteLogEnabled, disabledChannelIDs] = message.guild.settings.pluck(GuildSettings.Events.MessageDelete, GuildSettings.Events.IgnoredChannelIDs);
+		const [messageDeleteLogEnabled, disabledChannelIDs] = message.guild.settings.pluck(GuildSettings.Events.MessageDelete, GuildSettings.Messages.IgnoreChannels);
 		if (!messageDeleteLogEnabled || disabledChannelIDs.includes(message.channel.id)) return;
 
 		const channel = message.channel as TextChannel;

--- a/src/events/messageUpdate.ts
+++ b/src/events/messageUpdate.ts
@@ -10,10 +10,10 @@ export default class extends Event {
 	public async run(old: KlasaMessage, message: KlasaMessage) {
 		if (!this.client.ready || !message.guild || old.content === message.content || message.author === this.client.user) return;
 
-		const { guild } = message;
-		if (!guild!.settings.get(GuildSettings.Events.MessageEdit)) return;
+		const [messageEditLogEnabled, disabledChannelIDs] = message.guild.settings.pluck(GuildSettings.Events.MessageEdit, GuildSettings.Events.IgnoredChannelIDs);
+		if (!messageEditLogEnabled || disabledChannelIDs.includes(message.channel.id)) return;
 
-		this.client.emit(Events.GuildMessageLog, (message.channel as TextChannel).nsfw ? MessageLogsEnum.NSFWMessage : MessageLogsEnum.Message, guild, () => new MessageEmbed()
+		this.client.emit(Events.GuildMessageLog, (message.channel as TextChannel).nsfw ? MessageLogsEnum.NSFWMessage : MessageLogsEnum.Message, message.guild, () => new MessageEmbed()
 			.setColor(0xDCE775)
 			.setAuthor(`${message.author!.tag} (${message.author!.id})`, message.author!.displayAvatarURL(), message.url)
 			.splitFields(diffWordsWithSpace(Util.escapeMarkdown(old.content), Util.escapeMarkdown(message.content))

--- a/src/events/messageUpdate.ts
+++ b/src/events/messageUpdate.ts
@@ -10,7 +10,7 @@ export default class extends Event {
 	public async run(old: KlasaMessage, message: KlasaMessage) {
 		if (!this.client.ready || !message.guild || old.content === message.content || message.author === this.client.user) return;
 
-		const [messageEditLogEnabled, disabledChannelIDs] = message.guild.settings.pluck(GuildSettings.Events.MessageEdit, GuildSettings.Events.IgnoredChannelIDs);
+		const [messageEditLogEnabled, disabledChannelIDs] = message.guild.settings.pluck(GuildSettings.Events.MessageEdit, GuildSettings.Messages.IgnoreChannels);
 		if (!messageEditLogEnabled || disabledChannelIDs.includes(message.channel.id)) return;
 
 		this.client.emit(Events.GuildMessageLog, (message.channel as TextChannel).nsfw ? MessageLogsEnum.NSFWMessage : MessageLogsEnum.Message, message.guild, () => new MessageEmbed()

--- a/src/lib/SkyraClient.ts
+++ b/src/lib/SkyraClient.ts
@@ -169,7 +169,8 @@ SkyraClient.defaultGuildSchema
 		.add('farewell', 'String', { max: 2000 })
 		.add('greeting', 'String', { max: 2000 })
 		.add('join-dm', 'String', { max: 1500 })
-		.add('warnings', 'Boolean', { 'default': false }))
+		.add('warnings', 'Boolean', { 'default': false })
+		.add('ignoreChannels', 'TextChannel', { array: true }))
 	.add('stickyRoles', 'any', { array: true })
 	.add('roles', folder => folder
 		.add('admin', 'Role')

--- a/src/lib/SkyraClient.ts
+++ b/src/lib/SkyraClient.ts
@@ -161,7 +161,8 @@ SkyraClient.defaultGuildSchema
 		.add('memberAdd', 'Boolean', { 'default': false })
 		.add('memberRemove', 'Boolean', { 'default': false })
 		.add('messageDelete', 'Boolean', { 'default': false })
-		.add('messageEdit', 'Boolean', { 'default': false }))
+		.add('messageEdit', 'Boolean', { 'default': false })
+		.add('ignoredChannelIDs', 'TextChannel', { array: true }))
 	.add('filter', folder => folder
 		.add('level', 'Integer', { 'default': 0, 'min': 0, 'max': 7, 'configurable': false })
 		.add('raw', 'String', { array: true, configurable: false }))

--- a/src/lib/SkyraClient.ts
+++ b/src/lib/SkyraClient.ts
@@ -161,8 +161,7 @@ SkyraClient.defaultGuildSchema
 		.add('memberAdd', 'Boolean', { 'default': false })
 		.add('memberRemove', 'Boolean', { 'default': false })
 		.add('messageDelete', 'Boolean', { 'default': false })
-		.add('messageEdit', 'Boolean', { 'default': false })
-		.add('ignoredChannelIDs', 'TextChannel', { array: true }))
+		.add('messageEdit', 'Boolean', { 'default': false }))
 	.add('filter', folder => folder
 		.add('level', 'Integer', { 'default': 0, 'min': 0, 'max': 7, 'configurable': false })
 		.add('raw', 'String', { array: true, configurable: false }))

--- a/src/lib/types/settings/GuildSettings.ts
+++ b/src/lib/types/settings/GuildSettings.ts
@@ -1,5 +1,3 @@
-import { Snowflake } from "discord.js";
-
 /* eslint-disable @typescript-eslint/no-namespace */
 
 export namespace GuildSettings {

--- a/src/lib/types/settings/GuildSettings.ts
+++ b/src/lib/types/settings/GuildSettings.ts
@@ -1,3 +1,5 @@
+import { Snowflake } from "discord.js";
+
 /* eslint-disable @typescript-eslint/no-namespace */
 
 export namespace GuildSettings {
@@ -38,6 +40,8 @@ export namespace GuildSettings {
 		export const BanAdd = 'events.banAdd';
 		export type BanRemove = boolean;
 		export const BanRemove = 'events.banRemove';
+		export type IgnoredChannelIDs = Snowflake[];
+		export const IgnoredChannelIDs = 'events.ignoredChannelIDs';
 		export type MemberAdd = boolean;
 		export const MemberAdd = 'events.memberAdd';
 		export type MemberRemove = boolean;

--- a/src/lib/types/settings/GuildSettings.ts
+++ b/src/lib/types/settings/GuildSettings.ts
@@ -40,8 +40,6 @@ export namespace GuildSettings {
 		export const BanAdd = 'events.banAdd';
 		export type BanRemove = boolean;
 		export const BanRemove = 'events.banRemove';
-		export type IgnoredChannelIDs = Snowflake[];
-		export const IgnoredChannelIDs = 'events.ignoredChannelIDs';
 		export type MemberAdd = boolean;
 		export const MemberAdd = 'events.memberAdd';
 		export type MemberRemove = boolean;


### PR DESCRIPTION
This PR adds the functionality to ignore channels for message log events.

- [x] Added `events.ignoredChannelIDs` schema
- [x] Edited message delete event to ignore any ignored channel
- [x] Edited message update event to ignore any ignored channel
- [x] Tested Message Delete Log in ignored channel
- [x] Tested Message Edit log in ignored channel