### PR TITLE
refactor: actually have conf overwrite the commands from klasa core

### DIFF
--- a/src/commands/Admin/conf.ts
+++ b/src/commands/Admin/conf.ts
@@ -12,7 +12,7 @@ export default class extends SkyraCommand {
 
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
-			aliases: ['conf', 'config', 'configs', 'configuration'],
+			aliases: ['settings', 'config', 'configs', 'configuration'],
 			description: language => language.tget('COMMAND_CONF_SERVER_DESCRIPTION'),
 			guarded: true,
 			permissionLevel: PermissionLevels.Administrator,


### PR DESCRIPTION
I feel like this was always the intended purpose but because `conf` was an alias rather than the actual name of the Klasa piece it was not overwriting the core command causing the alias to go completely unused.

Before:

![image](https://user-images.githubusercontent.com/4019718/71696910-a4c6a100-2db6-11ea-89d7-aa4be3c794a4.png)

After:
![image](https://user-images.githubusercontent.com/4019718/71696931-b14af980-2db6-11ea-935d-6952213edc2f.png)

