### PR TITLE
refactor: remindme timestamp in 24h format

### DIFF
--- a/src/commands/Social/remindme.ts
+++ b/src/commands/Social/remindme.ts
@@ -5,7 +5,7 @@ import { UserRichDisplay } from '../../lib/structures/UserRichDisplay';
 import { Time, BrandingColors } from '../../lib/util/constants';
 import { cutText, getColor } from '../../lib/util/util';
 
-const timestamp = new Timestamp('YYYY/MM/DD hh:mm:ss');
+const timestamp = new Timestamp('YYYY/MM/DD HH:mm:ss');
 const REMINDER_TYPE = 'reminder';
 
 export default class extends SkyraCommand {


### PR DESCRIPTION
24h format is much cleaner coz we know which of the side of 12 it means.