### PR TITLE
feat: vault command

### DIFF
--- a/src/commands/Games/vault.ts
+++ b/src/commands/Games/vault.ts
@@ -1,0 +1,71 @@
+import { MessageEmbed } from 'discord.js';
+import { CommandStore, KlasaMessage } from 'klasa';
+import { SkyraCommand } from '../../lib/structures/SkyraCommand';
+import { UserSettings } from '../../lib/types/settings/UserSettings';
+import { getColor } from '../../lib/util/util';
+
+export default class extends SkyraCommand {
+
+	public constructor(store: CommandStore, file: string[], directory: string) {
+		super(store, file, directory, {
+			aliases: ['bank'],
+			description: language => language.tget('COMMAND_VAULT_DESCRIPTION'),
+			extendedHelp: language => language.tget('COMMAND_VAULT_EXTENDED'),
+			subcommands: true,
+			usage: '<deposit|withdraw> (coins:number)',
+			usageDelim: ' '
+		});
+	}
+
+	public async deposit(message: KlasaMessage, [coins]: [number]) {
+		const { settings } = message.author;
+
+		await settings.sync();
+
+		const money = settings.get(UserSettings.Money);
+		const vault = settings.get(UserSettings.Vault);
+
+		if (money < coins) {
+			throw message.language.tget('COMMAND_VAULT_NOT_ENOUGH_MONEY', money);
+		}
+
+		const newMoney = money - coins;
+		const newVault = vault + coins;
+
+		await settings.update(UserSettings.Money, newMoney);
+		await settings.update(UserSettings.Vault, newVault);
+
+		return message.sendEmbed(this.buildEmbed(message, coins, newMoney, newVault, true));
+	}
+
+	public async withdraw(message: KlasaMessage, [coins]: [number]) {
+		const { settings } = message.author;
+
+		await settings.sync();
+
+		const money = settings.get(UserSettings.Money);
+		const vault = settings.get(UserSettings.Vault);
+
+		if (vault < coins) {
+			throw message.language.tget('COMMAND_VAULT_NOT_ENOUGH_IN_VAULT', vault);
+		}
+
+		const newMoney = money + coins;
+		const newVault = vault - coins;
+
+		await settings.update(UserSettings.Money, newMoney);
+		await settings.update(UserSettings.Vault, newVault);
+
+		return message.sendEmbed(this.buildEmbed(message, coins, newMoney, newVault, false));
+	}
+
+	private buildEmbed(message: KlasaMessage, coins: number, money: number, vault: number, hasDeposited: boolean) {
+		const embedData = message.language.tget('COMMAND_VAULT_EMBED_DATA');
+		return new MessageEmbed()
+			.setColor(getColor(message))
+			.setDescription(hasDeposited ? embedData.DEPOSITED_DESCRIPTION(coins) : embedData.WITHDREW_DESCRIPTION(coins))
+			.addField(embedData.ACCOUNT_MONEY, money, true)
+			.addField(embedData.ACCOUNT_VAULT, vault, true);
+	}
+
+}

--- a/src/commands/Social/profile.ts
+++ b/src/commands/Social/profile.ts
@@ -36,15 +36,18 @@ export default class extends SkyraCommand {
 	}
 
 	public async showProfile(message: KlasaMessage, user: KlasaUser) {
-		await user.settings.sync();
+		const { settings } = user;
+
+		await settings.sync();
 		const level = user.profileLevel;
-		const points = user.settings.get(UserSettings.Points);
-		const themeProfile = user.settings.get(UserSettings.ThemeProfile);
-		const badgeSet = user.settings.get(UserSettings.BadgeSet);
-		const color = user.settings.get(UserSettings.Color);
-		const money = user.settings.get(UserSettings.Money);
-		const reputation = user.settings.get(UserSettings.Reputation);
-		const darkTheme = user.settings.get(UserSettings.DarkTheme);
+		const points = settings.get(UserSettings.Points);
+		const themeProfile = settings.get(UserSettings.ThemeProfile);
+		const badgeSet = settings.get(UserSettings.BadgeSet);
+		const color = settings.get(UserSettings.Color);
+		const money = settings.get(UserSettings.Money);
+		const vault = settings.get(UserSettings.Vault);
+		const reputation = settings.get(UserSettings.Reputation);
+		const darkTheme = settings.get(UserSettings.DarkTheme);
 
 		/* Calculate information from the user */
 		const previousLevel = Math.floor((level / 0.2) ** 2);
@@ -104,7 +107,7 @@ export default class extends SkyraCommand {
 			.setTextAlign('right')
 			.setTextFont('25px RobotoLight')
 			.addText(rank.toString(), 594, 276)
-			.addText(money.toString(), 594, 229)
+			.addText(`${money} | ${vault}`, 594, 229)
 			.addText(reputation.toString(), 594, 181)
 			.addText(points.toString(), 594, 346)
 

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -634,6 +634,24 @@ export default class extends Language {
 				players, X and O, who take turns marking the spaces in a 3×3 grid. The player who succeeds in placing three of
 				their marks in a horizontal, vertical, or diagonal row wins the game.`
 		}),
+		COMMAND_VAULT_DESCRIPTION: `Store your ${SHINY}'s securily in a vault so you cannot accidentally spend them gambling.`,
+		COMMAND_VAULT_EXTENDED: builder.display('vault', {
+			extendedHelp: `This is for the greedy spenders among us that tend to play a bit too much at the slot machine or
+				 spin the wheel of fortune. You need to actively withdraw ${SHINY}'s from your vault before they can be spend gambling.`,
+			explainedUsage: [
+				['action', 'The action to perform: **withdraw** to withdraw from your vault or **deposit** to deposit into your vault.'],
+				['money', `The amount of ${SHINY}'s to withdraw or deposit.`]
+			],
+			examples: ['deposit 10000.', 'withdraw 10000.']
+		}),
+		COMMAND_VAULT_EMBED_DATA: {
+			DEPOSITED_DESCRIPTION: coins => `Deposited ${coins} ${SHINY} from your account balance into your vault.`,
+			WITHDREW_DESCRIPTION: coins => `Withdrew ${coins} ${SHINY}\ from your vault.`,
+			ACCOUNT_MONEY: 'Account Money',
+			ACCOUNT_VAULT: 'Account Vault'
+		},
+		COMMAND_VAULT_NOT_ENOUGH_MONEY: money => `I am sorry, but you do not have enough money to make that deposit! Your current money balance is ${money}${SHINY}`,
+		COMMAND_VAULT_NOT_ENOUGH_IN_VAULT: vault => `I am sorry, but you do not have enough stored in your vault to make that withdrawel! Your current vault balance is ${vault}${SHINY}`,
 
 		/**
 		 * ################
@@ -2885,7 +2903,7 @@ export default class extends Language {
 		COMMAND_SOCIAL_PAY_BOT: 'Oh, sorry, but money is meaningless for bots, I am pretty sure a human would take advantage of it better.',
 		COMMAND_PROFILE: {
 			GLOBAL_RANK: 'Global Rank',
-			CREDITS: 'Credits',
+			CREDITS: 'Credits | Vault',
 			REPUTATION: 'Reputation',
 			EXPERIENCE: 'Experience',
 			LEVEL: 'Level'

--- a/src/languages/es-ES.ts
+++ b/src/languages/es-ES.ts
@@ -621,6 +621,24 @@ export default class extends Language {
 				players, X and O, who take turns marking the spaces in a 3×3 grid. The player who succeeds in placing three of
 				their marks in a horizontal, vertical, or diagonal row wins the game.`
 		}),
+		COMMAND_VAULT_DESCRIPTION: `Guarde sus ${SHINY} de forma segura en una bóveda para que no pueda gastarlos accidentalmente en juegos de azar.`,
+		COMMAND_VAULT_EXTENDED: builder.display('vault', {
+			extendedHelp: `Esto es para los gastadores codiciosos entre nosotros que tienden a jugar demasiado en la máquina tragamonedas o girar la rueda de la fortuna.
+				Debes retirar activamente a los ${SHINY} de tu bóveda antes de que puedan gastarse el juego.`,
+			explainedUsage: [
+				['acción', 'La acción a realizar: **retirarse** para retirarse de su bóveda o **depositar** para depositar en su bóveda.'],
+				['dinero', `La cantidad de ${SHINY} para retirar o depositar.`]
+			],
+			examples: ['depositar 10000.', 'retirar 10000.']
+		}),
+		COMMAND_VAULT_EMBED_DATA: {
+			DEPOSITED_DESCRIPTION: coins => `Depositó ${coins} ${SHINY} del saldo de su cuenta en su bóveda.`,
+			WITHDREW_DESCRIPTION: coins => `Retiró ${coins} ${SHINY} de su bóveda.`,
+			ACCOUNT_MONEY: 'Dinero de la cuenta',
+			ACCOUNT_VAULT: 'Bóveda de cuenta'
+		},
+		COMMAND_VAULT_NOT_ENOUGH_MONEY: money => `Lo siento, ¡pero no tienes suficiente dinero para hacer ese depósito! Su saldo monetario actual es ${money}${SHINY}`,
+		COMMAND_VAULT_NOT_ENOUGH_IN_VAULT: vault => `Lo siento, ¡pero no tienes suficiente almacenado en tu bóveda para hacer esa retirada! Su saldo actual es ${vault}${SHINY}`,
 
 		/**
 		 * ################
@@ -1823,12 +1841,12 @@ export default class extends Language {
 				'200 @kyra'
 			]
 		}),
-		COMMAND_PROFILE_DESCRIPTION: 'Check your user profile.',
+		COMMAND_PROFILE_DESCRIPTION: 'Verifica tu perfil de usuario.',
 		COMMAND_PROFILE_EXTENDED: builder.display('profile', {
-			extendedHelp: `This command sends a card image with some of your user profile such as your global rank, experience...
-				Additionally, you are able to customize your colours with the 'setColor' command.`,
+			extendedHelp: `Este comando envía una imagen de tarjeta con parte de su perfil de usuario, como su rango global, experiencia ...
+				Además, puede personalizar sus colores con el comando 'setColor'.`,
 			explainedUsage: [
-				['user', '(Optional) The user\'s profile to show. Defaults to the message\'s author!.']
+				['user', '(Opcional) El perfil del usuario para mostrar. El valor predeterminado es el autor del mensaje.']
 			]
 		}),
 		COMMAND_REMINDME_DESCRIPTION: 'Manage your reminders.',
@@ -2854,11 +2872,11 @@ export default class extends Language {
 		COMMAND_PAY_SELF: 'If I taxed this, you would lose money, therefore, do not try to pay yourself.',
 		COMMAND_SOCIAL_PAY_BOT: 'Oh, sorry, but money is meaningless for bots, I am pretty sure a human would take advantage of it better.',
 		COMMAND_PROFILE: {
-			GLOBAL_RANK: 'Global Rank',
-			CREDITS: 'Credits',
-			REPUTATION: 'Reputation',
-			EXPERIENCE: 'Experience',
-			LEVEL: 'Level'
+			GLOBAL_RANK: 'Posición Mundial',
+			CREDITS: 'Créditos | Bóveda',
+			REPUTATION: 'Reputación',
+			EXPERIENCE: 'Experiencia',
+			LEVEL: 'Nivel'
 		},
 		COMMAND_REMINDME_INPUT: 'You must tell me what you want me to remind you and when.',
 		COMMAND_REMINDME_INPUT_PROMPT: 'How long should your new reminder last?',

--- a/src/lib/schemas/Users.ts
+++ b/src/lib/schemas/Users.ts
@@ -9,6 +9,7 @@ export default Client.defaultUserSchema
 	.add(UserSettings.Color, 'Integer', { 'default': 0, 'min': 0, 'max': 0xFFFFFF, 'configurable': false })
 	.add(UserSettings.Marry, 'User', { array: true, configurable: false })
 	.add(UserSettings.Money, 'Integer', { 'default': 0, 'min': 0, 'configurable': false })
+	.add(UserSettings.Vault, 'Integer', { 'default': 0, 'min': 0, 'configurable': false })
 	.add(UserSettings.Points, 'Integer', { 'default': 0, 'min': 0, 'configurable': false })
 	.add(UserSettings.Reputation, 'Integer', { 'default': 0, 'min': 0, 'configurable': false })
 	.add(UserSettings.ThemeLevel, 'String', { 'default': '1001', 'configurable': false })

--- a/src/lib/types/Languages.d.ts
+++ b/src/lib/types/Languages.d.ts
@@ -932,6 +932,16 @@ export interface LanguageKeys {
 	COMMAND_TICTACTOE_TURN: (icon: string, player: string, board: string) => string;
 	COMMAND_TICTACTOE_WINNER: (winner: string, board: string) => string;
 	COMMAND_TICTACTOE_DRAW: (board: string) => string;
+	COMMAND_VAULT_DESCRIPTION: string;
+	COMMAND_VAULT_EXTENDED: string;
+	COMMAND_VAULT_EMBED_DATA: {
+		DEPOSITED_DESCRIPTION: (coins: number) => string;
+		WITHDREW_DESCRIPTION: (coins: number) => string;
+		ACCOUNT_MONEY: string;
+		ACCOUNT_VAULT: string;
+	};
+	COMMAND_VAULT_NOT_ENOUGH_MONEY: (money: number) => string;
+	COMMAND_VAULT_NOT_ENOUGH_IN_VAULT: (vault: number) => string;
 	GIVEAWAY_TIME: string;
 	GIVEAWAY_TIME_TOO_LONG: string;
 	GIVEAWAY_ENDS_AT: string;

--- a/src/lib/types/settings/UserSettings.ts
+++ b/src/lib/types/settings/UserSettings.ts
@@ -10,6 +10,7 @@ export namespace UserSettings {
 	export const Color = T<number>('color');
 	export const Marry = T<readonly string[]>('marry');
 	export const Money = T<number>('money');
+	export const Vault = T<number>('vault');
 	export const Points = T<number>('point_count');
 	export const Reputation = T<number>('reputation_count');
 	export const ThemeLevel = T<string>('theme_level');

--- a/src/lib/types/settings/raw/RawUserSettings.ts
+++ b/src/lib/types/settings/raw/RawUserSettings.ts
@@ -7,6 +7,7 @@ export interface RawUserSettings {
 	color: number;
 	marry: string[];
 	money: number;
+	vault: number;
 	point_count: number;
 	reputation_count: number;
 	theme_level: string;
@@ -27,6 +28,7 @@ export const SQL_TABLE_SCHEMA = /* sql */`
 		"color"            INTEGER       DEFAULT 0                   NOT NULL,
 		"marry"            VARCHAR(19)[] DEFAULT '{}'::VARCHAR(19)[] NOT NULL,
 		"money"            BIGINT        DEFAULT 0                   NOT NULL,
+		"vault"            BIGINT        DEFAULT 0                   NOT NULL,
 		"point_count"      INTEGER       DEFAULT 0                   NOT NULL,
 		"reputation_count" INTEGER       DEFAULT 0                   NOT NULL,
 		"theme_level"      VARCHAR(6)    DEFAULT '1001'              NOT NULL,
@@ -39,6 +41,7 @@ export const SQL_TABLE_SCHEMA = /* sql */`
 		CHECK("command_uses" >= 0),
 		CHECK("color" >= 0 AND "color" <= 16777215),
 		CHECK("money" >= 0),
+		CHECK("vault" >= 0),
 		CHECK("point_count" >= 0),
 		CHECK("reputation_count" >= 0),
 		CHECK("next_daily" >= 0),


### PR DESCRIPTION
users can use this command to store shinies safely away in a vault
before they lose them by spending them on gambling.

Reason: Ribbon Migration