### PR TITLE
hg: Add `--autofill` and `--autoskip` flags

### DIFF
--- a/src/commands/Games/hungergames.ts
+++ b/src/commands/Games/hungergames.ts
@@ -34,6 +34,8 @@ export default class extends SkyraCommand {
 			for (const { author } of messages.values()) {
 				if (author && !tributes.includes(author.username)) tributes.push(author.username);
 			}
+		} else if (tributes.length === 0) {
+			throw message.language.get('COMMAND_GAMES_NO_PLAYERS', message.guild!.settings.get('prefix'));
 		}
 
 		const filtered = new Set(tributes);

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -1884,6 +1884,7 @@ export default class extends Language {
 		COMMAND_GAMES_BOT: 'I am sorry, but I do not think they would like to stop doing what they are doing and play with humans.',
 		COMMAND_GAMES_SELF: 'You must be so sad to play against yourself. Try again with another user.',
 		COMMAND_GAMES_PROGRESS: 'I am sorry, but there is a game in progress in this channel, try again when it finishes.',
+		COMMAND_GAMES_NO_PLAYERS: prefix => `Please specify some tributes to play the Hunger Games, like so: \`${prefix}hg Bob, Mark, Jim, Kyra\``,
 		COMMAND_GAMES_TOO_MANY_OR_FEW: (min, max) => `I am sorry but the amount of players is less than ${min} or greater than ${max}.`,
 		COMMAND_GAMES_REPEAT: 'I am sorry, but a user cannot play twice.',
 		COMMAND_GAMES_PROMPT_TIMEOUT: 'I am sorry, but the challengee did not reply on time.',


### PR DESCRIPTION
Adds:
`--autofill`
Which: Adds everyone in the last 100 messages to the hunger games. Note: You can still add people alongside it, e.g. `s!hg kyra, vlad --autofill`

`--autoskip`
Which: Automatically skips through the pages so you dont have to click on the reactions, but still allows you to click on the reactions to stop, or to skip. It waits for `msg.content.length / 20` seconds, then skips.