### PR TITLE
fix: Create user tags correctly

### DIFF
--- a/src/events/rawGuildMemberAdd.ts
+++ b/src/events/rawGuildMemberAdd.ts
@@ -30,7 +30,7 @@ export default class extends Event {
 		if (!guild || !guild.available) return;
 
 		if (typeof data.nick !== 'undefined') guild.nicknames.set(data.user.id, data.nick);
-		guild.client.userTags.set(data.user.id, data.user);
+		guild.client.userTags.create(data.user);
 		const member = guild.members.add(data);
 
 		if (await this.handleRAID(guild, member)) return;


### PR DESCRIPTION
Didn't throw a type error cause technically APIUserData met the constraints of UserTag, however that takes more RAM as it holds more data