### PR TITLE
feat: %POSITION%` placeholder in Skyra's greetings

### DIFF
--- a/src/events/rawGuildMemberAdd.ts
+++ b/src/events/rawGuildMemberAdd.ts
@@ -153,8 +153,8 @@ export default class extends Event {
 				case MATCHES.MEMBERNAME: return user.username;
 				case MATCHES.MEMBERTAG: return user.tag;
 				case MATCHES.GUILD: return guild.name;
-				case MATCHES.MEMBERCOUNT: return guild.language.ordinal(guild.memberCount);
-				case MATCHES.POSITION: return guild.memberCount.toString();
+				case MATCHES.POSITION: return guild.language.ordinal(guild.memberCount);
+				case MATCHES.MEMBERCOUNT: return guild.memberCount.toString();
 				default: return match;
 			}
 		});

--- a/src/events/rawGuildMemberAdd.ts
+++ b/src/events/rawGuildMemberAdd.ts
@@ -6,12 +6,14 @@ import { MessageLogsEnum } from '../lib/util/constants';
 import { Event, EventStore } from 'klasa';
 
 const { FLAGS } = Permissions;
-const REGEXP = /%MEMBER%|%MEMBERNAME%|%MEMBERTAG%|%GUILD%/g;
+const REGEXP = /%MEMBER%|%MEMBERNAME%|%MEMBERTAG%|%GUILD%|%POSITION%|%MEMBERCOUNT%/g;
 const MATCHES = {
 	GUILD: '%GUILD%',
 	MEMBER: '%MEMBER%',
 	MEMBERNAME: '%MEMBERNAME%',
-	MEMBERTAG: '%MEMBERTAG%'
+	MEMBERTAG: '%MEMBERTAG%',
+	MEMBERCOUNT: '%MEMBERCOUNT%',
+	POSITION: '%POSITION%'
 };
 
 const COLORS = {
@@ -151,6 +153,8 @@ export default class extends Event {
 				case MATCHES.MEMBERNAME: return user.username;
 				case MATCHES.MEMBERTAG: return user.tag;
 				case MATCHES.GUILD: return guild.name;
+				case MATCHES.MEMBERCOUNT: return guild.language.ordinal(guild.memberCount);
+				case MATCHES.POSITION: return guild.memberCount.toString();
 				default: return match;
 			}
 		});

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -92,6 +92,27 @@ function duration(time: number, precision?: number) {
 	return friendlyDuration(time, TIMES, precision);
 }
 
+/** Parses cardinal numbers to the ordinal counterparts */
+function ordinal(cardinal: number) {
+	const cent = cardinal % 100;
+	const dec = cardinal % 10;
+
+	if (cent >= 10 && cent <= 20) {
+		return `${cardinal}th`;
+	}
+
+	switch (dec) {
+		case 1:
+			return `${cardinal}st`;
+		case 2:
+			return `${cardinal}nd`;
+		case 3:
+			return `${cardinal}rd`;
+		default:
+			return `${cardinal}th`;
+	}
+}
+
 export default class extends Language {
 
 	public PERMISSIONS = PERMS;
@@ -104,6 +125,7 @@ export default class extends Language {
 	};
 
 	public duration = duration;
+	public ordinal = ordinal;
 
 	// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 	// @ts-ignore:2416

--- a/src/languages/es-ES.ts
+++ b/src/languages/es-ES.ts
@@ -90,6 +90,29 @@ function duration(time: number, precision?: number) {
 	return friendlyDuration(time, TIMES, precision);
 }
 
+/** Parses cardinal numbers to the ordinal counterparts */
+function ordinal(cardinal: number) {
+	const dec = cardinal % 10;
+
+	switch (dec) {
+		case 1:
+			return `${cardinal}ro`;
+		case 2:
+			return `${cardinal}do`;
+		case 3:
+			return `${cardinal}ro`;
+		case 0:
+		case 7:
+			return `${cardinal}mo`;
+		case 8:
+			return `${cardinal}vo`;
+		case 9:
+			return `${cardinal}no`;
+		default:
+			return `${cardinal}to`;
+	}
+}
+
 export default class extends Language {
 
 	public PERMISSIONS = PERMS;
@@ -102,6 +125,7 @@ export default class extends Language {
 	};
 
 	public duration = duration;
+	public ordinal = ordinal;
 
 	// eslint-disable-next-line @typescript-eslint/ban-ts-ignore
 	// @ts-ignore:2416

--- a/src/lib/types/Augments.d.ts
+++ b/src/lib/types/Augments.d.ts
@@ -86,6 +86,7 @@ declare module 'klasa' {
 		PERMISSIONS: Record<PermissionString, string>;
 		HUMAN_LEVELS: Record<0 | 1 | 2 | 3 | 4, string>;
 		duration(time: number): string;
+		ordinal(cardinal: number): string;
 
 		get<T extends LanguageKeysSimple>(term: T): LanguageKeys[T];
 		get<T extends LanguageKeysComplex>(term: T, ...args: Parameters<LanguageKeys[T]>): ReturnType<LanguageKeys[T]>;


### PR DESCRIPTION
Closes #548

Tasks:

- [x] Position placeholder
- [x] i18n-safe parsing of ordinal numbers (i.e. 1st)

A good way has to be devised to make ordinal numbers available on i18n. Preferebly through `message.language.orderinal(5)` which would return `5th` in English.