### PR TITLE
Fix(Anime): Fix 2 reported bugs

### DIFF
--- a/src/commands/Anime/anime.ts
+++ b/src/commands/Anime/anime.ts
@@ -74,7 +74,8 @@ export default class extends SkyraCommand {
 				.setTitle(title)
 				.setURL(animeURL)
 				.setDescription(message.language.tget('COMMAND_ANIME_OUTPUT_DESCRIPTION', entry, synopsis))
-				.setThumbnail(entry.posterImage.original)
+				// TODO (favna) 06-11-2019 Change to optional chaining when TSC3.7 is fully supported
+				.setThumbnail((entry.posterImage || { original: '' }).original)
 				.addField(titles.TYPE, message.language.tget('COMMAND_ANIME_TYPES')[type.toUpperCase()] || type, true)
 				.addField(titles.SCORE, score, true)
 				.addField(titles.EPISODES, entry.episodeCount ? entry.episodeCount : 'Still airing', true)

--- a/src/commands/Anime/anime.ts
+++ b/src/commands/Anime/anime.ts
@@ -81,7 +81,7 @@ export default class extends SkyraCommand {
 				.addField(titles.EPISODES, entry.episodeCount ? entry.episodeCount : 'Still airing', true)
 				.addField(titles.EPISODE_LENGTH, message.language.duration(entry.episodeLength * 60 * 1000), true)
 				.addField(titles.AGE_RATING, entry.ageRating, true)
-				.addField(titles.FIRST_AIR_DATE, new Timestamp('MMMM d YYYY').display(entry.startDate), true)
+				.addField(titles.FIRST_AIR_DATE, new Timestamp('MMMM d YYYY').display(entry.startDate * 1000), true)
 				.addField(titles.WATCH_IT, `**[${title}](${animeURL})**`));
 		}
 		return display;

--- a/src/commands/Tools/Websearch/igdb.ts
+++ b/src/commands/Tools/Websearch/igdb.ts
@@ -75,7 +75,6 @@ export default class extends SkyraCommand {
 			.setColor(getColor(message)));
 
 		for (const game of entries) {
-			console.log(game);
 			const coverImg = /https?:/i.test(game.cover.url) ? game.cover.url : `https:${game.cover.url}`;
 			const userRating = game.rating ? `${roundNumber(game.rating, 2)}%` : fieldsData.NO_RATING;
 			const ageRating = game.age_ratings.map(ageRating => `${ageRating.category === 1 ? 'ESRB' : 'PEGI'}: ${IgdbAgeRating[ageRating.rating]}`);


### PR DESCRIPTION
Can't replicate the issue with not being able to access original of `entry.posterImage` but the way I fixed it should fix it if it ever occurs again. I feel like the API just derped. 

Also added a TODO comment at the same time to change it to optional chaining when LGTM and Typescript-ESLint fully support that.