### PR TITLE
fix: tag add/edit wont exceeds Discord message length anymore

### DIFF
--- a/src/commands/Tags/tag.ts
+++ b/src/commands/Tags/tag.ts
@@ -28,6 +28,7 @@
 import { CommandStore, KlasaMessage } from 'klasa';
 import { SkyraCommand } from '../../lib/structures/SkyraCommand';
 import { GuildSettings } from '../../lib/types/settings/GuildSettings';
+import { cutText } from '../../lib/util/util';
 
 export default class extends SkyraCommand {
 
@@ -37,11 +38,11 @@ export default class extends SkyraCommand {
 			extendedHelp: language => language.tget('COMMAND_TAG_EXTENDED'),
 			runIn: ['text'],
 			subcommands: true,
-			usage: '<add|remove|edit|source|list|show:default> (tag:string) [content:...string]',
+			usage: '<add|remove|edit|source|list|show:default> (tag:tagname) [content:...string]',
 			usageDelim: ' '
 		});
 
-		this.createCustomResolver('string', (arg, possible, message, [action]) => {
+		this.createCustomResolver('tagname', (arg, possible, message, [action]) => {
 			if (action === 'list') return undefined;
 			if (!arg) throw message.language.tget('RESOLVER_INVALID_STRING', possible.name);
 			if (arg.includes('`') || arg.includes('\u200B')) throw message.language.tget('COMMAND_TAG_NAME_NOTALLOWED');
@@ -60,7 +61,7 @@ export default class extends SkyraCommand {
 		if (tags.some(([name]) => name === tagName)) throw message.language.tget('COMMAND_TAG_EXISTS', tagName);
 		await message.guild!.settings.update(GuildSettings.Tags, [...tags, [tagName, content]], { arrayAction: 'overwrite' });
 
-		return message.sendLocale('COMMAND_TAG_ADDED', [tagName, content]);
+		return message.sendLocale('COMMAND_TAG_ADDED', [tagName, cutText(content, 1850)]);
 	}
 
 	public async remove(message: KlasaMessage, [tagName]: [string]) {
@@ -85,7 +86,7 @@ export default class extends SkyraCommand {
 		if (index === -1) throw message.language.tget('COMMAND_TAG_NOTEXISTS', tagName);
 		await message.guild!.settings.update(GuildSettings.Tags, [[tagName, content]], { arrayIndex: index });
 
-		return message.sendLocale('COMMAND_TAG_EDITED', [tagName, content]);
+		return message.sendLocale('COMMAND_TAG_EDITED', [tagName, cutText(content, 1850)]);
 	}
 
 	public async list(message: KlasaMessage) {

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -1,16 +1,16 @@
 /* eslint-disable @typescript-eslint/unbound-method */
-import { Language, Timestamp, util as klasaUtil, version as klasaVersion } from 'klasa';
+import { codeBlock, toTitleCase } from '@klasa/utils';
+import { MessageEmbed } from 'discord.js';
+import { Language, Timestamp, version as klasaVersion } from 'klasa';
 import { VERSION } from '../../config';
+import { Filter, LanguageKeys, Position } from '../lib/types/Languages';
+import { NotificationsStreamsTwitchEventStatus } from '../lib/types/settings/GuildSettings';
 import { Emojis } from '../lib/util/constants';
 import friendlyDuration from '../lib/util/FriendlyDuration';
 import { HungerGamesUsage } from '../lib/util/Games/HungerGamesUsage';
 import { LanguageHelp } from '../lib/util/LanguageHelp';
 import { createPick, inlineCodeblock } from '../lib/util/util';
-import { LanguageKeys, Position, Filter } from '../lib/types/Languages';
-import { NotificationsStreamsTwitchEventStatus } from '../lib/types/settings/GuildSettings';
-import { MessageEmbed } from 'discord.js';
 
-const { toTitleCase, codeBlock } = klasaUtil;
 const LOADING = Emojis.Loading;
 const SHINY = Emojis.Shiny;
 const GREENTICK = Emojis.GreenTick;
@@ -3153,10 +3153,16 @@ export default class extends Language {
 		COMMAND_TAG_NAME_TOOLONG: 'A tag name must be 50 or less characters long.',
 		COMMAND_TAG_EXISTS: tag => `The tag '${tag}' already exists.`,
 		COMMAND_TAG_CONTENT_REQUIRED: 'You must provide a content for this tag.',
-		COMMAND_TAG_ADDED: (name, content) => `Successfully added a new tag: **${name}** with a content of **${content}**.`,
+		COMMAND_TAG_ADDED: (name, content) => [
+			`Successfully added a new tag: **${name}** with a content of:`,
+			`**${content.endsWith('...') ? `${content} (truncated for Discord message length, full tag has been saved)` : content}**`
+		].join('\n'),
 		COMMAND_TAG_REMOVED: name => `Successfully removed the tag **${name}**.`,
 		COMMAND_TAG_NOTEXISTS: tag => `The tag '${tag}' does not exist.`,
-		COMMAND_TAG_EDITED: (name, content) => `Successfully edited the tag **${name}** with a content of **${content}**.`,
+		COMMAND_TAG_EDITED: (name, content) => [
+			`Successfully edited the tag **${name}** with a content of`,
+			`**${content.endsWith('...') ? `${content} (truncated for Discord message length, full tag has been saved)` : content}**`
+		].join('\n'),
 		COMMAND_TAG_LIST_EMPTY: 'The tag list for this server is empty.',
 		COMMAND_TAG_LIST: tags => `${(tags.length === 1 ? 'There is 1 tag: ' : `There are ${tags.length} tags: `)}${tags.join(', ')}`,
 

--- a/src/languages/es-ES.ts
+++ b/src/languages/es-ES.ts
@@ -1,15 +1,15 @@
 /* eslint-disable @typescript-eslint/unbound-method */
-import { Language, Timestamp, util as klasaUtil, version as klasaVersion } from 'klasa';
+import { codeBlock, toTitleCase } from '@klasa/utils';
+import { MessageEmbed } from 'discord.js';
+import { Language, Timestamp, version as klasaVersion } from 'klasa';
 import { VERSION } from '../../config';
+import { Filter, LanguageKeys, Position } from '../lib/types/Languages';
+import { NotificationsStreamsTwitchEventStatus } from '../lib/types/settings/GuildSettings';
 import { Emojis } from '../lib/util/constants';
 import friendlyDuration from '../lib/util/FriendlyDuration';
 import { LanguageHelp } from '../lib/util/LanguageHelp';
 import { createPick, inlineCodeblock } from '../lib/util/util';
-import { LanguageKeys, Position, Filter } from '../lib/types/Languages';
-import { NotificationsStreamsTwitchEventStatus } from '../lib/types/settings/GuildSettings';
-import { MessageEmbed } from 'discord.js';
 
-const { toTitleCase, codeBlock } = klasaUtil;
 const LOADING = Emojis.Loading;
 const SHINY = Emojis.Shiny;
 const GREENTICK = Emojis.GreenTick;
@@ -3133,17 +3133,23 @@ export default class extends Language {
 		 * TAGS COMMANDS
 		 */
 
-		COMMAND_TAG_PERMISSIONLEVEL: 'You must be a staff member, moderator, or admin, to be able to manage tags.',
-		COMMAND_TAG_NAME_NOTALLOWED: 'A tag name may not have a grave accent nor invisible characters.',
-		COMMAND_TAG_NAME_TOOLONG: 'A tag name must be 50 or less characters long.',
-		COMMAND_TAG_EXISTS: tag => `The tag '${tag}' already exists.`,
-		COMMAND_TAG_CONTENT_REQUIRED: 'You must provide a content for this tag.',
-		COMMAND_TAG_ADDED: (name, content) => `Successfully added a new tag: **${name}** with a content of **${content}**.`,
-		COMMAND_TAG_REMOVED: name => `Successfully removed the tag **${name}**.`,
-		COMMAND_TAG_NOTEXISTS: tag => `The tag '${tag}' does not exist.`,
-		COMMAND_TAG_EDITED: (name, content) => `Successfully edited the tag **${name}** with a content of **${content}**.`,
-		COMMAND_TAG_LIST_EMPTY: 'The tag list for this server is empty.',
-		COMMAND_TAG_LIST: tags => `${(tags.length === 1 ? 'There is 1 tag: ' : `There are ${tags.length} tags: `)}${tags.join(', ')}`,
+		COMMAND_TAG_PERMISSIONLEVEL: 'Debe ser miembro del personal, moderador o administrador para poder administrar las etiquetas.',
+		COMMAND_TAG_NAME_NOTALLOWED: 'Un nombre de etiqueta puede no tener un acento grave ni caracteres invisibles.',
+		COMMAND_TAG_NAME_TOOLONG: 'El nombre de una etiqueta debe tener 50 caracteres o menos.',
+		COMMAND_TAG_EXISTS: tag => `La etiqueta \`${tag}\` ya existe.`,
+		COMMAND_TAG_CONTENT_REQUIRED: 'Debe proporcionar un contenido para esta etiqueta.',
+		COMMAND_TAG_ADDED: (name, content) => [
+			`Se agregó con éxito una nueva etiqueta: **${name}** con un contenido de:`,
+			`**${content.endsWith('...') ? `${content} (truncado para la longitud del mensaje de Discord, se ha guardado la etiqueta completa)` : content}**`
+		].join('\n'),
+		COMMAND_TAG_REMOVED: name => `Se eliminó con éxito la etiqueta **${name}**.`,
+		COMMAND_TAG_NOTEXISTS: tag => `La etiqueta \`${tag}\` no existe.`,
+		COMMAND_TAG_EDITED: (name, content) => [
+			`Se editó correctamente la etiqueta **${name}** con un contenido de:`,
+			`**${content.endsWith('...') ? `${content} (truncado para la longitud del mensaje de Discord, se ha guardado la etiqueta completa)` : content}**`
+		].join('\n'),
+		COMMAND_TAG_LIST_EMPTY: 'La lista de etiquetas para este servidor está vacía.',
+		COMMAND_TAG_LIST: tags => `${(tags.length === 1 ? 'Hay 1 etiqueta:' : `Hay ${tags.length} etiquetas: `)}${tags.join(', ')}`,
 
 		/**
 		 * ##############


### PR DESCRIPTION
I just stumbled on this one while creating a tag of 1933 characters. Now
the text gets truncated to 1850 characters and a message gets added to
inform the users of this as well as that the full tag has been saved. In
case cutText doesn't have to apply its magic then the content gets shown
untruncated and unchanged (aside from a slight formatting change).

I also did some i18n stuff on Spanish for tags and moved codeBlock and
toTitleCase imports from klasaUtils (klasa core) to those from
@klasa/utils since the latter are properly typed and tested