### PR TITLE
feat: add emotes command

### DIFF
--- a/src/commands/Tools/emotes.ts
+++ b/src/commands/Tools/emotes.ts
@@ -7,8 +7,6 @@ import { getColor } from '../../lib/util/util';
 
 export default class extends SkyraCommand {
 
-	private kFilter = this.removeNullAndUndefined.bind(this);
-
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
 			cooldown: 10,
@@ -26,8 +24,14 @@ export default class extends SkyraCommand {
 
 		await this.populateCache(message);
 
-		const animEmotes = message.guild!.emojis.map(emote => emote.animated ? `<a:${emote.name}:${emote.id}>` : undefined).filter(this.kFilter);
-		const staticEmotes = message.guild!.emojis.map(emote => emote.animated ? undefined : `<:${emote.name}:${emote.id}>`).filter(this.kFilter);
+		const animEmotes: string[] = [];
+		const staticEmotes: string[] = [];
+
+		for (const [id, emote] of [...message.guild!.emojis.entries()]) {
+			if (emote.animated) animEmotes.push(`<a:${emote.name}:${id}>`);
+			else staticEmotes.push(`<:${emote.name}:${id}>`);
+		}
+
 		const chunkedAnimatedEmojis = this.emotesChunker(animEmotes, 50);
 		const chunkedStaticEmojis = this.emotesChunker(staticEmotes, 50);
 
@@ -46,10 +50,6 @@ export default class extends SkyraCommand {
 		chunkedEmotes.shift();
 
 		return chunkedEmotes;
-	}
-
-	private removeNullAndUndefined<TValue>(value: TValue | null | undefined): value is TValue {
-		return value !== null && value !== undefined;
 	}
 
 	private async populateCache(message: KlasaMessage) {

--- a/src/commands/Tools/emotes.ts
+++ b/src/commands/Tools/emotes.ts
@@ -1,3 +1,4 @@
+import { chunk } from '@klasa/utils';
 import { MessageEmbed } from 'discord.js';
 import { CommandStore, KlasaMessage } from 'klasa';
 import { SkyraCommand } from '../../lib/structures/SkyraCommand';
@@ -22,8 +23,6 @@ export default class extends SkyraCommand {
 			.setDescription(message.language.tget('SYSTEM_LOADING'))
 			.setColor(BrandingColors.Secondary));
 
-		await this.populateCache(message);
-
 		const animEmotes: string[] = [];
 		const staticEmotes: string[] = [];
 
@@ -32,30 +31,10 @@ export default class extends SkyraCommand {
 			else staticEmotes.push(`<:${emote.name}:${id}>`);
 		}
 
-		const chunkedAnimatedEmojis = this.emotesChunker(animEmotes, 50);
-		const chunkedStaticEmojis = this.emotesChunker(staticEmotes, 50);
-
-		const display = this.buildDisplay(message, chunkedAnimatedEmojis, chunkedStaticEmojis);
+		const display = this.buildDisplay(message, chunk(animEmotes, 50), chunk(staticEmotes, 50));
 
 		await display.start(response, message.author.id);
 		return response;
-	}
-
-	private emotesChunker(emotes: string[], size: number): string[][] {
-		const chunkedEmotes: string[][] = [[]];
-
-		do {
-			chunkedEmotes.push(emotes.splice(0, size));
-		} while (emotes.length > 0);
-		chunkedEmotes.shift();
-
-		return chunkedEmotes;
-	}
-
-	private async populateCache(message: KlasaMessage) {
-		if (!message.guild!.emojis.size) {
-			await message.guild!.fetch();
-		}
 	}
 
 	private buildDisplay(message: KlasaMessage, animatedEmojis: string[][], staticEmojis: string[][]) {

--- a/src/commands/Tools/emotes.ts
+++ b/src/commands/Tools/emotes.ts
@@ -1,0 +1,83 @@
+import { MessageEmbed } from 'discord.js';
+import { CommandStore, KlasaMessage } from 'klasa';
+import { SkyraCommand } from '../../lib/structures/SkyraCommand';
+import { UserRichDisplay } from '../../lib/structures/UserRichDisplay';
+import { BrandingColors } from '../../lib/util/constants';
+import { getColor } from '../../lib/util/util';
+
+export default class extends SkyraCommand {
+
+	private kFilter = this.removeNullAndUndefined.bind(this);
+
+	public constructor(store: CommandStore, file: string[], directory: string) {
+		super(store, file, directory, {
+			cooldown: 10,
+			description: language => language.tget('COMMAND_EMOTES_DESCRIPTION'),
+			extendedHelp: language => language.tget('COMMAND_EMOTES_EXTENDED'),
+			requiredPermissions: ['EMBED_LINKS'],
+			runIn: ['text']
+		});
+	}
+
+	public async run(message: KlasaMessage) {
+		const response = await message.sendEmbed(new MessageEmbed()
+			.setDescription(message.language.tget('SYSTEM_LOADING'))
+			.setColor(BrandingColors.Secondary));
+
+		await this.populateCache(message);
+
+		const animEmotes = message.guild!.emojis.map(emote => emote.animated ? `<a:${emote.name}:${emote.id}>` : undefined).filter(this.kFilter);
+		const staticEmotes = message.guild!.emojis.map(emote => emote.animated ? undefined : `<:${emote.name}:${emote.id}>`).filter(this.kFilter);
+		const chunkedAnimatedEmojis = this.emotesChunker(animEmotes, 50);
+		const chunkedStaticEmojis = this.emotesChunker(staticEmotes, 50);
+
+		const display = this.buildDisplay(message, chunkedAnimatedEmojis, chunkedStaticEmojis);
+
+		await display.start(response, message.author.id);
+		return response;
+	}
+
+	private emotesChunker(emotes: string[], size: number): string[][] {
+		const chunkedEmotes: string[][] = [[]];
+
+		do {
+			chunkedEmotes.push(emotes.splice(0, size));
+		} while (emotes.length > 0);
+		chunkedEmotes.shift();
+
+		return chunkedEmotes;
+	}
+
+	private removeNullAndUndefined<TValue>(value: TValue | null | undefined): value is TValue {
+		return value !== null && value !== undefined;
+	}
+
+	private async populateCache(message: KlasaMessage) {
+		if (!message.guild!.emojis.size) {
+			await message.guild!.fetch();
+		}
+	}
+
+	private buildDisplay(message: KlasaMessage, animatedEmojis: string[][], staticEmojis: string[][]) {
+		const display = new UserRichDisplay(new MessageEmbed()
+			.setColor(getColor(message))
+			.setAuthor([
+				`${message.guild!.emojis.size}`,
+				`${message.language.tget('COMMAND_EMOTES_TITLE')}`,
+				`${message.guild!.name}`
+			].join(' '), message.guild!.iconURL({ format: 'png' })!));
+
+		for (const chunk of staticEmojis) {
+			display.addPage((embed: MessageEmbed) => embed
+				.setDescription(chunk.join(' ')));
+		}
+
+		for (const chunk of animatedEmojis) {
+			display.addPage((embed: MessageEmbed) => embed
+				.setDescription(chunk.join(' ')));
+		}
+
+		return display;
+	}
+
+}

--- a/src/commands/Tools/topinvites.ts
+++ b/src/commands/Tools/topinvites.ts
@@ -8,7 +8,7 @@ import { getColor } from '../../lib/util/util';
 export default class extends SkyraCommand {
 
 	private inviteTimestamp = new Timestamp('YYYY/MM/DD HH:mm');
-	private filter: (invite: Invite) => boolean;
+	private kFilterInvites = this.filterInvites.bind(this);
 
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
@@ -19,8 +19,6 @@ export default class extends SkyraCommand {
 			requiredGuildPermissions: ['MANAGE_GUILD'],
 			runIn: ['text']
 		});
-
-		this.filter = this.filterInvites.bind(this);
 	}
 
 	public async run(message: KlasaMessage) {
@@ -30,7 +28,7 @@ export default class extends SkyraCommand {
 
 		const invites = await message.guild!.fetchInvites();
 		const topTen = invites
-			.filter(this.filter)
+			.filter(this.kFilterInvites)
 			.sort((a, b) => b.uses! - a.uses!)
 			.first(10) as NonNullableInvite[];
 

--- a/src/events/readySweeper.ts
+++ b/src/events/readySweeper.ts
@@ -15,7 +15,6 @@ export default class extends Event {
 		const users = this.client.users.size;
 		let presences = 0;
 		let guildMembers = 0;
-		let emojis = 0;
 
 		// Populate the usernames
 		for (const user of this.client.users.values()) {
@@ -37,11 +36,9 @@ export default class extends Event {
 			// Update counters
 			guildMembers += guild.members.size - 1;
 			presences += guild.presences.size;
-			emojis += guild.emojis.size;
 
 			// Clear all members
 			guild.presences.clear();
-			guild.emojis.clear();
 
 			guild.members.clear();
 			if (me) guild.members.set(me.id, me);
@@ -50,8 +47,7 @@ export default class extends Event {
 		this.client.emit(Events.Verbose, `${HEADER} ${
 			this.setColor(presences)} [Presence]s | ${
 			this.setColor(guildMembers)} [GuildMember]s | ${
-			this.setColor(users)} [User]s | ${
-			this.setColor(emojis)} [Emoji]s`);
+			this.setColor(users)} [User]s`);
 	}
 
 	public setColor(n: number) {

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -2032,6 +2032,11 @@ export default class extends Language {
 		COMMAND_CONTENT_EXTENDED: builder.display('content', {}),
 		COMMAND_EMOJI_DESCRIPTION: 'Get info on an emoji.',
 		COMMAND_EMOJI_EXTENDED: builder.display('emoji', {}),
+		COMMAND_EMOTES_DESCRIPTION: 'Shows all custom emotes available on this server',
+		COMMAND_EMOTES_EXTENDED: builder.display('emotes', {
+			extendedHelp: 'The list of emotes is split per 50 emotes'
+		}),
+		COMMAND_EMOTES_TITLE: 'Emotes in',
 		COMMAND_POLL_DESCRIPTION: 'Manage polls.',
 		COMMAND_POLL_EXTENDED: builder.display('poll', {
 			extendedHelp: `The poll command creates a poll and tracks any vote, whilst also offering filters and unique

--- a/src/languages/es-ES.ts
+++ b/src/languages/es-ES.ts
@@ -2006,10 +2006,15 @@ export default class extends Language {
 			],
 			examples: ['#dfdfdf >25', 'rgb(200, 130, 75)']
 		}),
-		COMMAND_CONTENT_DESCRIPTION: 'Get messages\' raw content.',
+		COMMAND_CONTENT_DESCRIPTION: 'Obtener el contenido sin formato de los mensajes.',
 		COMMAND_CONTENT_EXTENDED: builder.display('content', {}),
-		COMMAND_EMOJI_DESCRIPTION: 'Get info on an emoji.',
+		COMMAND_EMOJI_DESCRIPTION: 'Obtén información sobre un emoji.',
 		COMMAND_EMOJI_EXTENDED: builder.display('emoji', {}),
+		COMMAND_EMOTES_DESCRIPTION: 'Muestra todos los gestos personalizados disponibles en este servidor.',
+		COMMAND_EMOTES_EXTENDED: builder.display('emotes', {
+			extendedHelp: 'La lista de emotes se divide por 50 emotes..'
+		}),
+		COMMAND_EMOTES_TITLE: 'Emotes en',
 		COMMAND_POLL_DESCRIPTION: 'Manage polls.',
 		COMMAND_POLL_EXTENDED: builder.display('poll', {
 			extendedHelp: `The poll command creates a poll and tracks any vote, whilst also offering filters and unique

--- a/src/lib/types/Languages.d.ts
+++ b/src/lib/types/Languages.d.ts
@@ -1264,6 +1264,9 @@ export interface LanguageKeys {
 	COMMAND_EMOJI_TWEMOJI: (emoji: string, id: string) => string;
 	COMMAND_EMOJI_INVALID: (emoji: string) => string;
 	COMMAND_EMOJI_TOO_LARGE: (emoji: string) => string;
+	COMMAND_EMOTES_DESCRIPTION: string;
+	COMMAND_EMOTES_EXTENDED: string;
+	COMMAND_EMOTES_TITLE: string;
 	COMMAND_POLL_MISSING_TITLE: string;
 	COMMAND_POLL_TIME: string;
 	COMMAND_POLL_WANT_USERS: string;

--- a/src/tasks/cleanup.ts
+++ b/src/tasks/cleanup.ts
@@ -48,7 +48,6 @@ export default class extends Task {
 		const OLD_SNOWFLAKE = Util.binaryToID(((Date.now() - THRESHOLD) - EPOCH).toString(2).padStart(42, '0') + EMPTY);
 		let presences = 0;
 		let guildMembers = 0;
-		let emojis = 0;
 		let lastMessages = 0;
 		let users = 0;
 
@@ -67,10 +66,6 @@ export default class extends Task {
 				guild.members.delete(id);
 				guildMembers++;
 			}
-
-			// Clear emojis
-			emojis += guild.emojis.size;
-			guild.emojis.clear();
 		}
 
 		// Per-Channel sweeper
@@ -94,7 +89,6 @@ export default class extends Task {
 				this.setColor(presences)} [Presence]s | ${
 				this.setColor(guildMembers)} [GuildMember]s | ${
 				this.setColor(users)} [User]s | ${
-				this.setColor(emojis)} [Emoji]s | ${
 				this.setColor(lastMessages)} [Last Message]s.`);
 	}
 


### PR DESCRIPTION
This command lists the emotes in a server, chunked by every 50 to ensure the maximum size of an embed is not exceeded (shocker but yes I had that happen with Ribbon).

Open question: 2 ways to ensure this works
1. Remove sweeping emojis from Skyra entirely
2. Keep the current implementation inside the command (lines 55-59). Advantage of this is that the cache of emojis will only hold the emojis of the servers that ran this command. 
Current implementation:
https://github.com/kyranet/Skyra/blob/4e39caeb4b11ec2e33a5a8d28ddb235349496813/src/commands/Tools/emotes.ts#L55-L59