### PR TITLE
Fix embed permission error

### DIFF
--- a/src/commands/Announcement/announcement.ts
+++ b/src/commands/Announcement/announcement.ts
@@ -19,6 +19,7 @@ export default class extends SkyraCommand {
 			extendedHelp: language => language.tget('COMMAND_ANNOUNCEMENT_EXTENDED'),
 			permissionLevel: PermissionLevels.Administrator,
 			requiredGuildPermissions: ['MANAGE_ROLES'],
+			requiredPermissions: ['EMBED_LINKS'],
 			runIn: ['text'],
 			usage: '<announcement:string{,1900}>'
 		});

--- a/src/commands/Announcement/announcement.ts
+++ b/src/commands/Announcement/announcement.ts
@@ -19,7 +19,7 @@ export default class extends SkyraCommand {
 			extendedHelp: language => language.tget('COMMAND_ANNOUNCEMENT_EXTENDED'),
 			permissionLevel: PermissionLevels.Administrator,
 			requiredGuildPermissions: ['MANAGE_ROLES'],
-			requiredPermissions: ['EMBED_LINKS'],
+			requiredPermissions: ['ADD_REACTIONS', 'MANAGE_MESSAGES', 'EMBED_LINKS'],
 			runIn: ['text'],
 			usage: '<announcement:string{,1900}>'
 		});

--- a/src/commands/Management/roles.ts
+++ b/src/commands/Management/roles.ts
@@ -15,8 +15,8 @@ export default class extends SkyraCommand {
 			cooldown: 5,
 			description: language => language.tget('COMMAND_ROLES_DESCRIPTION'),
 			extendedHelp: language => language.tget('COMMAND_ROLES_EXTENDED'),
-			requiredPermissions: ['MANAGE_MESSAGES'],
 			requiredGuildPermissions: ['MANAGE_ROLES'],
+			requiredPermissions: ['MANAGE_MESSAGES', 'EMBED_LINKS'],
 			runIn: ['text'],
 			usage: '(roles:rolenames)'
 		});

--- a/src/commands/Management/triggers.ts
+++ b/src/commands/Management/triggers.ts
@@ -16,7 +16,7 @@ export default class extends SkyraCommand {
 			description: language => language.tget('COMMAND_TRIGGERS_DESCRIPTION'),
 			extendedHelp: language => language.tget('COMMAND_TRIGGERS_EXTENDED'),
 			permissionLevel: PermissionLevels.Administrator,
-			requiredPermissions: ['ADD_REACTIONS', 'READ_MESSAGE_HISTORY'],
+			requiredPermissions: ['ADD_REACTIONS', 'READ_MESSAGE_HISTORY', 'EMBED_LINKS'],
 			runIn: ['text'],
 			subcommands: true,
 			usage: '<add|remove|show:default> (type:type) (input:input) (output:output)',

--- a/src/commands/Moderation/prune.ts
+++ b/src/commands/Moderation/prune.ts
@@ -21,7 +21,7 @@ export default class extends SkyraCommand {
 			extendedHelp: language => language.tget('COMMAND_PRUNE_EXTENDED'),
 			permissionLevel: PermissionLevels.Moderator,
 			flagSupport: true,
-			requiredPermissions: ['MANAGE_MESSAGES', 'READ_MESSAGE_HISTORY'],
+			requiredPermissions: ['MANAGE_MESSAGES', 'READ_MESSAGE_HISTORY', 'EMBED_LINKS'],
 			runIn: ['text'],
 			usage: '[limit:integer{1,100}] [filter:filter|user:user] (position:position) (message:message)',
 			usageDelim: ' '

--- a/src/commands/Music/playing.ts
+++ b/src/commands/Music/playing.ts
@@ -8,7 +8,8 @@ export default class extends MusicCommand {
 		super(store, file, directory, {
 			aliases: ['np', 'nowplaying'],
 			description: language => language.tget('COMMAND_PLAYING_DESCRIPTION'),
-			music: ['QUEUE_NOT_EMPTY', 'VOICE_PLAYING']
+			music: ['QUEUE_NOT_EMPTY', 'VOICE_PLAYING'],
+			requiredPermissions: ['EMBED_LINKS']
 		});
 	}
 

--- a/src/commands/Social/remindme.ts
+++ b/src/commands/Social/remindme.ts
@@ -17,6 +17,7 @@ export default class extends SkyraCommand {
 			cooldown: 30,
 			description: language => language.tget('COMMAND_REMINDME_DESCRIPTION'),
 			extendedHelp: language => language.tget('COMMAND_REMINDME_EXTENDED'),
+			requiredPermissions: ['EMBED_LINKS'],
 			usage: '[list|delete|me] [input:...string]',
 			usageDelim: ' '
 		});

--- a/src/commands/Social/vault.ts
+++ b/src/commands/Social/vault.ts
@@ -12,6 +12,7 @@ export default class extends SkyraCommand {
 			aliases: ['bank'],
 			description: language => language.tget('COMMAND_VAULT_DESCRIPTION'),
 			extendedHelp: language => language.tget('COMMAND_VAULT_EXTENDED'),
+			requiredPermissions: ['EMBED_LINKS'],
 			subcommands: true,
 			usage: '<deposit|withdraw|show:default> (coins:coins)',
 			usageDelim: ' '

--- a/src/commands/System/stats.ts
+++ b/src/commands/System/stats.ts
@@ -12,7 +12,8 @@ export default class extends SkyraCommand {
 			bucket: 2,
 			cooldown: 15,
 			description: language => language.tget('COMMAND_STATS_DESCRIPTION'),
-			extendedHelp: language => language.tget('COMMAND_STATS_EXTENDED')
+			extendedHelp: language => language.tget('COMMAND_STATS_EXTENDED'),
+			requiredPermissions: ['EMBED_LINKS']
 		});
 	}
 

--- a/src/commands/System/support.ts
+++ b/src/commands/System/support.ts
@@ -10,7 +10,8 @@ export default class extends SkyraCommand {
 			aliases: ['support-server', 'server'],
 			description: language => language.tget('COMMAND_SUPPORT_DESCRIPTION'),
 			extendedHelp: language => language.tget('COMMAND_SUPPORT_EXTENDED'),
-			guarded: true
+			guarded: true,
+			requiredPermissions: ['EMBED_LINKS']
 		});
 
 	}

--- a/src/commands/Tools/topinvites.ts
+++ b/src/commands/Tools/topinvites.ts
@@ -17,6 +17,7 @@ export default class extends SkyraCommand {
 			description: language => language.tget('COMMAND_TOPINVITES_DESCRIPTION'),
 			extendedHelp: language => language.tget('COMMAND_TOPINVITES_EXTENDED'),
 			requiredGuildPermissions: ['MANAGE_GUILD'],
+			requiredPermissions: ['EMBED_LINKS'],
 			runIn: ['text']
 		});
 	}

--- a/src/commands/Twitch/followage.ts
+++ b/src/commands/Twitch/followage.ts
@@ -20,6 +20,7 @@ export default class extends SkyraCommand {
 		super(store, file, directory, {
 			description: language => language.tget('COMMAND_FOLLOWAGE_DESCRIPTION'),
 			extendedHelp: language => language.tget('COMMAND_FOLLOWAGE_EXTENDED'),
+			requiredPermissions: ['EMBED_LINKS'],
 			runIn: ['text'],
 			usage: '<user:string{1,20}> <channel:string{1,20}>',
 			usageDelim: ' '

--- a/src/commands/Twitch/twitch.ts
+++ b/src/commands/Twitch/twitch.ts
@@ -20,6 +20,7 @@ export default class extends SkyraCommand {
 		super(store, file, directory, {
 			description: language => language.tget('COMMAND_TWITCH_DESCRIPTION'),
 			extendedHelp: language => language.tget('COMMAND_TWITCH_EXTENDED'),
+			requiredPermissions: ['EMBED_LINKS'],
 			runIn: ['text'],
 			usage: '<name:string>'
 		});

--- a/src/commands/Twitch/twitchsubscription.ts
+++ b/src/commands/Twitch/twitchsubscription.ts
@@ -34,6 +34,7 @@ export default class extends SkyraCommand {
 			description: language => language.tget('COMMAND_TWITCHSUBSCRIPTION_DESCRIPTION'),
 			extendedHelp: language => language.tget('COMMAND_TWITCHSUBSCRIPTION_EXTENDED'),
 			permissionLevel: PermissionLevels.Administrator,
+			requiredPermissions: ['EMBED_LINKS'],
 			runIn: ['text'],
 			subcommands: true,
 			usage: '<add|remove|reset|show:default> (streamer:streamer) (channel:channelname) (status:status) (content:content)',


### PR DESCRIPTION
Some commands like `stats`, `support` and `topinvites` did not have permission checks for `EMBED_LINKS`