### PR TITLE
fix: fortnite command property access

### DIFF
--- a/src/commands/GameIntegration/fortnite.ts
+++ b/src/commands/GameIntegration/fortnite.ts
@@ -50,75 +50,82 @@ export default class extends SkyraCommand {
 		}
 	}
 
-	private buildDisplay(message: KlasaMessage, user: Fortnite.FortniteUser) {
+	private buildDisplay(message: KlasaMessage, { lifeTimeStats, epicUserHandle, platformName, stats: { p2, p10, p9 } }: Fortnite.FortniteUser) {
 		const TITLES = message.language.tget('COMMAND_FORTNITE_TITLES');
 
 		const display = new UserRichDisplay(
 			new MessageEmbed()
-				.setTitle(TITLES.TITLE(user.epicUserHandle))
-				.setURL(encodeURI(`https://fortnitetracker.com/profile/${user.platformName}/${user.epicUserHandle}`))
+				.setTitle(TITLES.TITLE(epicUserHandle))
+				.setURL(encodeURI(`https://fortnitetracker.com/profile/${platformName}/${epicUserHandle}`))
 				.setColor(getColor(message))
 		);
+		const lts = lifeTimeStats.map(stat => ({ ...stat, key: stat.key.toLowerCase() }));
 
 		display.addPage((embed: MessageEmbed) => embed
 			.setDescription([
 				TITLES.LIFETIME_STATS,
-				TITLES.WINS(user.lifeTimeStats.find(el => el.key.toLowerCase() === 'wins')!.value),
-				TITLES.KILLS(user.lifeTimeStats.find(el => el.key.toLowerCase() === 'kills')!.value),
-				TITLES.KDR(user.lifeTimeStats.find(el => el.key.toLowerCase() === 'k/d')!.value),
-				TITLES.MATCHES_PLAYED(user.lifeTimeStats.find(el => el.key.toLowerCase() === 'matches played')!.value),
-				TITLES.TOP_3S(user.lifeTimeStats.find(el => el.key.toLowerCase() === 'top 3s')!.value),
-				TITLES.TOP_5S(user.lifeTimeStats.find(el => el.key.toLowerCase() === 'top 5s')!.value),
-				TITLES.TOP_6S(user.lifeTimeStats.find(el => el.key.toLowerCase() === 'top 6s')!.value),
-				TITLES.TOP_10S(user.lifeTimeStats.find(el => el.key.toLowerCase() === 'top 10')!.value),
-				TITLES.TOP_12S(user.lifeTimeStats.find(el => el.key.toLowerCase() === 'top 12s')!.value),
-				TITLES.TOP_25S(user.lifeTimeStats.find(el => el.key.toLowerCase() === 'top 25s')!.value)
+				TITLES.WINS(lts.find(el => el.key === 'wins')!.value),
+				TITLES.KILLS(lts.find(el => el.key === 'kills')!.value),
+				TITLES.KDR(lts.find(el => el.key === 'k/d')!.value),
+				TITLES.MATCHES_PLAYED(lts.find(el => el.key === 'matches played')!.value),
+				TITLES.TOP_3S(lts.find(el => el.key === 'top 3s')!.value),
+				TITLES.TOP_5S(lts.find(el => el.key === 'top 5s')!.value),
+				TITLES.TOP_6S(lts.find(el => el.key === 'top 6s')!.value),
+				TITLES.TOP_10S(lts.find(el => el.key === 'top 10')!.value),
+				TITLES.TOP_12S(lts.find(el => el.key === 'top 12s')!.value),
+				TITLES.TOP_25S(lts.find(el => el.key === 'top 25s')!.value)
 			].join('\n')))
 			.addPage((embed: MessageEmbed) => embed
 				.setDescription([
 					TITLES.SOLOS,
-					TITLES.WINS(user.stats.p2.top1.value),
-					TITLES.KILLS(user.stats.p2.kills.value),
-					TITLES.KDR(user.stats.p2.kd.value),
-					TITLES.MATCHES_PLAYED(user.stats.p2.matches.value),
-					TITLES.TOP_1S(user.stats.p2.top1.value),
-					TITLES.TOP_3S(user.stats.p2.top3.value),
-					TITLES.TOP_5S(user.stats.p2.top5.value),
-					TITLES.TOP_6S(user.stats.p2.top6.value),
-					TITLES.TOP_10S(user.stats.p2.top10.value),
-					TITLES.TOP_12S(user.stats.p2.top12.value),
-					TITLES.TOP_25S(user.stats.p2.top25.value)
-				].join('\n')))
-			.addPage((embed: MessageEmbed) => embed
+					TITLES.WINS(p2.top1.value),
+					TITLES.KILLS(p2.kills.value),
+					TITLES.KDR(p2.kd.value),
+					TITLES.MATCHES_PLAYED(p2.matches.value),
+					TITLES.TOP_1S(p2.top1.value),
+					TITLES.TOP_3S(p2.top3.value),
+					TITLES.TOP_5S(p2.top5.value),
+					TITLES.TOP_6S(p2.top6.value),
+					TITLES.TOP_10S(p2.top10.value),
+					TITLES.TOP_12S(p2.top12.value),
+					TITLES.TOP_25S(p2.top25.value)
+				].join('\n')));
+
+		if (p10) {
+			display.addPage((embed: MessageEmbed) => embed
 				.setDescription([
 					TITLES.DUOS,
-					TITLES.WINS(user.stats.p10.top1.value),
-					TITLES.KILLS(user.stats.p10.kills.value),
-					TITLES.KDR(user.stats.p10.kd.value),
-					TITLES.MATCHES_PLAYED(user.stats.p10.matches.value),
-					TITLES.TOP_1S(user.stats.p10.top1.value),
-					TITLES.TOP_3S(user.stats.p10.top3.value),
-					TITLES.TOP_5S(user.stats.p10.top5.value),
-					TITLES.TOP_6S(user.stats.p10.top6.value),
-					TITLES.TOP_10S(user.stats.p10.top10.value),
-					TITLES.TOP_12S(user.stats.p10.top12.value),
-					TITLES.TOP_25S(user.stats.p10.top25.value)
-				].join('\n')))
-			.addPage((embed: MessageEmbed) => embed
+					TITLES.WINS(p10.top1.value),
+					TITLES.KILLS(p10.kills.value),
+					TITLES.KDR(p10.kd.value),
+					TITLES.MATCHES_PLAYED(p10.matches.value),
+					TITLES.TOP_1S(p10.top1.value),
+					TITLES.TOP_3S(p10.top3.value),
+					TITLES.TOP_5S(p10.top5.value),
+					TITLES.TOP_6S(p10.top6.value),
+					TITLES.TOP_10S(p10.top10.value),
+					TITLES.TOP_12S(p10.top12.value),
+					TITLES.TOP_25S(p10.top25.value)
+				].join('\n')));
+		}
+
+		if (p9) {
+			display.addPage((embed: MessageEmbed) => embed
 				.setDescription([
 					TITLES.SQUADS,
-					TITLES.WINS(user.stats.p9.top1.value),
-					TITLES.KILLS(user.stats.p9.kills.value),
-					TITLES.KDR(user.stats.p9.kd.value),
-					TITLES.MATCHES_PLAYED(user.stats.p9.matches.value),
-					TITLES.TOP_1S(user.stats.p9.top1.value),
-					TITLES.TOP_3S(user.stats.p9.top3.value),
-					TITLES.TOP_5S(user.stats.p9.top5.value),
-					TITLES.TOP_6S(user.stats.p9.top6.value),
-					TITLES.TOP_10S(user.stats.p9.top10.value),
-					TITLES.TOP_12S(user.stats.p9.top12.value),
-					TITLES.TOP_25S(user.stats.p9.top25.value)
+					TITLES.WINS(p9.top1.value),
+					TITLES.KILLS(p9.kills.value),
+					TITLES.KDR(p9.kd.value),
+					TITLES.MATCHES_PLAYED(p9.matches.value),
+					TITLES.TOP_1S(p9.top1.value),
+					TITLES.TOP_3S(p9.top3.value),
+					TITLES.TOP_5S(p9.top5.value),
+					TITLES.TOP_6S(p9.top6.value),
+					TITLES.TOP_10S(p9.top10.value),
+					TITLES.TOP_12S(p9.top12.value),
+					TITLES.TOP_25S(p9.top25.value)
 				].join('\n')));
+		}
 
 		return display;
 	}

--- a/src/lib/util/GameIntegration/Fortnite.d.ts
+++ b/src/lib/util/GameIntegration/Fortnite.d.ts
@@ -1267,8 +1267,8 @@ export namespace Fortnite {
 
 	export interface Stats {
 		p2: P2;
-		p10: P10;
-		p9: P9;
+		p10?: P10;
+		p9?: P9;
 		curr_p2: CurrP2;
 		curr_p10: CurrP10;
 		curr_p9: CurrP9;


### PR DESCRIPTION
I guess I should've seen this coming because I did have them if-wrapped in Ribbon as well. I did some refactoring while I was at it as well to make the code a bit cleaner. Also with the destructured way of getting the params in buildDisplay allowed me to properly set the p10 and p9 as potentially undefined, otherwise TS was complaining that "user.stats.p10" is potentially undefined despite being in an if-statement that checked that same property... -_-"


fixes #835