### PR TITLE
feat(anime): implement UserDisplay for Anime/Manga

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,8 +7,34 @@
         {
             "type": "node",
             "request": "launch",
-            "name": "Main",
-            "program": "${workspaceFolder}\\dist\\src\\main.js"
+            "name": "Main - Windows",
+            "args": [
+                "${workspaceFolder}\\dist\\src\\Skyra.js"
+            ],
+            "protocol": "inspector",
+            "internalConsoleOptions": "openOnSessionStart",
+            "env": {
+                "NODE_ENV": "development"
+            },
+            "preLaunchTask": "yarn: build",
+            "console": "internalConsole",
+            "outputCapture": "std",
+        },
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Main - Linux",
+            "args": [
+                "${workspaceFolder}/dist/src/Skyra.js"
+            ],
+            "protocol": "inspector",
+            "internalConsoleOptions": "openOnSessionStart",
+            "env": {
+                "NODE_ENV": "development"
+            },
+            "preLaunchTask": "yarn: build",
+            "console": "internalConsole",
+            "outputCapture": "std",
         }
     ]
 }

--- a/config.ts.example
+++ b/config.ts.example
@@ -138,6 +138,10 @@ export const TOKENS = {
 		password: '',
 		user: ''
 	},
+	KITSU: {
+		ID: 'AWQO5J657S',
+		KEY: 'NzYxODA5NmY0ODRjYTRmMzQ2YjMzNzNmZmFhNjY5ZGRmYjZlMzViN2VkZDIzMGUwYjM5ZjQ5NjAwZGI4ZTc5MHJlc3RyaWN0SW5kaWNlcz1wcm9kdWN0aW9uX21lZGlhJmZpbHRlcnM9Tk9UK2FnZVJhdGluZyUzQVIxOA=='
+	},
 	BLIZZARD: '',
 	BOT: {
 		DEV: '',

--- a/src/commands/Anime/anime.ts
+++ b/src/commands/Anime/anime.ts
@@ -1,9 +1,9 @@
 import { MessageEmbed } from 'discord.js';
 import { CommandStore, KlasaMessage } from 'klasa';
 import { SkyraCommand } from '../../lib/structures/SkyraCommand';
+import { UserRichDisplay } from '../../lib/structures/UserRichDisplay';
 import { Kitsu } from '../../lib/types/definitions/Kitsu';
-import { prompt } from '../../lib/util/PromptList';
-import { cutText, fetch, oneToTen } from '../../lib/util/util';
+import { cutText, fetch, getColor, oneToTen } from '../../lib/util/util';
 
 export default class extends SkyraCommand {
 
@@ -18,46 +18,25 @@ export default class extends SkyraCommand {
 	}
 
 	public async run(message: KlasaMessage, [animeName]: [string]) {
+		const response = await message.sendEmbed(new MessageEmbed()
+			.setDescription(message.language.tget('SYSTEM_LOADING'))
+			.setColor(getColor(message) || 0xFFAB2D));
+
 		const url = new URL('https://kitsu.io/api/edge/anime');
 		url.searchParams.append('filter[text]', animeName);
 
-		const body = await fetch(url, 'json')
-			.catch(() => { throw message.language.tget('COMMAND_ANIME_QUERY_FAIL'); }) as Kitsu.Result<Kitsu.AnimeAttributes>;
+		const { data: entries } = await fetch(url, 'json')
+			.catch(() => { throw message.language.tget('COMMAND_ANIME_QUERY_FAIL'); }) as Kitsu.Result<Kitsu.MangaAttributes>;
 
-		const entry = await this.getIndex(message, body.data)
-			.catch(error => { throw error || message.language.tget('COMMAND_ANIME_NO_CHOICE'); });
-
-		const synopsis = cutText(entry.attributes.synopsis, 750);
-		const score = oneToTen(Math.ceil(Number(entry.attributes.averageRating) / 10))!;
-		const animeURL = `https://kitsu.io/anime/${entry.attributes.slug}`;
-		const titles = message.language.language.COMMAND_ANIME_TITLES as unknown as AnimeLanguage;
-		const type = entry.attributes.subtype;
-		const title = entry.attributes.titles.en || entry.attributes.titles.en_jp || Object.values(entry.attributes.titles)[0] || '--';
-
-		return message.sendEmbed(new MessageEmbed()
-			.setColor(score.color)
-			.setAuthor(title, entry.attributes.posterImage.tiny, animeURL)
-			.setDescription(message.language.tget('COMMAND_ANIME_OUTPUT_DESCRIPTION', entry, synopsis))
-			.addField(titles.TYPE, message.language.tget('COMMAND_ANIME_TYPES')[type.toUpperCase()] || type, true)
-			.addField(titles.SCORE, `**${entry.attributes.averageRating}** / 100 ${score.emoji}`, true)
-			.addField(titles.STATUS, message.language.tget('COMMAND_ANIME_OUTPUT_STATUS', entry))
-			.addField(titles.WATCH_IT, `**[${title}](${animeURL})**`)
-			.setFooter('© kitsu.io'));
-	}
-
-	private async getIndex(message: KlasaMessage, entries: Kitsu.Datum[]) {
-		if (entries.length === 1) return entries[0];
-		const _choice = await prompt(message, entries.slice(0, 10).map(entry => {
+		const list = entries.map(entry => {
 			if (entry.attributes.averageRating === null) entry.attributes.averageRating = this.extractAverage(entry);
-			return `(${entry.attributes.averageRating}) ${this.extractTitle(entry.attributes.titles)}`;
-		}));
-		const chosen = entries[_choice];
-		if (!chosen) throw message.language.tget('COMMAND_ANIME_INVALID_CHOICE');
-		return chosen;
-	}
+			return entry;
+		});
 
-	private extractTitle(titles: Kitsu.Titles) {
-		return Object.values(titles).find(Boolean);
+		const display = this.buildDisplay(list, message);
+
+		await display.run(response, message.author.id);
+		return response;
 	}
 
 	private extractAverage(entry: Kitsu.Datum) {
@@ -71,6 +50,33 @@ export default class extends SkyraCommand {
 
 		return total ? ((total / (max * 20)) * 100).toFixed(2) : '--.--';
 	}
+
+	private buildDisplay(entries: (Kitsu.Datum<Kitsu.MangaAttributes>)[], message: KlasaMessage) {
+		const display = new UserRichDisplay();
+
+		for (const entry of entries) {
+			const synopsis = cutText(entry.attributes.synopsis, 750);
+			const score = oneToTen(Math.ceil(Number(entry.attributes.averageRating) / 10))!;
+			const animeURL = `https://kitsu.io/anime/${entry.attributes.slug}`;
+			const titles = message.language.language.COMMAND_ANIME_TITLES as unknown as AnimeLanguage;
+			const type = entry.attributes.subtype;
+			const title = entry.attributes.titles.en || entry.attributes.titles.en_jp || Object.values(entry.attributes.titles)[0] || '--';
+
+			display.addPage(
+				new MessageEmbed()
+					.setColor(score.color)
+					.setAuthor(title, entry.attributes.posterImage.tiny, animeURL)
+					.setDescription(message.language.tget('COMMAND_ANIME_OUTPUT_DESCRIPTION', entry, synopsis))
+					.addField(titles.TYPE, message.language.tget('COMMAND_ANIME_TYPES')[type.toUpperCase()] || type, true)
+					.addField(titles.SCORE, `**${entry.attributes.averageRating}** / 100 ${score.emoji}`, true)
+					.addField(titles.STATUS, message.language.tget('COMMAND_ANIME_OUTPUT_STATUS', entry))
+					.addField(titles.WATCH_IT, `**[${title}](${animeURL})**`)
+					.setFooter('© kitsu.io')
+			);
+		}
+		return display;
+	}
+
 
 }
 

--- a/src/commands/Anime/anime.ts
+++ b/src/commands/Anime/anime.ts
@@ -24,9 +24,7 @@ export default class extends SkyraCommand {
 			.setDescription(message.language.tget('SYSTEM_LOADING'))
 			.setColor(getColor(message) || 0xFFAB2D));
 
-		const url = new URL(`https://${TOKENS.KITSU.ID}-dsn.algolia.net/1/indexes/production_media/query`);
-
-		const { hits: entries } = await fetch(url, {
+		const { hits: entries } = await fetch(`https://${TOKENS.KITSU.ID}-dsn.algolia.net/1/indexes/production_media/query`, {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',

--- a/src/commands/Anime/manga.ts
+++ b/src/commands/Anime/manga.ts
@@ -24,10 +24,7 @@ export default class extends SkyraCommand {
 			.setDescription(message.language.tget('SYSTEM_LOADING'))
 			.setColor(getColor(message) || 0xFFAB2D));
 
-		const url = new URL(`https://${TOKENS.KITSU.ID}-dsn.algolia.net/1/indexes/production_media/query`);
-
-
-		const { hits: entries } = await fetch(url, {
+		const { hits: entries } = await fetch(`https://${TOKENS.KITSU.ID}-dsn.algolia.net/1/indexes/production_media/query`, {
 			method: 'POST',
 			headers: {
 				'Content-Type': 'application/json',

--- a/src/commands/Anime/manga.ts
+++ b/src/commands/Anime/manga.ts
@@ -35,7 +35,7 @@ export default class extends SkyraCommand {
 				{
 					params: stringify({
 						query: mangaName,
-						facetFilters: ['kind:anime'],
+						facetFilters: ['kind:manga'],
 						hitsPerPage: 10
 					})
 				}
@@ -66,7 +66,7 @@ export default class extends SkyraCommand {
 					.setTitle(title)
 					.setURL(mangaURL)
 					.setDescription(message.language.tget('COMMAND_MANGA_OUTPUT_DESCRIPTION', entry, synopsis))
-					.setImage(entry.posterImage.original)
+					.setThumbnail(entry.posterImage.original)
 					.addField(titles.TYPE, message.language.tget('COMMAND_MANGA_TITLES')[type.toUpperCase()] || type, true)
 					.addField(titles.SCORE, score, true)
 					.addField(titles.AGE_RATING, entry.ageRating ? entry.ageRating : 'None', true)

--- a/src/commands/Anime/manga.ts
+++ b/src/commands/Anime/manga.ts
@@ -1,9 +1,11 @@
 import { MessageEmbed } from 'discord.js';
-import { CommandStore, KlasaMessage } from 'klasa';
+import { CommandStore, KlasaMessage, Timestamp } from 'klasa';
+import { stringify } from 'querystring';
+import { TOKENS } from '../../../config';
 import { SkyraCommand } from '../../lib/structures/SkyraCommand';
 import { UserRichDisplay } from '../../lib/structures/UserRichDisplay';
 import { Kitsu } from '../../lib/types/definitions/Kitsu';
-import { cutText, fetch, getColor, oneToTen } from '../../lib/util/util';
+import { cutText, fetch, getColor } from '../../lib/util/util';
 
 export default class extends SkyraCommand {
 
@@ -22,56 +24,56 @@ export default class extends SkyraCommand {
 			.setDescription(message.language.tget('SYSTEM_LOADING'))
 			.setColor(getColor(message) || 0xFFAB2D));
 
-		const url = new URL('https://kitsu.io/api/edge/manga');
-		url.searchParams.append('filter[text]', mangaName);
+		const url = new URL(`https://${TOKENS.KITSU.ID}-dsn.algolia.net/1/indexes/production_media/query`);
 
-		const { data: entries } = await fetch(url, 'json')
-			.catch(() => { throw message.language.tget('COMMAND_ANIME_QUERY_FAIL'); }) as Kitsu.Result<Kitsu.MangaAttributes>;
 
-		const list = entries.map(entry => {
-			if (entry.attributes.averageRating === null) entry.attributes.averageRating = this.extractAverage(entry);
-			return entry;
-		});
+		const { hits: entries } = await fetch(url, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'X-Algolia-API-Key': TOKENS.KITSU.KEY,
+				'X-Algolia-Application-Id': TOKENS.KITSU.ID
+			},
+			body: JSON.stringify(
+				{
+					params: stringify({
+						query: mangaName,
+						facetFilters: ['kind:anime'],
+						hitsPerPage: 10
+					})
+				}
+			)
+		}, 'json')
+			.catch(() => { throw message.language.tget('COMMAND_ANIME_QUERY_FAIL'); }) as Kitsu.KitsuResult;
 
-		const display = this.buildDisplay(list, message);
+		const display = this.buildDisplay(entries, message);
 
 		await display.run(response, message.author.id);
 		return response;
 	}
 
-	private extractAverage(entry: Kitsu.Datum) {
-		let total = 0;
-		let max = 0;
-		for (const array of Object.entries(entry.attributes.ratingFrequencies)) {
-			const [key, value] = array.map(Number);
-			total += key * value;
-			max += value;
-		}
-
-		return total ? ((total / (max * 20)) * 100).toFixed(2) : '--.--';
-	}
-
-	private buildDisplay(entries: (Kitsu.Datum<Kitsu.MangaAttributes>)[], message: KlasaMessage) {
+	private buildDisplay(entries: Kitsu.KitsuHit[], message: KlasaMessage) {
 		const display = new UserRichDisplay();
 
 		for (const entry of entries) {
-			this.client.console.log(entry.attributes);
-			this.client.console.error('===========');
-			const synopsis = cutText(entry.attributes.synopsis, 750);
-			const score = oneToTen(Math.ceil(Number(entry.attributes.averageRating) / 10))!;
-			const mangaURL = `https://kitsu.io/manga/${entry.attributes.slug}`;
+			const synopsis = cutText(entry.synopsis.replace(/(.+)[\r\n\t](.+)/gim, '$1 $2').split('\r\n')[0], 750);
+			const score = `${entry.averageRating}%`;
+			const mangaURL = `https://kitsu.io/manga/${entry.id}`;
 			const titles = message.language.language.COMMAND_ANIME_TITLES as unknown as MangaLanguage;
-			const type = entry.attributes.subtype;
-			const title = entry.attributes.titles.en || entry.attributes.titles.en_jp || Object.values(entry.attributes.titles)[0] || '--';
+			const type = entry.subtype;
+			const title = entry.titles.en || entry.titles.en_jp || entry.canonicalTitle || '--';
 
 			display.addPage(
 				new MessageEmbed()
-					.setColor(score.color)
-					.setAuthor(title, entry.attributes.posterImage.tiny, mangaURL)
+					.setColor(getColor(message) || 0xFFAB2D)
+					.setTitle(title)
+					.setURL(mangaURL)
 					.setDescription(message.language.tget('COMMAND_MANGA_OUTPUT_DESCRIPTION', entry, synopsis))
+					.setImage(entry.posterImage.original)
 					.addField(titles.TYPE, message.language.tget('COMMAND_MANGA_TITLES')[type.toUpperCase()] || type, true)
-					.addField(titles.SCORE, `**${entry.attributes.averageRating}** / 100 ${score.emoji}`, true)
-					.addField(titles.STATUS, message.language.tget('COMMAND_MANGA_OUTPUT_STATUS', entry))
+					.addField(titles.SCORE, score, true)
+					.addField(titles.AGE_RATING, entry.ageRating ? entry.ageRating : 'None', true)
+					.addField(titles.FIRST_PUBLISH_DATE, new Timestamp('MMMM d YYYY').display(entry.startDate), true)
 					.addField(titles.READ_IT, `**[${title}](${mangaURL})**`)
 					.setFooter('© kitsu.io')
 			);
@@ -84,7 +86,11 @@ export default class extends SkyraCommand {
 interface MangaLanguage {
 	TYPE: string;
 	SCORE: string;
-	STATUS: string;
+	EPISODES: string;
+	EPISODE_LENGTH: string;
+	AGE_RATING: string;
+	FIRST_AIR_DATE: string;
+	FIRST_PUBLISH_DATE: string;
 	WATCH_IT: string;
 	READ_IT: string;
 }

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -1854,33 +1854,27 @@ export default class extends Language {
 		COMMAND_ANIME_QUERY_FAIL: 'I am sorry, but the application could not resolve your request. Are you sure you wrote the name correctly?',
 		COMMAND_ANIME_INVALID_CHOICE: `That's an invalid choice! Please try with another option.`,
 		COMMAND_ANIME_OUTPUT_DESCRIPTION: (entry, synopsis) => [
-			`**English title:** ${entry.attributes.titles.en || entry.attributes.titles.en_us || 'None'}`,
-			`**Japanese title:** ${entry.attributes.titles.ja_jp || 'None'}`,
-			`**Canonical title:** ${entry.attributes.canonicalTitle || 'None'}`,
+			`**English title:** ${entry.titles.en || entry.titles.en_us || 'None'}`,
+			`**Japanese title:** ${entry.titles.ja_jp || 'None'}`,
+			`**Canonical title:** ${entry.canonicalTitle || 'None'}`,
 			synopsis
-		].join('\n'),
-		COMMAND_ANIME_OUTPUT_STATUS: entry => [
-			`  ❯  Current status: **${entry.attributes.status}**`,
-			`    • Started: **${entry.attributes.startDate}**\n${entry.attributes.endDate ? `    • Finished: **${entry.attributes.endDate}**` : ''}`
 		].join('\n'),
 		COMMAND_ANIME_TITLES: {
 			TYPE: 'Type',
 			SCORE: 'Score',
-			STATUS: 'Status',
+			EPISODES: 'Episode(s)',
+			EPISODE_LENGTH: 'Episode length',
+			AGE_RATING: 'Age rating',
+			FIRST_AIR_DATE: 'First air date',
+			FIRST_PUBLISH_DATE: 'First publish date',
 			WATCH_IT: 'Watch it here:',
 			READ_IT: 'Read it here:'
 		},
 		COMMAND_MANGA_OUTPUT_DESCRIPTION: (entry, synopsis) => [
-			`**English title:** ${entry.attributes.titles.en || entry.attributes.titles.en_us || 'None'}`,
-			`**Japanese title:** ${entry.attributes.titles.ja_jp || 'None'}`,
-			`**Canonical title:** ${entry.attributes.canonicalTitle || 'None'}`,
+			`**English title:** ${entry.titles.en || entry.titles.en_us || 'None'}`,
+			`**Japanese title:** ${entry.titles.ja_jp || 'None'}`,
+			`**Canonical title:** ${entry.canonicalTitle || 'None'}`,
 			synopsis
-		].join('\n'),
-		COMMAND_MANGA_OUTPUT_STATUS: entry => [
-			`  ❯  Current status: **${entry.attributes.status}**`,
-			entry.attributes.startDate
-				? `    • Started: **${entry.attributes.startDate}**\n${entry.attributes.endDate ? `    • Finished: **${entry.attributes.endDate}**` : ''}`
-				: ''
 		].join('\n'),
 		COMMAND_MANGA_TITLES: {
 			'MANGA': '📘 Manga',

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -1853,10 +1853,10 @@ export default class extends Language {
 		},
 		COMMAND_ANIME_QUERY_FAIL: 'I am sorry, but the application could not resolve your request. Are you sure you wrote the name correctly?',
 		COMMAND_ANIME_INVALID_CHOICE: `That's an invalid choice! Please try with another option.`,
-		COMMAND_ANIME_NO_CHOICE: 'You got me waiting... try again when you are decided!',
 		COMMAND_ANIME_OUTPUT_DESCRIPTION: (entry, synopsis) => [
 			`**English title:** ${entry.attributes.titles.en || entry.attributes.titles.en_us || 'None'}`,
 			`**Japanese title:** ${entry.attributes.titles.ja_jp || 'None'}`,
+			`**Canonical title:** ${entry.attributes.canonicalTitle || 'None'}`,
 			synopsis
 		].join('\n'),
 		COMMAND_ANIME_OUTPUT_STATUS: entry => [
@@ -1873,11 +1873,14 @@ export default class extends Language {
 		COMMAND_MANGA_OUTPUT_DESCRIPTION: (entry, synopsis) => [
 			`**English title:** ${entry.attributes.titles.en || entry.attributes.titles.en_us || 'None'}`,
 			`**Japanese title:** ${entry.attributes.titles.ja_jp || 'None'}`,
+			`**Canonical title:** ${entry.attributes.canonicalTitle || 'None'}`,
 			synopsis
 		].join('\n'),
 		COMMAND_MANGA_OUTPUT_STATUS: entry => [
 			`  ❯  Current status: **${entry.attributes.status}**`,
-			`    • Started: **${entry.attributes.startDate}**\n${entry.attributes.endDate ? `    • Finished: **${entry.attributes.endDate}**` : ''}`
+			entry.attributes.startDate
+				? `    • Started: **${entry.attributes.startDate}**\n${entry.attributes.endDate ? `    • Finished: **${entry.attributes.endDate}**` : ''}`
+				: ''
 		].join('\n'),
 		COMMAND_MANGA_TITLES: {
 			'MANGA': '📘 Manga',

--- a/src/languages/es-ES.ts
+++ b/src/languages/es-ES.ts
@@ -1831,10 +1831,10 @@ export default class extends Language {
 		},
 		COMMAND_ANIME_QUERY_FAIL: 'Lo siento, pero la aplicación no pudo resolver su solicitud. ¿Estás seguro/a que escribiste el nombre correctamente?',
 		COMMAND_ANIME_INVALID_CHOICE: `¡Esa opción no es válida! Selecciona otra opción, por favor.`,
-		COMMAND_ANIME_NO_CHOICE: 'Me dejaste esperando... ¡prueba de nuevo cuando te hayas decidido!',
 		COMMAND_ANIME_OUTPUT_DESCRIPTION: (entry, synopsis) => [
 			`**Título inglés:** ${entry.attributes.titles.en || entry.attributes.titles.en_us || 'Ninguno'}`,
 			`**Título japonés:** ${entry.attributes.titles.ja_jp || 'Ninguno'}`,
+			`**Título canónico:** ${entry.attributes.canonicalTitle || 'Ninguno'}`,
 			synopsis
 		].join('\n'),
 		COMMAND_ANIME_OUTPUT_STATUS: entry => [
@@ -1851,11 +1851,14 @@ export default class extends Language {
 		COMMAND_MANGA_OUTPUT_DESCRIPTION: (entry, synopsis) => [
 			`**Título inglés:** ${entry.attributes.titles.en || entry.attributes.titles.en_us || 'Ninguno'}`,
 			`**Título japonés:** ${entry.attributes.titles.ja_jp || 'Ninguno'}`,
+			`**Título canónico:** ${entry.attributes.canonicalTitle || 'Ninguno'}`,
 			synopsis
 		].join('\n'),
 		COMMAND_MANGA_OUTPUT_STATUS: entry => [
 			`  ❯  Estado actual: **${entry.attributes.status}**`,
-			`    • Empezó: **${entry.attributes.startDate}**\n${entry.attributes.endDate ? `    • Terminó: **${entry.attributes.endDate}**` : ''}`
+			entry.attributes.startDate
+				? `    • Empezó: **${entry.attributes.startDate}**\n${entry.attributes.endDate ? `    • Terminó: **${entry.attributes.endDate}**` : ''}`
+				: ''
 		].join('\n'),
 		COMMAND_MANGA_TITLES: {
 			'MANGA': '📘 Manga',

--- a/src/languages/es-ES.ts
+++ b/src/languages/es-ES.ts
@@ -1832,33 +1832,27 @@ export default class extends Language {
 		COMMAND_ANIME_QUERY_FAIL: 'Lo siento, pero la aplicación no pudo resolver su solicitud. ¿Estás seguro/a que escribiste el nombre correctamente?',
 		COMMAND_ANIME_INVALID_CHOICE: `¡Esa opción no es válida! Selecciona otra opción, por favor.`,
 		COMMAND_ANIME_OUTPUT_DESCRIPTION: (entry, synopsis) => [
-			`**Título inglés:** ${entry.attributes.titles.en || entry.attributes.titles.en_us || 'Ninguno'}`,
-			`**Título japonés:** ${entry.attributes.titles.ja_jp || 'Ninguno'}`,
-			`**Título canónico:** ${entry.attributes.canonicalTitle || 'Ninguno'}`,
+			`**Título inglés:** ${entry.titles.en || entry.titles.en_us || 'Ninguno'}`,
+			`**Título japonés:** ${entry.titles.ja_jp || 'Ninguno'}`,
+			`**Título canónico:** ${entry.canonicalTitle || 'Ninguno'}`,
 			synopsis
-		].join('\n'),
-		COMMAND_ANIME_OUTPUT_STATUS: entry => [
-			`  ❯  Estado actual: **${entry.attributes.status}**`,
-			`    • Empezó: **${entry.attributes.startDate}**\n${entry.attributes.endDate ? `    • Terminó: **${entry.attributes.endDate}**` : ''}`
 		].join('\n'),
 		COMMAND_ANIME_TITLES: {
 			TYPE: 'Tipo',
 			SCORE: 'Puntuación',
-			STATUS: 'Estado',
+			EPISODES: 'Episodio(s)',
+			EPISODE_LENGTH: 'Duración del episodio',
+			AGE_RATING: 'Clasificación de edad',
+			FIRST_AIR_DATE: 'Primera fecha de emisión',
+			FIRST_PUBLISH_DATE: 'Primera fecha de publicación',
 			WATCH_IT: 'Míralo Aquí:',
 			READ_IT: 'Léelo Aquí:'
 		},
 		COMMAND_MANGA_OUTPUT_DESCRIPTION: (entry, synopsis) => [
-			`**Título inglés:** ${entry.attributes.titles.en || entry.attributes.titles.en_us || 'Ninguno'}`,
-			`**Título japonés:** ${entry.attributes.titles.ja_jp || 'Ninguno'}`,
-			`**Título canónico:** ${entry.attributes.canonicalTitle || 'Ninguno'}`,
+			`**Título inglés:** ${entry.titles.en || entry.titles.en_us || 'Ninguno'}`,
+			`**Título japonés:** ${entry.titles.ja_jp || 'Ninguno'}`,
+			`**Título canónico:** ${entry.canonicalTitle || 'Ninguno'}`,
 			synopsis
-		].join('\n'),
-		COMMAND_MANGA_OUTPUT_STATUS: entry => [
-			`  ❯  Estado actual: **${entry.attributes.status}**`,
-			entry.attributes.startDate
-				? `    • Empezó: **${entry.attributes.startDate}**\n${entry.attributes.endDate ? `    • Terminó: **${entry.attributes.endDate}**` : ''}`
-				: ''
 		].join('\n'),
 		COMMAND_MANGA_TITLES: {
 			'MANGA': '📘 Manga',

--- a/src/lib/types/Languages.d.ts
+++ b/src/lib/types/Languages.d.ts
@@ -556,7 +556,6 @@ export interface LanguageKeys {
 	COMMAND_ANIME_TYPES: Record<string, string>;
 	COMMAND_ANIME_QUERY_FAIL: string;
 	COMMAND_ANIME_INVALID_CHOICE: string;
-	COMMAND_ANIME_NO_CHOICE: string;
 	COMMAND_ANIME_OUTPUT_DESCRIPTION: (entry: Kitsu.Datum<Kitsu.Attributes>, synopsis: string) => string;
 	COMMAND_ANIME_OUTPUT_STATUS: (entry: Kitsu.Datum<Kitsu.Attributes>) => string;
 	COMMAND_ANIME_TITLES: Record<string, string>;

--- a/src/lib/types/Languages.d.ts
+++ b/src/lib/types/Languages.d.ts
@@ -556,11 +556,9 @@ export interface LanguageKeys {
 	COMMAND_ANIME_TYPES: Record<string, string>;
 	COMMAND_ANIME_QUERY_FAIL: string;
 	COMMAND_ANIME_INVALID_CHOICE: string;
-	COMMAND_ANIME_OUTPUT_DESCRIPTION: (entry: Kitsu.Datum<Kitsu.Attributes>, synopsis: string) => string;
-	COMMAND_ANIME_OUTPUT_STATUS: (entry: Kitsu.Datum<Kitsu.Attributes>) => string;
+	COMMAND_ANIME_OUTPUT_DESCRIPTION: (entry: Kitsu.KitsuHit, synopsis: string) => string;
 	COMMAND_ANIME_TITLES: Record<string, string>;
-	COMMAND_MANGA_OUTPUT_DESCRIPTION: (entry: Kitsu.Datum<Kitsu.Attributes>, synopsis: string) => string;
-	COMMAND_MANGA_OUTPUT_STATUS: (entry: Kitsu.Datum<Kitsu.Attributes>) => string;
+	COMMAND_MANGA_OUTPUT_DESCRIPTION: (entry: Kitsu.KitsuHit, synopsis: string) => string;
 	COMMAND_MANGA_TITLES: Record<string, string>;
 	COMMAND_SUBSCRIBE_NO_ROLE: string;
 	COMMAND_SUBSCRIBE_SUCCESS: (role: string) => string;

--- a/src/lib/types/definitions/Kitsu.d.ts
+++ b/src/lib/types/definitions/Kitsu.d.ts
@@ -27,8 +27,8 @@ export namespace Kitsu {
 		ratingFrequencies: { [key: string]: string };
 		userCount: number;
 		favoritesCount: number;
-		startDate: Date | null;
-		endDate: Date | null;
+		startDate?: Date;
+		endDate?: Date;
 		nextRelease: null | string;
 		popularityRank: number;
 		ratingRank: number;

--- a/src/lib/types/definitions/Kitsu.d.ts
+++ b/src/lib/types/definitions/Kitsu.d.ts
@@ -1,117 +1,63 @@
 export namespace Kitsu {
 
-	export interface Result<A extends Attributes> {
-		data: Datum<A>[];
-		meta: KitsuMeta;
-		links: KitsuLinks;
+	export interface KitsuResult {
+		exhaustiveNbHits: boolean;
+		hitsPerPage: number;
+		nbHits: number;
+		nbPages: number;
+		page: number;
+		params: string;
+		processingTimeMS: number;
+		query: string;
+		queryAfterRemoval: string;
+		hits: KitsuHit[];
 	}
 
-	export interface Datum<A extends Attributes = Attributes> {
-		id: string;
-		type: Type;
-		links: DatumLinks;
-		attributes: Attributes;
-		relationships: { [key: string]: Relationship };
-	}
-
-	export interface Attributes {
-		createdAt: Date;
-		updatedAt: Date;
-		slug: string;
-		synopsis: string;
-		coverImageTopOffset: number;
-		titles: Titles;
-		canonicalTitle: string;
+	export interface KitsuHit {
 		abbreviatedTitles: string[];
-		averageRating: string;
-		ratingFrequencies: { [key: string]: string };
-		userCount: number;
-		favoritesCount: number;
-		startDate?: Date;
-		endDate?: Date;
-		nextRelease: null | string;
-		popularityRank: number;
-		ratingRank: number;
-		ageRating: AgeRating;
-		ageRatingGuide: AgeRatingGuide;
-		subtype: string;
-		status: Status;
-		tba: null | string;
-		posterImage: PosterImage;
-		coverImage: CoverImage | null;
-	}
-
-	export interface AnimeAttributes extends Attributes {
-		episodeCount: number | null;
+		ageRating: 'PG' | 'G' | string;
+		averageRating: number;
+		canonicalTitle: string;
+		endDate: number;
+		episodeCount: number;
 		episodeLength: number;
+		favoritesCount: number;
+		id: number;
+		kind: 'anime' | string;
+		objectID: string;
+		season: 'spring' | 'summer' | 'autumn' | 'winter' | string;
+		seasonYear: number;
+		slug: string;
+		startDate: number;
+		subtype: 'TV' | 'movie' | 'special' | string;
+		synopsis: string;
 		totalLength: number;
-		youtubeVideoID: null | string;
-		showType: string;
-		nsfw: boolean;
+		userCount: number;
+		year: number;
+		posterImage: KitsuPosterImage;
+		titles: Titles;
+		_tags: string[];
 	}
 
-	export interface MangaAttributes extends Attributes {
-		chapterCount: number | null;
-		volumeCount: number | null;
-		serialization: null | string;
-		mangaType: string;
-	}
-
-	export enum AgeRating {
-		PG = 'PG',
-	}
-
-	export enum AgeRatingGuide {
-		Teens13OrOlder = 'Teens 13 or older',
-	}
-
-	export interface CoverImage {
-		tiny: string;
-		small: string;
-		large: string;
-		original: string;
-		meta: CoverImageMeta;
-	}
-
-	export interface CoverImageMeta {
-		dimensions: PurpleDimensions;
-	}
-
-	export interface PurpleDimensions {
-		tiny: Large;
-		small: Large;
-		large: Large;
-	}
-
-	export interface Large {
+	export interface KitsuPosterImageDimensions {
 		width: number | null;
 		height: number | null;
 	}
 
-	export interface PosterImage {
-		tiny: string;
-		small: string;
-		medium: string;
-		large: string;
+	export interface KitsuPosterImage {
+		tiny?: string;
+		small?: string;
+		medium?: string;
+		large?: string;
 		original: string;
-		meta: PosterImageMeta;
-	}
-
-	export interface PosterImageMeta {
-		dimensions: FluffyDimensions;
-	}
-
-	export interface FluffyDimensions {
-		tiny: Large;
-		small: Large;
-		medium: Large;
-		large: Large;
-	}
-
-	export enum Status {
-		Current = 'current',
-		Finished = 'finished',
-		Tba = 'tba'
+		meta: {
+			dimensions: {
+				large: KitsuPosterImageDimensions;
+				medium: KitsuPosterImageDimensions;
+				small: KitsuPosterImageDimensions;
+				tiny: KitsuPosterImageDimensions;
+			};
+		};
 	}
 
 	export interface Titles {
@@ -120,33 +66,4 @@ export namespace Kitsu {
 		en_us?: string;
 		ja_jp?: string;
 	}
-
-	export interface DatumLinks {
-		self: string;
-	}
-
-	export interface Relationship {
-		links: RelationshipLinks;
-	}
-
-	export interface RelationshipLinks {
-		self: string;
-		related: string;
-	}
-
-	export enum Type {
-		Anime = 'anime',
-		Manga = 'manga'
-	}
-
-	export interface KitsuLinks {
-		first: string;
-		next: string;
-		last: string;
-	}
-
-	export interface KitsuMeta {
-		count: number;
-	}
-
 }

--- a/src/lib/types/definitions/Kitsu.d.ts
+++ b/src/lib/types/definitions/Kitsu.d.ts
@@ -27,7 +27,7 @@ export namespace Kitsu {
 		ratingFrequencies: { [key: string]: string };
 		userCount: number;
 		favoritesCount: number;
-		startDate: Date;
+		startDate: Date | null;
 		endDate: Date | null;
 		nextRelease: null | string;
 		popularityRank: number;


### PR DESCRIPTION
This is the first PR of many to come, as you requested they'll be in smaller batches. Bundled these 2 commands since the files were and still are so similar anyway. Please do verify the Spanish translations I added, the only Spanish I know is `ne hablo espanol` and I don't fully trust Google Translate 😂.

I marked `Attributes.startDate` and `Attributes.endDate` as optional and handled the former in the translation as I noticed that they can be undefined at least on manga's, which caused this:
![00-40-16_19-10-2019_DiscordCanary](https://user-images.githubusercontent.com/4019718/67134633-64be3c00-f213-11e9-82f7-da0251899bc8.png)

Edit: Rewritten to use Algolia search API which is Kitsu's preferred API
