### PR TITLE
Add a hint for the help command's --all flag

### DIFF
--- a/src/commands/General/Chat Bot Info/help.ts
+++ b/src/commands/General/Chat Bot Info/help.ts
@@ -73,7 +73,7 @@ export default class extends SkyraCommand {
 		const prefix = message.guildSettings.get(GuildSettings.Prefix);
 
 		const display = new UserRichDisplay()
-			.setFooterSuffix('| Use the --all flag for the list in DMs');
+			.setFooterSuffix(' | Use the --all flag to get the full list in DMs');
 
 		const color = getColor(message) || 0xFFAB2D;
 		for (const [category, list] of commands) {

--- a/src/commands/General/Chat Bot Info/help.ts
+++ b/src/commands/General/Chat Bot Info/help.ts
@@ -72,7 +72,9 @@ export default class extends SkyraCommand {
 		const commands = await this._fetchCommands(message);
 		const prefix = message.guildSettings.get(GuildSettings.Prefix);
 
-		const display = new UserRichDisplay();
+		const display = new UserRichDisplay()
+			.setFooterSuffix('| Use the --all flag for the list in DMs');
+
 		const color = getColor(message) || 0xFFAB2D;
 		for (const [category, list] of commands) {
 			display.addPage(new MessageEmbed()


### PR DESCRIPTION
It displays the message in the footer of the help embed.

E.g., "2/2 | Use the --all flag to get the full list in DMs":
![image](https://user-images.githubusercontent.com/25398066/67298879-e0411700-f4b9-11e9-8027-8019de430d72.png)

Tested locally, and works.

Resolves #322 