### PR TITLE
fix: Prune command should use `Message#alert`

### DIFF
--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -1602,7 +1602,8 @@ export default class extends Language {
 		COMMAND_PRUNE_DESCRIPTION: 'Prunes a certain amount of messages w/o filter.',
 		COMMAND_PRUNE_EXTENDED: builder.display('prune', {
 			extendedHelp: `This command deletes the given amount of messages given a filter within the last 100 messages sent
-					in the channel the command has been run.`,
+					in the channel the command has been run. Optionally, you can add \`--silent\` to tell Skyra not to send a
+					response message.`,
 			explainedUsage: [
 				['Messages', 'The amount of messages to prune.'],
 				['Filter', 'The filter to apply.'],

--- a/src/languages/es-ES.ts
+++ b/src/languages/es-ES.ts
@@ -1611,7 +1611,8 @@ export default class extends Language {
 		COMMAND_PRUNE_DESCRIPTION: 'Prunes a certain amount of messages w/o filter.',
 		COMMAND_PRUNE_EXTENDED: builder.display('prune', {
 			extendedHelp: `This command deletes the given amount of messages given a filter within the last 100 messages sent
-					in the channel the command has been run.`,
+					in the channel the command has been run. Optionally, you can add \`--silent\` to tell Skyra not to send a
+					response message.`,
 			explainedUsage: [
 				['Messages', 'La cantidad de mensajes a eliminar.'],
 				['Filter', 'El filtro a aplicar.'],


### PR DESCRIPTION
Also in this change-set:

- Backports 7855217 to the `prune` command, making the invite check more robust.
- Backports 64af52c to the `prune` command, making the links check more robust.
- Cache the RegExp instead of instantiating them on a loop.
- Adds `--silent` flag.