### PR TITLE
fix(Moderation): Resolved bugs in the moderation events

### DIFF
--- a/src/commands/Moderation/Utilities/reason.ts
+++ b/src/commands/Moderation/Utilities/reason.ts
@@ -29,8 +29,9 @@ export default class extends SkyraCommand {
 		await this.client.queries.updateModerationLogReasonBulk(message.guild!.id, entries.map(ml => ml.case!), reason);
 		await message.guild!.moderation.fetchChannelMessages();
 		for (const entry of entries.values()) {
+			const clone = entry.clone();
 			entry.setReason(reason);
-			this.client.emit(Events.ModerationEntryEdit, entry);
+			this.client.emit(Events.ModerationEntryEdit, clone, entry);
 		}
 
 		return message.alert(message.language.tget('COMMAND_REASON_UPDATED', cases, reason));

--- a/src/tasks/moderationEndBan.ts
+++ b/src/tasks/moderationEndBan.ts
@@ -8,6 +8,7 @@ export default class extends ModerationTask {
 		const me = guild.me === null ? await guild.members.fetch(CLIENT_ID) : guild.me;
 		if (!me.permissions.has(Permissions.FLAGS.BAN_MEMBERS)) return null;
 		await guild.security.actions.unBan({
+			moderator_id: CLIENT_ID,
 			user_id: data.userID,
 			reason: `[MODERATION] Ban released after ${this.client.languages.default.duration(data.duration)}`
 		}, this.getTargetDM(guild, await this.client.users.fetch(data.userID)));

--- a/src/tasks/moderationEndMute.ts
+++ b/src/tasks/moderationEndMute.ts
@@ -1,10 +1,12 @@
 import { ModerationData, ModerationTask } from '@lib/structures/ModerationTask';
 import { Guild } from 'discord.js';
+import { CLIENT_ID } from '@root/config';
 
 export default class extends ModerationTask {
 
 	protected async handle(guild: Guild, data: ModerationData) {
 		await guild.security.actions.unMute({
+			moderator_id: CLIENT_ID,
 			user_id: data.userID,
 			reason: `[MODERATION] Mute released after ${this.client.languages.default.duration(data.duration)}`
 		}, this.getTargetDM(guild, await this.client.users.fetch(data.userID)));

--- a/src/tasks/moderationEndRestrictionAttachment.ts
+++ b/src/tasks/moderationEndRestrictionAttachment.ts
@@ -8,6 +8,7 @@ export default class extends ModerationTask {
 		const me = guild.me === null ? await guild.members.fetch(CLIENT_ID) : guild.me;
 		if (!me.permissions.has(Permissions.FLAGS.MANAGE_ROLES)) return null;
 		await guild.security.actions.unRestrictAttachment({
+			moderator_id: CLIENT_ID,
 			user_id: data.userID,
 			reason: `[MODERATION] Attachment Restricted released after ${this.client.languages.default.duration(data.duration)}`
 		}, this.getTargetDM(guild, await this.client.users.fetch(data.userID)));

--- a/src/tasks/moderationEndRestrictionEmbed.ts
+++ b/src/tasks/moderationEndRestrictionEmbed.ts
@@ -8,6 +8,7 @@ export default class extends ModerationTask {
 		const me = guild.me === null ? await guild.members.fetch(CLIENT_ID) : guild.me;
 		if (!me.permissions.has(Permissions.FLAGS.MANAGE_ROLES)) return null;
 		await guild.security.actions.unRestrictEmbed({
+			moderator_id: CLIENT_ID,
 			user_id: data.userID,
 			reason: `[MODERATION] Embed Restricted released after ${this.client.languages.default.duration(data.duration)}`
 		}, this.getTargetDM(guild, await this.client.users.fetch(data.userID)));

--- a/src/tasks/moderationEndRestrictionReaction.ts
+++ b/src/tasks/moderationEndRestrictionReaction.ts
@@ -8,6 +8,7 @@ export default class extends ModerationTask {
 		const me = guild.me === null ? await guild.members.fetch(CLIENT_ID) : guild.me;
 		if (!me.permissions.has(Permissions.FLAGS.MANAGE_ROLES)) return null;
 		await guild.security.actions.unRestrictReaction({
+			moderator_id: CLIENT_ID,
 			user_id: data.userID,
 			reason: `[MODERATION] Reaction Restricted released after ${this.client.languages.default.duration(data.duration)}`
 		}, this.getTargetDM(guild, await this.client.users.fetch(data.userID)));

--- a/src/tasks/moderationEndRestrictionVoice.ts
+++ b/src/tasks/moderationEndRestrictionVoice.ts
@@ -8,6 +8,7 @@ export default class extends ModerationTask {
 		const me = guild.me === null ? await guild.members.fetch(CLIENT_ID) : guild.me;
 		if (!me.permissions.has(Permissions.FLAGS.MANAGE_ROLES)) return null;
 		await guild.security.actions.unRestrictVoice({
+			moderator_id: CLIENT_ID,
 			user_id: data.userID,
 			reason: `[MODERATION] Voice Restricted released after ${this.client.languages.default.duration(data.duration)}`
 		}, this.getTargetDM(guild, await this.client.users.fetch(data.userID)));

--- a/src/tasks/moderationEndVoiceMute.ts
+++ b/src/tasks/moderationEndVoiceMute.ts
@@ -8,6 +8,7 @@ export default class extends ModerationTask {
 		const me = guild.me === null ? await guild.members.fetch(CLIENT_ID) : guild.me;
 		if (!me.permissions.has(Permissions.FLAGS.MUTE_MEMBERS)) return null;
 		await guild.security.actions.unVoiceMute({
+			moderator_id: CLIENT_ID,
 			user_id: data.userID,
 			reason: `[MODERATION] Voice Mute released after ${this.client.languages.default.duration(data.duration)}`
 		}, this.getTargetDM(guild, await this.client.users.fetch(data.userID)));

--- a/src/tasks/moderationEndWarning.ts
+++ b/src/tasks/moderationEndWarning.ts
@@ -8,6 +8,7 @@ export default class extends ModerationTask {
 		const me = guild.me === null ? await guild.members.fetch(CLIENT_ID) : guild.me;
 		if (!me.permissions.has(Permissions.FLAGS.BAN_MEMBERS)) return null;
 		await guild.security.actions.unWarning({
+			moderator_id: CLIENT_ID,
 			user_id: data.userID,
 			reason: `[MODERATION] Warning released after ${this.client.languages.default.duration(data.duration)}`
 		}, data.caseID, this.getTargetDM(guild, await this.client.users.fetch(data.userID)));


### PR DESCRIPTION
- Fixes moderation logs having their message edited when invalidated (mute-unmute)
- Fixes error from Schedule for deleting the ScheduledTask from the `moderationEntryEdit` event due to the lack of the defensive code (the task sets invalidated, then fires this event, which only changes the bitwise, checking if the previous and new duration are the same, then skipping, fixes this error).
- Fixes issue with short moderation logs not sending a message (`Fast*` moderation logs will have a better mechanism to determine them).