### PR TITLE
src: Escape message content in content command

### DIFF
--- a/src/commands/Tools/content.ts
+++ b/src/commands/Tools/content.ts
@@ -1,6 +1,6 @@
 import { SkyraCommand } from '@lib/structures/SkyraCommand';
 import { getContent } from '@utils/util';
-import { TextChannel } from 'discord.js';
+import { TextChannel, Util } from 'discord.js';
 import { CommandStore, KlasaMessage, Serializer } from 'klasa';
 const SNOWFLAKE_REGEXP = Serializer.regex.snowflake;
 
@@ -29,8 +29,8 @@ export default class extends SkyraCommand {
 		const attachments = target.attachments.size
 			? target.attachments.map(att => `📁 <${att.url}>`).join('\n')
 			: '';
-		const content = getContent(target);
-		return message.sendMessage(`${content || ''}${content && attachments ? `\n\n\n=============\n${attachments}` : attachments}`, { code: 'md' });
+		const content = Util.escapeMarkdown(getContent(target) || '');
+		return message.sendMessage(`${content}${content && attachments ? `\n\n\n=============\n${attachments}` : attachments}`, { code: 'md' });
 	}
 
 }

--- a/src/commands/Tools/content.ts
+++ b/src/commands/Tools/content.ts
@@ -29,7 +29,7 @@ export default class extends SkyraCommand {
 		const attachments = target.attachments.size
 			? target.attachments.map(att => `📁 <${att.url}>`).join('\n')
 			: '';
-		const content = Util.escapeMarkdown(getContent(target) || '');
+		const content = Util.escapeCodeBlock(getContent(target) || '');
 		return message.sendMessage(`${content}${content && attachments ? `\n\n\n=============\n${attachments}` : attachments}`, { code: 'md' });
 	}
 


### PR DESCRIPTION
Just a minor thing. Prevents things like these:
![image](https://user-images.githubusercontent.com/17960496/75120026-b62e7a00-5690-11ea-8aa6-7c1d6d513362.png)
