### PR TITLE
fix: avatar as png when not animated because ios discord is dumb

### DIFF
--- a/src/commands/Tools/avatar.ts
+++ b/src/commands/Tools/avatar.ts
@@ -22,10 +22,12 @@ export default class extends SkyraCommand {
 
 	public async run(message: KlasaMessage, [user]: [KlasaUser]) {
 		if (!user.avatar) throw message.language.tget('COMMAND_AVATAR_NONE');
+
+		const format = user.avatar.startsWith('a_') ? 'gif' : 'png';
 		return message.sendEmbed(new MessageEmbed()
-			.setAuthor(user.tag, user.avatarURL({ size: 128 })!)
+			.setAuthor(user.tag, user.avatarURL({ format, size: 128 })!)
 			.setColor(getColor(message))
-			.setImage(user.avatarURL({ size: 2048 })!));
+			.setImage(user.avatarURL({ format, size: 2048 })!));
 	}
 
 }


### PR DESCRIPTION
Temporary solution until https://github.com/discordjs/discord.js/pull/3530 lands