### PR TITLE
fix: role-reaction messageid length issue fixed

### DIFF
--- a/src/commands/Management/Configuration/setRoleMessage.ts
+++ b/src/commands/Management/Configuration/setRoleMessage.ts
@@ -1,7 +1,9 @@
 import { SkyraCommand } from '@lib/structures/SkyraCommand';
 import { PermissionLevels } from '@lib/types/Enums';
 import { GuildSettings } from '@lib/types/settings/GuildSettings';
-import { CommandStore, KlasaMessage, Serializer } from 'klasa';
+import { CommandStore, KlasaMessage } from 'klasa';
+import { Serializer } from '@klasa/settings-gateway';
+
 const SNOWFLAKE_REGEXP = Serializer.regex.snowflake;
 
 export default class extends SkyraCommand {

--- a/src/lib/schemas/Guilds.ts
+++ b/src/lib/schemas/Guilds.ts
@@ -48,7 +48,7 @@ export default Client.defaultGuildSchema
 		.add('admin', 'Role')
 		.add('auto', 'any', { array: true })
 		.add('initial', 'Role')
-		.add('messageReaction', 'String', { minimum: 17, maximum: 18, configurable: false })
+		.add('messageReaction', 'String', { minimum: 17, maximum: 19, configurable: false })
 		.add('moderator', 'Role')
 		.add('muted', 'Role')
 		.add('restricted-reaction', 'Role')


### PR DESCRIPTION
So apparently it wasn't the regex, it wasn't the argument resolver, no it was the settings gateway that was  throwing the error. Why? Because "between 17 and 18 ***exclusively***" means that the boundaries of 17 and 18 are excluded. DOH!! 

The reason I couldn't find the error message was because I was looking in our `en-US` and even the one from `klasa` core but NOT the error messages from `@klasa/settings-gateway`. 

Fixes #832