### PR TITLE
chore: config.example.ts doesn't need to be built

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,6 @@
 		"./src/**/*",
 		"./database/**/*",
 		"./config.ts",
-		"./config.example.ts"
 	],
 	"exclude": [
 		"**/node_modules",


### PR DESCRIPTION
`tsconfig.json` included an extra file that needn't be built. This PR removes it

~~wrong branch, I know, sosumi~~