### PR TITLE
fix(urd): always allowed in dm

### DIFF
--- a/src/commands/GameIntegration/clashofclans.ts
+++ b/src/commands/GameIntegration/clashofclans.ts
@@ -20,6 +20,7 @@ const enum ClashOfClansFetchCategories {
 	description: language => language.tget('COMMAND_CLASHOFCLANS_DESCRIPTION'),
 	extendedHelp: language => language.tget('COMMAND_CLASHOFCLANS_EXTENDED'),
 	requiredPermissions: ['EMBED_LINKS'],
+	runIn: ['text'],
 	subcommands: true,
 	usage: '<player|clan:default> <query:tagOrName>',
 	usageDelim: ' '

--- a/src/commands/Management/Configuration/setIgnoreChannels.ts
+++ b/src/commands/Management/Configuration/setIgnoreChannels.ts
@@ -1,6 +1,7 @@
 import { SkyraCommand } from '@lib/structures/SkyraCommand';
 import { PermissionLevels } from '@lib/types/Enums';
 import { GuildSettings } from '@lib/types/settings/GuildSettings';
+import { isTextBasedChannel } from '@utils/util';
 import { TextChannel } from 'discord.js';
 import { CommandStore, KlasaMessage } from 'klasa';
 
@@ -20,7 +21,7 @@ export default class extends SkyraCommand {
 
 	public async run(message: KlasaMessage, [channel]: [TextChannel | 'here']) {
 		if (channel === 'here') channel = message.channel as TextChannel;
-		else if (channel.type !== 'text') throw message.language.tget('CONFIGURATION_TEXTCHANNEL_REQUIRED');
+		else if (!isTextBasedChannel(channel)) throw message.language.tget('CONFIGURATION_TEXTCHANNEL_REQUIRED');
 		const oldLength = message.guild!.settings.get(GuildSettings.DisabledChannels).length;
 		await message.guild!.settings.update(GuildSettings.DisabledChannels, channel, {
 			extraContext: { author: message.author.id }

--- a/src/commands/Management/Configuration/setImageLogs.ts
+++ b/src/commands/Management/Configuration/setImageLogs.ts
@@ -1,6 +1,7 @@
 import { SkyraCommand } from '@lib/structures/SkyraCommand';
 import { PermissionLevels } from '@lib/types/Enums';
 import { GuildSettings } from '@lib/types/settings/GuildSettings';
+import { isTextBasedChannel } from '@utils/util';
 import { TextChannel } from 'discord.js';
 import { CommandStore, KlasaMessage } from 'klasa';
 
@@ -20,7 +21,7 @@ export default class extends SkyraCommand {
 
 	public async run(message: KlasaMessage, [channel]: [TextChannel | 'here']) {
 		if (channel === 'here') channel = message.channel as TextChannel;
-		else if (channel.type !== 'text') throw message.language.tget('CONFIGURATION_TEXTCHANNEL_REQUIRED');
+		else if (!isTextBasedChannel(channel)) throw message.language.tget('CONFIGURATION_TEXTCHANNEL_REQUIRED');
 
 		const current = message.guild!.settings.get(GuildSettings.Channels.ImageLogs);
 		if (current === channel.id) throw message.language.tget('CONFIGURATION_EQUALS');

--- a/src/commands/Management/Configuration/setMemberLogs.ts
+++ b/src/commands/Management/Configuration/setMemberLogs.ts
@@ -1,6 +1,7 @@
 import { SkyraCommand } from '@lib/structures/SkyraCommand';
 import { PermissionLevels } from '@lib/types/Enums';
 import { GuildSettings } from '@lib/types/settings/GuildSettings';
+import { isTextBasedChannel } from '@utils/util';
 import { TextChannel } from 'discord.js';
 import { CommandStore, KlasaMessage } from 'klasa';
 
@@ -20,7 +21,7 @@ export default class extends SkyraCommand {
 
 	public async run(message: KlasaMessage, [channel]: [TextChannel | 'here']) {
 		if (channel === 'here') channel = message.channel as TextChannel;
-		else if (channel.type !== 'text') throw message.language.tget('CONFIGURATION_TEXTCHANNEL_REQUIRED');
+		else if (!isTextBasedChannel(channel)) throw message.language.tget('CONFIGURATION_TEXTCHANNEL_REQUIRED');
 
 		const previous = message.guild!.settings.get(GuildSettings.Channels.MemberLogs);
 		if (previous === channel.id) throw message.language.tget('CONFIGURATION_EQUALS');

--- a/src/commands/Management/Configuration/setMessageLogs.ts
+++ b/src/commands/Management/Configuration/setMessageLogs.ts
@@ -1,6 +1,7 @@
 import { SkyraCommand } from '@lib/structures/SkyraCommand';
 import { PermissionLevels } from '@lib/types/Enums';
 import { GuildSettings } from '@lib/types/settings/GuildSettings';
+import { isTextBasedChannel } from '@utils/util';
 import { TextChannel } from 'discord.js';
 import { CommandStore, KlasaMessage } from 'klasa';
 
@@ -20,7 +21,7 @@ export default class extends SkyraCommand {
 
 	public async run(message: KlasaMessage, [channel]: [TextChannel | 'here']) {
 		if (channel === 'here') channel = message.channel as TextChannel;
-		else if (channel.type !== 'text') throw message.language.tget('CONFIGURATION_TEXTCHANNEL_REQUIRED');
+		else if (!isTextBasedChannel(channel)) throw message.language.tget('CONFIGURATION_TEXTCHANNEL_REQUIRED');
 
 		const current = message.guild!.settings.get(GuildSettings.Channels.MessageLogs);
 		if (current === channel.id) throw message.language.tget('CONFIGURATION_EQUALS');

--- a/src/commands/Management/Configuration/setModLogs.ts
+++ b/src/commands/Management/Configuration/setModLogs.ts
@@ -1,6 +1,7 @@
 import { SkyraCommand } from '@lib/structures/SkyraCommand';
 import { PermissionLevels } from '@lib/types/Enums';
 import { GuildSettings } from '@lib/types/settings/GuildSettings';
+import { isTextBasedChannel } from '@utils/util';
 import { TextChannel } from 'discord.js';
 import { CommandStore, KlasaMessage } from 'klasa';
 
@@ -20,7 +21,7 @@ export default class extends SkyraCommand {
 
 	public async run(message: KlasaMessage, [channel]: [TextChannel | 'here']) {
 		if (channel === 'here') channel = message.channel as TextChannel;
-		else if (channel.type !== 'text') throw message.language.tget('CONFIGURATION_TEXTCHANNEL_REQUIRED');
+		else if (!isTextBasedChannel(channel)) throw message.language.tget('CONFIGURATION_TEXTCHANNEL_REQUIRED');
 
 		const current = message.guild!.settings.get(GuildSettings.Channels.ModerationLogs);
 		if (current === channel.id) throw message.language.tget('CONFIGURATION_EQUALS');

--- a/src/commands/Management/Configuration/setRoleChannel.ts
+++ b/src/commands/Management/Configuration/setRoleChannel.ts
@@ -1,6 +1,7 @@
 import { SkyraCommand } from '@lib/structures/SkyraCommand';
 import { PermissionLevels } from '@lib/types/Enums';
 import { GuildSettings } from '@lib/types/settings/GuildSettings';
+import { isTextBasedChannel } from '@utils/util';
 import { TextChannel } from 'discord.js';
 import { CommandStore, KlasaMessage } from 'klasa';
 
@@ -20,7 +21,7 @@ export default class extends SkyraCommand {
 
 	public async run(message: KlasaMessage, [channel]: [TextChannel | 'here']) {
 		if (channel === 'here') channel = message.channel as TextChannel;
-		else if (channel.type !== 'text') throw message.language.tget('CONFIGURATION_TEXTCHANNEL_REQUIRED');
+		else if (!isTextBasedChannel(channel)) throw message.language.tget('CONFIGURATION_TEXTCHANNEL_REQUIRED');
 		if (message.guild!.settings.get(GuildSettings.Channels.Roles) === channel.id) throw message.language.tget('CONFIGURATION_EQUALS');
 		await message.guild!.settings.update([[GuildSettings.Channels.Roles, channel], [GuildSettings.Roles.MessageReaction, null]], {
 			extraContext: { author: message.author.id }

--- a/src/commands/Tools/quote.ts
+++ b/src/commands/Tools/quote.ts
@@ -1,6 +1,6 @@
 import { SkyraCommand, SkyraCommandOptions } from '@lib/structures/SkyraCommand';
 import { ApplyOptions } from '@skyra/decorators';
-import { cutText, getColor, getContent, getImage } from '@utils/util';
+import { cutText, getColor, getContent, getImage, isTextBasedChannel } from '@utils/util';
 import { GuildChannel, MessageEmbed, Permissions, TextChannel } from 'discord.js';
 import { KlasaMessage, Serializer } from 'klasa';
 
@@ -23,7 +23,7 @@ export default class extends SkyraCommand {
 			const messageUrl = await this.getFromUrl(message, arg);
 			if (messageUrl) return messageUrl;
 
-			if (channel.type !== 'text') throw message.language.tget('RESOLVER_INVALID_CHANNEL', 'Channel');
+			if (!isTextBasedChannel(channel)) throw message.language.tget('RESOLVER_INVALID_CHANNEL', 'Channel');
 			if (!arg || !SNOWFLAKE_REGEXP.test(arg)) throw message.language.tget('RESOLVER_INVALID_MESSAGE', 'Message');
 			const m = await (channel as TextChannel).messages.fetch(arg).catch(() => null);
 			if (m) return m;

--- a/src/events/rawMessageReactionAdd.ts
+++ b/src/events/rawMessageReactionAdd.ts
@@ -6,7 +6,7 @@ import { GuildSettings } from '@lib/types/settings/GuildSettings';
 import { MessageLogsEnum } from '@utils/constants';
 import { LLRCData } from '@utils/LongLivingReactionCollector';
 import { api } from '@utils/Models/Api';
-import { floatPromise, getDisplayAvatar, resolveEmoji, twemoji } from '@utils/util';
+import { floatPromise, getDisplayAvatar, isTextBasedChannel, resolveEmoji, twemoji } from '@utils/util';
 import { MessageEmbed, TextChannel } from 'discord.js';
 import { Event, EventStore } from 'klasa';
 
@@ -22,7 +22,7 @@ export default class extends Event {
 
 	public run(raw: WSMessageReactionAdd) {
 		const channel = this.client.channels.get(raw.channel_id) as TextChannel | undefined;
-		if (!channel || channel.type !== 'text' || !channel.readable) return;
+		if (!channel || !isTextBasedChannel(channel) || !channel.readable) return;
 
 		const data: LLRCData = {
 			channel,

--- a/src/events/rawMessageReactionRemove.ts
+++ b/src/events/rawMessageReactionRemove.ts
@@ -1,5 +1,6 @@
 import { WSMessageReactionRemove } from '@lib/types/DiscordAPI';
 import { Events } from '@lib/types/Enums';
+import { isTextBasedChannel } from '@utils/util';
 import { TextChannel } from 'discord.js';
 import { Event, EventStore } from 'klasa';
 
@@ -11,7 +12,7 @@ export default class extends Event {
 
 	public run(data: WSMessageReactionRemove) {
 		const channel = this.client.channels.get(data.channel_id) as TextChannel;
-		if (!channel || !channel.readable || channel.type !== 'text') return;
+		if (!channel || !channel.readable || !isTextBasedChannel(channel)) return;
 		this.client.emit(Events.RoleReactionRemove, channel, data);
 	}
 

--- a/src/events/rawMessageReactionRemove.ts
+++ b/src/events/rawMessageReactionRemove.ts
@@ -11,7 +11,7 @@ export default class extends Event {
 
 	public run(data: WSMessageReactionRemove) {
 		const channel = this.client.channels.get(data.channel_id) as TextChannel;
-		if (!channel || !channel.readable) return;
+		if (!channel || !channel.readable || channel.type !== 'text') return;
 		this.client.emit(Events.RoleReactionRemove, channel, data);
 	}
 

--- a/src/events/roleReactionRemove.ts
+++ b/src/events/roleReactionRemove.ts
@@ -1,7 +1,7 @@
 import { WSMessageReactionRemove } from '@lib/types/DiscordAPI';
 import { Events } from '@lib/types/Enums';
 import { GuildSettings } from '@lib/types/settings/GuildSettings';
-import { resolveEmoji } from '@utils/util';
+import { isTextBasedChannel, resolveEmoji } from '@utils/util';
 import { TextChannel } from 'discord.js';
 import { Event } from 'klasa';
 
@@ -9,7 +9,7 @@ export default class extends Event {
 
 	public async run(channel: TextChannel, data: WSMessageReactionRemove) {
 		// If the channel is not a text channel then stop processing
-		if (channel.type !== 'text') return;
+		if (!isTextBasedChannel(channel)) return;
 		// Role reactions only apply on the roles channel
 		const channelRoles = channel.guild.settings.get(GuildSettings.Channels.Roles);
 		if (!channelRoles) return;

--- a/src/events/roleReactionRemove.ts
+++ b/src/events/roleReactionRemove.ts
@@ -8,6 +8,8 @@ import { Event } from 'klasa';
 export default class extends Event {
 
 	public async run(channel: TextChannel, data: WSMessageReactionRemove) {
+		// If the channel is not a text channel then stop processing
+		if (channel.type !== 'text') return;
 		// Role reactions only apply on the roles channel
 		const channelRoles = channel.guild.settings.get(GuildSettings.Channels.Roles);
 		if (!channelRoles) return;

--- a/src/inhibitors/musicInhibitor.ts
+++ b/src/inhibitors/musicInhibitor.ts
@@ -1,5 +1,6 @@
 import { MusicBitField } from '@lib/structures/MusicBitField';
 import { MusicCommand } from '@lib/structures/MusicCommand';
+import { isTextBasedChannel } from '@utils/util';
 import { Command, Inhibitor, InhibitorStore, KlasaMessage } from 'klasa';
 
 const { FLAGS } = MusicBitField;
@@ -16,7 +17,7 @@ export default class extends Inhibitor {
 		if (!(command instanceof MusicCommand) || !command.music.bitfield) return;
 
 		// MusicCommands only run in text channels
-		if (message.channel.type !== 'text') return;
+		if (!isTextBasedChannel(message.channel)) return;
 
 		// Checks for empty queue
 		if (command.music.has(FLAGS.QUEUE_NOT_EMPTY) && !message.guild!.music.canPlay) {

--- a/src/lib/structures/UserRichDisplay.ts
+++ b/src/lib/structures/UserRichDisplay.ts
@@ -1,6 +1,7 @@
+import { mergeDefault } from '@klasa/utils';
 import { Time } from '@utils/constants';
-import { Client, MessageEmbed, MessageReaction, Permissions, TextChannel } from 'discord.js';
-import { KlasaMessage, KlasaUser, ReactionHandler, RichDisplay, RichDisplayRunOptions, util } from 'klasa';
+import { Client, DMChannel, MessageEmbed, MessageReaction, Permissions, TextChannel } from 'discord.js';
+import { KlasaMessage, KlasaUser, ReactionHandler, RichDisplay, RichDisplayRunOptions } from 'klasa';
 
 export class UserRichDisplay extends RichDisplay {
 
@@ -10,7 +11,7 @@ export class UserRichDisplay extends RichDisplay {
 	}
 
 	public async start(message: KlasaMessage, target: string = message.author.id, options: RichDisplayRunOptions = {}): Promise<ReactionHandler> {
-		util.mergeDefault({
+		mergeDefault({
 			filter: (_: MessageReaction, user: KlasaUser) => user.id === target,
 			time: Time.Minute * 5
 		}, options);
@@ -20,7 +21,7 @@ export class UserRichDisplay extends RichDisplay {
 			if (display) display.stop();
 		}
 
-		this.setAuthorizedFooter(message.client, message.channel as TextChannel);
+		this.setAuthorizedFooter(message.client, message.channel);
 
 		const handler = await super.run(message, options);
 		const messageID = handler.message.id;
@@ -36,8 +37,15 @@ export class UserRichDisplay extends RichDisplay {
 		return handler;
 	}
 
-	private setAuthorizedFooter(client: Client, channel: TextChannel) {
-		const priviledged = channel.permissionsFor(client.user!)?.has(UserRichDisplay.kPermissions) ?? false;
+	private isDmChannel(channel: TextChannel | DMChannel): channel is DMChannel {
+		return channel.type === 'dm';
+	}
+
+	private setAuthorizedFooter(client: Client, channel: TextChannel | DMChannel) {
+		const priviledged = this.isDmChannel(channel)
+			? true
+			: channel.permissionsFor(client.user!)?.has(UserRichDisplay.kPermissions) ?? false;
+
 		if (priviledged) {
 			for (let i = 1; i <= this.pages.length; i++) this.pages[i - 1].setFooter(`${this.footerPrefix}${i}/${this.pages.length}${this.footerSuffix}`);
 			if (this.infoPage) this.infoPage.setFooter('ℹ');

--- a/src/lib/util/util.ts
+++ b/src/lib/util/util.ts
@@ -8,9 +8,9 @@ import { UserSettings } from '@lib/types/settings/UserSettings';
 import { CLIENT_SECRET } from '@root/config';
 import { createFunctionInhibitor } from '@skyra/decorators';
 import { Image } from 'canvas';
-import { Client, DiscordAPIError, Guild, GuildChannel, ImageSize, ImageURLOptions, Message, Permissions, Role, User, UserResolvable, PermissionResolvable, TextChannel } from 'discord.js';
+import { Channel, Client, DiscordAPIError, Guild, GuildChannel, ImageSize, ImageURLOptions, Message, PermissionResolvable, Permissions, Role, TextChannel, User, UserResolvable } from 'discord.js';
 import { readFile } from 'fs-nextra';
-import { KlasaGuild, RateLimitManager, util, KlasaMessage } from 'klasa';
+import { KlasaGuild, KlasaMessage, RateLimitManager, util } from 'klasa';
 import { Util } from 'klasa-dashboard-hooks';
 import nodeFetch, { RequestInit, Response } from 'node-fetch';
 import { UserTag } from './Cache/UserTags';
@@ -688,6 +688,15 @@ export function getHighestRole(guild: KlasaGuild, roles: readonly string[]) {
 	}
 
 	return highest;
+}
+
+/**
+ * Checks whether a channel is either a guild text channel, guild news channel or guild store channel
+ * This ensures the channel is *not* a DM / group DM / unknown / something else
+ * @param channel The channel to validate
+ */
+export function isTextBasedChannel(channel: Channel) {
+	return channel.type === 'text' || channel.type === 'news' || channel.type === 'store';
 }
 
 export interface UtilOneToTenEntry {

--- a/src/lib/util/util.ts
+++ b/src/lib/util/util.ts
@@ -696,7 +696,7 @@ export function getHighestRole(guild: KlasaGuild, roles: readonly string[]) {
  * @param channel The channel to validate
  */
 export function isTextBasedChannel(channel: Channel) {
-	return channel.type === 'text' || channel.type === 'news' || channel.type === 'store';
+	return channel.type === 'text' || channel.type === 'news';
 }
 
 export interface UtilOneToTenEntry {


### PR DESCRIPTION
- fix(events): additional channel type checks
  Had some additional errors after fixing the bug in URD, this resolves them.

  Stacktrace that was being thrown:
  ```
  [2020-05-11 19:22:08] [EVENT] E:\dev\Skyra\dist\events\roleReactionRemove.js
  [2020-05-11 19:22:08] TypeError: Cannot read property 'settings' of undefined
  [2020-05-11 19:22:08]     at default_1.run (E:\dev\Skyra\dist\events\roleReactionRemove.js:9:44)
  [2020-05-11 19:22:08]     at default_1._run (E:\dev\Skyra\node_modules\klasa\src\lib\structures\Event.js:101:15)
  [2020-05-11 19:22:08]     at SkyraClient.emit (events.js:315:20)
  [2020-05-11 19:22:08]     at default_1.run (E:\dev\Skyra\dist\events\rawMessageReactionRemove.js:12:21)
  [2020-05-11 19:22:08]     at default_1._run (E:\dev\Skyra\node_modules\klasa\src\lib\structures\Event.js:101:15)
  [2020-05-11 19:22:08]     at WebSocketManager.emit (events.js:315:20)
  [2020-05-11 19:22:08]     at WebSocketShard.onMessage (E:\dev\Skyra\node_modules\discord.js\src\client\websocket\WebSocketShard.js:290:56)
  [2020-05-11 19:22:08]     at WebSocket.onMessage (E:\dev\Skyra\node_modules\discord.js\node_modules\ws\lib\event-target.js:120:16)
  [2020-05-11 19:22:08]     at WebSocket.emit (events.js:315:20)
  [2020-05-11 19:22:08]     at Receiver.receiverOnMessage (E:\dev\Skyra\node_modules\discord.js\node_modules\ws\lib\websocket.js:801:20)
  ```

- fix(coc): lock clashofclans to guild for urd
- fix(urd): skyra is always privileged in DMs
