### PR TITLE
refactor: stats command cpu usage & initClean

### DIFF
--- a/src/Skyra.ts
+++ b/src/Skyra.ts
@@ -1,4 +1,5 @@
 import 'module-alias/register';
+import '@utils/initClean';
 import { SkyraClient } from '@lib/SkyraClient';
 import { CLIENT_OPTIONS, TOKENS } from '@root/config';
 import { inspect } from 'util';

--- a/src/commands/System/stats.ts
+++ b/src/commands/System/stats.ts
@@ -1,8 +1,8 @@
 import { SkyraCommand } from '@lib/structures/SkyraCommand';
+import { getColor, roundNumber } from '@utils/util';
 import { version } from 'discord.js';
 import { CommandStore, KlasaMessage } from 'klasa';
-import { loadavg, uptime } from 'os';
-import { getColor } from '@utils/util';
+import { cpus, uptime } from 'os';
 
 export default class extends SkyraCommand {
 
@@ -42,7 +42,7 @@ export default class extends SkyraCommand {
 	private get usageStatistics(): StatsUsage {
 		const usage = process.memoryUsage();
 		return {
-			CPU_LOAD: loadavg().map(load => Math.round(load * 10000) / 100) as [number, number, number],
+			CPU_LOAD: cpus().map(({ times }) => roundNumber(((times.user + times.nice + times.sys + times.irq) / times.idle) * 10000) / 100),
 			RAM_TOTAL: `${Math.round(100 * (usage.heapTotal / 1048576)) / 100}MB`,
 			RAM_USED: `${Math.round(100 * (usage.heapUsed / 1048576)) / 100}MB`
 		};
@@ -65,7 +65,7 @@ export interface StatsUptime {
 }
 
 export interface StatsUsage {
-	CPU_LOAD: [number, number, number];
+	CPU_LOAD: number[];
 	RAM_TOTAL: string;
 	RAM_USED: string;
 }

--- a/src/lib/SkyraClient.ts
+++ b/src/lib/SkyraClient.ts
@@ -25,13 +25,9 @@ import { enumerable } from './util/util';
 
 // Import all configuration
 import {
-	CLIENT_SECRET,
 	ENABLE_LAVALINK,
 	ENABLE_POSTGRES,
 	EVLYN_PORT,
-	LAVALINK_PASSWORD,
-	PGSQL_DATABASE_PASSWORD,
-	TOKENS,
 	VERSION,
 	WEBHOOK_ERROR
 } from '@root/config';
@@ -49,7 +45,6 @@ import './setup/Canvas';
 import { CommonQuery } from './queries/common';
 import { PostgresCommonQuery } from './queries/postgres';
 import { JsonCommonQuery } from './queries/json';
-import { initClean } from './util/clean';
 import { WebsocketHandler } from './websocket';
 import { InviteStore } from './structures/InviteStore';
 
@@ -162,13 +157,6 @@ export class SkyraClient extends KlasaClient {
 	public static defaultMemberSchema = new Schema()
 		.add('points', 'Number', { configurable: false });
 
-}
-
-{
-	const raw = Object.values(TOKENS)
-		.concat([CLIENT_SECRET, LAVALINK_PASSWORD, PGSQL_DATABASE_PASSWORD, WEBHOOK_ERROR.token])
-		.filter(value => typeof value === 'string' && value !== '');
-	initClean([...new Set(raw)]);
 }
 
 SkyraClient.use(DashboardClient);

--- a/src/lib/util/initClean.ts
+++ b/src/lib/util/initClean.ts
@@ -5,6 +5,4 @@ const raw = Object.values(TOKENS)
 	.concat([CLIENT_SECRET, LAVALINK_PASSWORD, PGSQL_DATABASE_PASSWORD, WEBHOOK_ERROR.token])
 	.filter(value => typeof value === 'string' && value !== '');
 
-export const clean = () => initClean([...new Set(raw)]);
-
-clean();
+initClean([...new Set(raw)]);

--- a/src/lib/util/initClean.ts
+++ b/src/lib/util/initClean.ts
@@ -1,0 +1,10 @@
+import { CLIENT_SECRET, LAVALINK_PASSWORD, PGSQL_DATABASE_PASSWORD, TOKENS, WEBHOOK_ERROR } from '@root/config';
+import { initClean } from '@utils/clean';
+
+const raw = Object.values(TOKENS)
+	.concat([CLIENT_SECRET, LAVALINK_PASSWORD, PGSQL_DATABASE_PASSWORD, WEBHOOK_ERROR.token])
+	.filter(value => typeof value === 'string' && value !== '');
+
+export const clean = () => initClean([...new Set(raw)]);
+
+clean();

--- a/src/tasks/reloadOnChanges.ts
+++ b/src/tasks/reloadOnChanges.ts
@@ -2,6 +2,7 @@
 import { SkyraCommand } from '@lib/structures/SkyraCommand';
 import { Events } from '@lib/types/Enums';
 import { WATCH_FILES } from '@root/config';
+import { clean } from '@utils/initClean';
 import { floatPromise } from '@utils/util';
 import { watch } from 'chokidar';
 import { KlasaMessage, Piece, Stopwatch, Task } from 'klasa';
@@ -54,6 +55,7 @@ export default class extends Task {
 		}
 
 		this.client.emit(Events.Verbose, `[${store}] ${name} was updated. ${log}`);
+		clean();
 	}
 
 	public init() {

--- a/src/tasks/reloadOnChanges.ts
+++ b/src/tasks/reloadOnChanges.ts
@@ -2,7 +2,6 @@
 import { SkyraCommand } from '@lib/structures/SkyraCommand';
 import { Events } from '@lib/types/Enums';
 import { WATCH_FILES } from '@root/config';
-import { clean } from '@utils/initClean';
 import { floatPromise } from '@utils/util';
 import { watch } from 'chokidar';
 import { KlasaMessage, Piece, Stopwatch, Task } from 'klasa';
@@ -55,7 +54,7 @@ export default class extends Task {
 		}
 
 		this.client.emit(Events.Verbose, `[${store}] ${name} was updated. ${log}`);
-		clean();
+		await import('@utils/initClean');
 	}
 
 	public init() {


### PR DESCRIPTION
I also fixed `initClean` not properly always being ran. Specifically when reloading on changes.

- refactor(stats): show better cpu usage
- fix(initClean): Fix initClean not running always
