### PR TITLE
fix(urd): dont add page numbers when lacking permissions

### DIFF
--- a/src/commands/Anime/anime.ts
+++ b/src/commands/Anime/anime.ts
@@ -60,7 +60,8 @@ export default class extends SkyraCommand {
 	private buildDisplay(entries: Kitsu.KitsuHit[], message: KlasaMessage) {
 		const embedData = message.language.tget('COMMAND_ANIME_EMBED_DATA');
 		const display = new UserRichDisplay(new MessageEmbed()
-			.setColor(getColor(message)));
+			.setColor(getColor(message)))
+			.setFooterSuffix(' - © kitsu.io');
 
 		for (const entry of entries) {
 			const synopsis = cutText(entry.synopsis.replace(/(.+)[\r\n\t](.+)/gim, '$1 $2').split('\r\n')[0], 750);

--- a/src/commands/Anime/anime.ts
+++ b/src/commands/Anime/anime.ts
@@ -60,8 +60,7 @@ export default class extends SkyraCommand {
 	private buildDisplay(entries: Kitsu.KitsuHit[], message: KlasaMessage) {
 		const embedData = message.language.tget('COMMAND_ANIME_EMBED_DATA');
 		const display = new UserRichDisplay(new MessageEmbed()
-			.setColor(getColor(message))
-			.setFooter('© kitsu.io'));
+			.setColor(getColor(message)));
 
 		for (const entry of entries) {
 			const synopsis = cutText(entry.synopsis.replace(/(.+)[\r\n\t](.+)/gim, '$1 $2').split('\r\n')[0], 750);

--- a/src/commands/Anime/manga.ts
+++ b/src/commands/Anime/manga.ts
@@ -60,8 +60,7 @@ export default class extends SkyraCommand {
 	private buildDisplay(entries: Kitsu.KitsuHit[], message: KlasaMessage) {
 		const embedData = message.language.tget('COMMAND_MANGA_EMBED_DATA');
 		const display = new UserRichDisplay(new MessageEmbed()
-			.setColor(getColor(message))
-			.setFooter('© kitsu.io'));
+			.setColor(getColor(message)));
 
 		for (const entry of entries) {
 			const synopsis = cutText(entry.synopsis.replace(/(.+)[\r\n\t](.+)/gim, '$1 $2').split('\r\n')[0], 750);

--- a/src/commands/Anime/manga.ts
+++ b/src/commands/Anime/manga.ts
@@ -60,7 +60,8 @@ export default class extends SkyraCommand {
 	private buildDisplay(entries: Kitsu.KitsuHit[], message: KlasaMessage) {
 		const embedData = message.language.tget('COMMAND_MANGA_EMBED_DATA');
 		const display = new UserRichDisplay(new MessageEmbed()
-			.setColor(getColor(message)));
+			.setColor(getColor(message)))
+			.setFooterSuffix(' - © kitsu.io');
 
 		for (const entry of entries) {
 			const synopsis = cutText(entry.synopsis.replace(/(.+)[\r\n\t](.+)/gim, '$1 $2').split('\r\n')[0], 750);

--- a/src/commands/Tools/Dictionary/urban.ts
+++ b/src/commands/Tools/Dictionary/urban.ts
@@ -46,7 +46,7 @@ export default class extends SkyraCommand {
 			.setTitle(`Urban Dictionary: ${util.toTitleCase(query)}`)
 			.setColor(getColor(message))
 			.setThumbnail('https://i.imgur.com/CcIZZsa.png'))
-			.setFooterSuffix('© Urban Dictionary');
+			.setFooterSuffix(' - © Urban Dictionary');
 
 		for (const result of results) {
 			const definition = this.content(result.definition, result.permalink, message.language);

--- a/src/commands/Tools/Dictionary/urban.ts
+++ b/src/commands/Tools/Dictionary/urban.ts
@@ -45,7 +45,8 @@ export default class extends SkyraCommand {
 		const display = new UserRichDisplay(new MessageEmbed()
 			.setTitle(`Urban Dictionary: ${util.toTitleCase(query)}`)
 			.setColor(getColor(message))
-			.setThumbnail('https://i.imgur.com/CcIZZsa.png'));
+			.setThumbnail('https://i.imgur.com/CcIZZsa.png'))
+			.setFooterSuffix('© Urban Dictionary');
 
 		for (const result of results) {
 			const definition = this.content(result.definition, result.permalink, message.language);

--- a/src/commands/Tools/Dictionary/urban.ts
+++ b/src/commands/Tools/Dictionary/urban.ts
@@ -45,8 +45,7 @@ export default class extends SkyraCommand {
 		const display = new UserRichDisplay(new MessageEmbed()
 			.setTitle(`Urban Dictionary: ${util.toTitleCase(query)}`)
 			.setColor(getColor(message))
-			.setThumbnail('https://i.imgur.com/CcIZZsa.png')
-			.setFooter('© Urban Dictionary'));
+			.setThumbnail('https://i.imgur.com/CcIZZsa.png'));
 
 		for (const result of results) {
 			const definition = this.content(result.definition, result.permalink, message.language);

--- a/src/lib/structures/UserRichDisplay.ts
+++ b/src/lib/structures/UserRichDisplay.ts
@@ -1,5 +1,5 @@
 import { Time } from '@utils/constants';
-import { Client, MessageEmbed, MessageReaction, TextChannel } from 'discord.js';
+import { Client, MessageEmbed, MessageReaction, Permissions, TextChannel } from 'discord.js';
 import { KlasaMessage, KlasaUser, ReactionHandler, RichDisplay, RichDisplayRunOptions, util } from 'klasa';
 
 export class UserRichDisplay extends RichDisplay {
@@ -29,8 +29,8 @@ export class UserRichDisplay extends RichDisplay {
 	}
 
 	private setAuthorizedFooter(client: Client, channel: TextChannel) {
-		const permissionsForClient = (channel.permissionsFor(client.user!)!);
-		if (permissionsForClient.has('ADD_REACTIONS') && permissionsForClient.has('MANAGE_MESSAGES')) {
+		const priviledged = channel.permissionsFor(client.user!)?.has(UserRichDisplay.kPermissions) ?? false;
+		if (priviledged) {
 			for (let i = 1; i <= this.pages.length; i++) this.pages[i - 1].setFooter(`${this.footerPrefix}${i}/${this.pages.length}${this.footerSuffix}`);
 			if (this.infoPage) this.infoPage.setFooter('ℹ');
 		}
@@ -38,5 +38,9 @@ export class UserRichDisplay extends RichDisplay {
 
 	public static readonly handlers: Map<string, ReactionHandler> = new Map();
 
+	private static readonly kPermissions = new Permissions([
+		Permissions.FLAGS.ADD_REACTIONS,
+		Permissions.FLAGS.MANAGE_MESSAGES
+	]).freeze();
 
 }

--- a/src/lib/structures/UserRichDisplay.ts
+++ b/src/lib/structures/UserRichDisplay.ts
@@ -1,8 +1,13 @@
 import { Time } from '@utils/constants';
-import { MessageReaction } from 'discord.js';
+import { Client, MessageEmbed, MessageReaction, TextChannel } from 'discord.js';
 import { KlasaMessage, KlasaUser, ReactionHandler, RichDisplay, RichDisplayRunOptions, util } from 'klasa';
 
 export class UserRichDisplay extends RichDisplay {
+
+	public constructor(embed?: MessageEmbed) {
+		super(embed);
+		this.useCustomFooters();
+	}
 
 	public async start(message: KlasaMessage, target: string = message.author.id, options: RichDisplayRunOptions = {}): Promise<ReactionHandler> {
 		util.mergeDefault({
@@ -15,6 +20,7 @@ export class UserRichDisplay extends RichDisplay {
 			if (display) display.stop();
 		}
 
+		this.setAuthorizedFooter(message.client, message.channel as TextChannel);
 		const handler = (await super.run(message, options))
 			.once('end', () => UserRichDisplay.handlers.delete(target));
 		UserRichDisplay.handlers.set(target, handler);
@@ -22,6 +28,15 @@ export class UserRichDisplay extends RichDisplay {
 		return handler;
 	}
 
+	private setAuthorizedFooter(client: Client, channel: TextChannel) {
+		const permissionsForClient = (channel.permissionsFor(client.user!)!);
+		if (permissionsForClient.has('ADD_REACTIONS') && permissionsForClient.has('MANAGE_MESSAGES')) {
+			for (let i = 1; i <= this.pages.length; i++) this.pages[i - 1].setFooter(`${this.footerPrefix}${i}/${this.pages.length}${this.footerSuffix}`);
+			if (this.infoPage) this.infoPage.setFooter('ℹ');
+		}
+	}
+
 	public static readonly handlers: Map<string, ReactionHandler> = new Map();
+
 
 }


### PR DESCRIPTION
I noticed when Skyra has no permission to add reactions that it still adds the page number count which is very misleading since users cannot do anything with the RichDisplay at that point. 

So instead of using Klasa's build in way to add a footer we should use this way to ensure that Skyra has the required permissions before setting the footer.

As for the changes on `anime`, `manga` and `urban`, they were just wrong before and never showing up.