### PR TITLE
fix(giveaway): fixed duration and scheduling

### DIFF
--- a/src/commands/Giveaway/gcreate.ts
+++ b/src/commands/Giveaway/gcreate.ts
@@ -13,33 +13,37 @@ export default class extends SkyraCommand {
 			extendedHelp: language => language.tget('COMMAND_GIVEAWAYSCHEDULE_EXTENDED'),
 			requiredPermissions: ['EMBED_LINKS', 'ADD_REACTIONS', 'READ_MESSAGE_HISTORY'],
 			runIn: ['text'],
-			usage: '<schedule:time> <duration:timespan> <title:...string{,256}>',
+			usage: '<schedule:time> <duration:time> <title:...string{,256}>',
+			flagSupport: true,
 			usageDelim: ' ',
 			promptLimit: Infinity
 		});
 	}
 
-	public async run(message: KlasaMessage, [schedule, duration, title]: [Date, number, string]) {
+	public async run(message: KlasaMessage, [schedule, duration, title]: [Date, Date, string]) {
 		// First do the checks for the giveaway itself
 		const scheduleOffset = schedule.getTime() - Date.now();
+		const durationOffset = duration.getTime() - Date.now();
 
-		if (duration < 9500 || scheduleOffset < 9500) throw message.language.tget('GIVEAWAY_TIME');
-		if (duration > YEAR || scheduleOffset > YEAR) throw message.language.tget('GIVEAWAY_TIME_TOO_LONG');
+		if (durationOffset < 9500 || scheduleOffset < 9500) throw message.language.tget('GIVEAWAY_TIME');
+		if (durationOffset > YEAR || scheduleOffset > YEAR) throw message.language.tget('GIVEAWAY_TIME_TOO_LONG');
 
+		// Resolve the amount of winners the giveaway will have
+		const winners = Number(message.flagArgs.winners) ? parseInt(message.flagArgs.winners, 10) : 1;
 		// This creates an single time task to start the giveaway
 		await this.client.schedule.create('giveaway', schedule.getTime(), {
 			data: {
-				channelID: message.channel.id,
-				endsAt: duration,
-				guildID: message.guild!.id,
+				channel_id: message.channel.id,
+				ends_at: duration.getTime() + scheduleOffset + 500,
+				guild_id: message.guild!.id,
 				minimum: 1,
-				minimumWinners: 1,
+				minimum_winners: winners,
 				title: cleanMentions(message.guild!, title)
 			},
 			catchUp: true
 		});
 
-		return message.sendLocale('GIVEAWAY_SCHEDULED', [schedule, duration, title]);
+		return message.sendLocale('GIVEAWAY_SCHEDULED', [scheduleOffset]);
 	}
 
 }

--- a/src/commands/Giveaway/gstart.ts
+++ b/src/commands/Giveaway/gstart.ts
@@ -14,6 +14,7 @@ export default class extends SkyraCommand {
 			requiredPermissions: ['EMBED_LINKS', 'ADD_REACTIONS', 'READ_MESSAGE_HISTORY'],
 			runIn: ['text'],
 			usage: '<time:time> <title:...string{,256}>',
+			flagSupport: true,
 			usageDelim: ' '
 		});
 	}
@@ -23,12 +24,14 @@ export default class extends SkyraCommand {
 
 		if (offset < 9500) throw message.language.tget('GIVEAWAY_TIME');
 		if (offset > YEAR) throw message.language.tget('GIVEAWAY_TIME_TOO_LONG');
+
+		const winners = Number(message.flagArgs.winners) ? parseInt(message.flagArgs.winners, 10) : 1;
 		await this.client.giveaways.create({
 			channel_id: message.channel.id,
 			ends_at: time.getTime() + 500,
 			guild_id: message.guild!.id,
 			minimum: 1,
-			minimum_winners: 1,
+			minimum_winners: winners,
 			title: cleanMentions(message.guild!, title)
 		});
 	}

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -801,7 +801,8 @@ export default class extends Language {
 					time and a title. When a giveaway has been created, Skyra will send a giveaway message and react to it with 🎉
 					so the members of the server can participate on it. Once the timer ends, Skyra will retrieve all the users who
 					reacted and send the owner of the giveaway a message in direct messages with the winner, and other 10 possible
-					winners (in case of needing to re-roll).`,
+					winners (in case of needing to re-roll).
+					You can also pass a flag of \`--winners=X\`, wherein X is a numbe, to allow multiple people to win this giveaway.`,
 			explainedUsage: [
 				['time', 'The time the giveaway should last.'],
 				['title', 'The title of the giveaway.']
@@ -820,7 +821,10 @@ export default class extends Language {
 		}),
 		COMMAND_GIVEAWAYSCHEDULE_DESCRIPTION: `Schedule a giveaway to start at a certain time.`,
 		COMMAND_GIVEAWAYSCHEDULE_EXTENDED: builder.display('gcreate', {
-			extendedHelp: `This command prepares a giveaway to start at a certain time if you do not wish to start it immediately.`,
+			extendedHelp: `
+				This command prepares a giveaway to start at a certain time if you do not wish to start it immediately.
+				You can also pass a flag of \`--winners=X\`, wherein X is a numbe, to allow multiple people to win this giveaway.
+			`,
 			explainedUsage: [
 				['schedule', 'The time to wait before starting the giveaway.'],
 				['time', 'The time the giveaway should last.'],

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -802,7 +802,7 @@ export default class extends Language {
 					so the members of the server can participate on it. Once the timer ends, Skyra will retrieve all the users who
 					reacted and send the owner of the giveaway a message in direct messages with the winner, and other 10 possible
 					winners (in case of needing to re-roll).
-					You can also pass a flag of \`--winners=X\`, wherein X is a numbe, to allow multiple people to win this giveaway.`,
+					You can also pass a flag of \`--winners=X\`, wherein X is a number, to allow multiple people to win this giveaway.`,
 			explainedUsage: [
 				['time', 'The time the giveaway should last.'],
 				['title', 'The title of the giveaway.']
@@ -823,7 +823,7 @@ export default class extends Language {
 		COMMAND_GIVEAWAYSCHEDULE_EXTENDED: builder.display('gcreate', {
 			extendedHelp: `
 				This command prepares a giveaway to start at a certain time if you do not wish to start it immediately.
-				You can also pass a flag of \`--winners=X\`, wherein X is a numbe, to allow multiple people to win this giveaway.
+				You can also pass a flag of \`--winners=X\`, wherein X is a number, to allow multiple people to win this giveaway..
 			`,
 			explainedUsage: [
 				['schedule', 'The time to wait before starting the giveaway.'],

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -2794,7 +2794,7 @@ export default class extends Language {
 		GIVEAWAY_ENDED_TITLE: '🎉 **GIVEAWAY ENDED** 🎉',
 		GIVEAWAY_ENDED_MESSAGE: (winners, title) => `Congratulations ${winners.join(' ')}! You won the giveaway **${title}**`,
 		GIVEAWAY_ENDED_MESSAGE_NO_WINNER: title => `The giveaway **${title}** ended without enough participants.`,
-		GIVEAWAY_SCHEDULED: time => `The giveaway will start at ${time}.`,
+		GIVEAWAY_SCHEDULED: scheduledTime => `The giveaway will start in ${duration(scheduledTime)}.`,
 
 		/**
 		 * ###################

--- a/src/languages/es-ES.ts
+++ b/src/languages/es-ES.ts
@@ -2769,6 +2769,7 @@ export default class extends Language {
 		GIVEAWAY_ENDED_AT: 'Ended at:',
 		GIVEAWAY_ENDED_TITLE: '🎉 **GIVEAWAY ENDED** 🎉',
 		GIVEAWAY_ENDED_MESSAGE: (mention, title) => `Congratulations ${mention}! You won the giveaway **${title}**`,
+		GIVEAWAY_SCHEDULED: scheduledTime => `El sorteo comenzará en ${duration(scheduledTime)}.`,
 		GIVEAWAY_ENDED_MESSAGE_NO_WINNER: title => `The giveaway **${title}** ended without enough participants.`,
 
 		/**

--- a/src/languages/es-ES.ts
+++ b/src/languages/es-ES.ts
@@ -800,7 +800,8 @@ export default class extends Language {
 					time and a title. When a giveaway has been created, Skyra will send a giveaway message and react to it with 🎉
 					so the members of the server can participate on it. Once the timer ends, Skyra will retrieve all the users who
 					reacted and send the owner of the giveaway a message in direct messages with the winner, and other 10 possible
-					winners (in case of needing to re-roll).`,
+					winners (in case of needing to re-roll).
+					También puede pasar una bandera de \`--winners=X\`, donde X es un número, para permitir que varias personas ganen este sorteo.`,
 			explainedUsage: [
 				['time', 'The time the giveaway should last.'],
 				['title', 'The title of the giveaway.']
@@ -819,7 +820,10 @@ export default class extends Language {
 		}),
 		COMMAND_GIVEAWAYSCHEDULE_DESCRIPTION: `Schedule a giveaway to start at a certain time.`,
 		COMMAND_GIVEAWAYSCHEDULE_EXTENDED: builder.display('gcreate', {
-			extendedHelp: `This command prepares a giveaway to start at a certain time if you do not wish to start it immediately.`,
+			extendedHelp: `
+				This command prepares a giveaway to start at a certain time if you do not wish to start it immediately.
+				También puede pasar una bandera de \`--winners=X\`, donde X es un número, para permitir que varias personas ganen este sorteo.
+			`,
 			explainedUsage: [
 				['schedule', 'The time to wait before starting the giveaway.'],
 				['time', 'The time the giveaway should last.'],

--- a/src/languages/es-ES.ts
+++ b/src/languages/es-ES.ts
@@ -801,7 +801,7 @@ export default class extends Language {
 					so the members of the server can participate on it. Once the timer ends, Skyra will retrieve all the users who
 					reacted and send the owner of the giveaway a message in direct messages with the winner, and other 10 possible
 					winners (in case of needing to re-roll).
-					También puede pasar una bandera de \`--winners=X\`, donde X es un número, para permitir que varias personas ganen este sorteo.`,
+					También puede pasar una bandera de \`--winners=X\`, en la que X es un número, para permitir que varias personas ganen este sorteo.`,
 			explainedUsage: [
 				['time', 'The time the giveaway should last.'],
 				['title', 'The title of the giveaway.']
@@ -822,7 +822,7 @@ export default class extends Language {
 		COMMAND_GIVEAWAYSCHEDULE_EXTENDED: builder.display('gcreate', {
 			extendedHelp: `
 				This command prepares a giveaway to start at a certain time if you do not wish to start it immediately.
-				También puede pasar una bandera de \`--winners=X\`, donde X es un número, para permitir que varias personas ganen este sorteo.
+				También puede pasar una bandera de \`--winners=X\`, en la que X es un número, para permitir que varias personas ganen este sorteo.
 			`,
 			explainedUsage: [
 				['schedule', 'The time to wait before starting the giveaway.'],

--- a/src/lib/types/Languages.d.ts
+++ b/src/lib/types/Languages.d.ts
@@ -1154,7 +1154,7 @@ export interface LanguageKeys {
 	GIVEAWAY_ENDED_TITLE: string;
 	GIVEAWAY_ENDED_MESSAGE: (winners: readonly string[], title: string) => string;
 	GIVEAWAY_ENDED_MESSAGE_NO_WINNER: (title: string) => string;
-	GIVEAWAY_SCHEDULED: (time: string) => string;
+	GIVEAWAY_SCHEDULED: (scheduledTime: number) => string;
 	COMMAND_NICK_SET: (nickname: string) => string;
 	COMMAND_NICK_CLEARED: string;
 	COMMAND_PERMISSIONNODES_HIGHER: string;


### PR DESCRIPTION
Also added the option to assign multiple winners for 1 giveaway through the `--winners` message flag, which I considered to be the least breaking way for people who are used to the command in the form that it is now.

All in all:

- Fixed gcreate which was crashing altogether, even on VPS
  - Because it was passing the wrong data, camelCased instead of snake_cased. Blame schedule create not being strongly typed *sigh*
- Made gcreate first reply message use duration so it's not a raw `Date.toString()`, 
  - Fixed the language key belonging to it
  - Added it to spanish
- Added option for `--winners` to `gcreate` and `gstart`