### PR TITLE
build: ignore more output files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ bwd/
 
 # Ignore JavaScript files
 **/*.js
+**/*.js.map
+**/*.d.ts
+**/*.tsbuildinfo
 !jest.config.js
 
 # Ignore the config file (contains sensitive information such as tokens)


### PR DESCRIPTION
Just in case people (~~enkiel~~) run `yarn tsc` instead of `yarn build` and it doesn't use the build targets.