### PR TITLE
fix(api): fixed method of checking guild manageable

### DIFF
--- a/src/lib/util/API.ts
+++ b/src/lib/util/API.ts
@@ -1,0 +1,42 @@
+import { GuildSettings } from '@lib/types/settings/GuildSettings';
+import { Guild, GuildMember, Permissions } from 'discord.js';
+import { MemberTag } from './Cache/MemberTags';
+
+export function canManage(guild: Guild, member: GuildMember) {
+	if (guild.ownerID === member.id) return true;
+	if (member.permissions.has(Permissions.FLAGS.MANAGE_GUILD)) return true;
+
+	const roleID = guild.settings.get(GuildSettings.Roles.Admin);
+	const memberTag = guild.memberTags.get(member.id);
+
+	// MemberTag must always exist:
+	return typeof memberTag !== 'undefined'
+		// If Roles.Admin is not configured, check MANAGE_GUILD, else check if the member has the role.
+		&& (roleID === null ? member.permissions.has(Permissions.FLAGS.MANAGE_GUILD) : memberTag.roles.includes(roleID))
+		// Check if despite of having permissions, user permission nodes do not deny them.
+		&& allowedPermissionsNodeUser(guild, member.id)
+		// Check if despite of having permissions, role permission nodes do not deny them.
+		&& allowedPermissionsNodeRole(guild, memberTag);
+}
+
+export function allowedPermissionsNodeUser(guild: Guild, userID: string) {
+	const permissionNodeRoles = guild.settings.get(GuildSettings.Permissions.Users);
+	for (const node of permissionNodeRoles) {
+		if (node.id !== userID) continue;
+		if (node.allow.includes('settings')) return true;
+		if (node.deny.includes('settings')) return false;
+	}
+
+	return true;
+}
+
+export function allowedPermissionsNodeRole(guild: Guild, memberTag: MemberTag) {
+	// Assume sorted data
+	for (const [id, node] of guild.permissionsManager.entries()) {
+		if (!memberTag.roles.includes(id)) continue;
+		if (node.allow.has('settings')) return true;
+		if (node.deny.has('settings')) return false;
+	}
+
+	return true;
+}

--- a/src/routes/guilds/guild.ts
+++ b/src/routes/guilds/guild.ts
@@ -1,12 +1,10 @@
 import ApiRequest from '@lib/structures/api/ApiRequest';
 import ApiResponse from '@lib/structures/api/ApiResponse';
+import { canManage } from '@utils/API';
 import { api } from '@utils/Models/Api';
 import { flattenGuild } from '@utils/Models/ApiTransform';
 import { authenticated, ratelimit } from '@utils/util';
-import { Permissions } from 'discord.js';
 import { Route, RouteStore } from 'klasa-dashboard-hooks';
-
-const { FLAGS: { MANAGE_GUILD } } = Permissions;
 
 export default class extends Route {
 
@@ -25,8 +23,7 @@ export default class extends Route {
 		const member = await guild.members.fetch(request.auth!.user_id).catch(() => null);
 		if (!member) return response.error(400);
 
-		const canManage = member.permissions.has(MANAGE_GUILD);
-		if (!canManage) return response.error(401);
+		if (!canManage(guild, member)) return response.error(403);
 
 		const emojis = await api(this.client).guilds(guildID).emojis.get();
 		return response.json({ ...flattenGuild(guild), emojis });

--- a/src/routes/guilds/guild/channels.ts
+++ b/src/routes/guilds/guild/channels.ts
@@ -1,11 +1,9 @@
 import ApiRequest from '@lib/structures/api/ApiRequest';
 import ApiResponse from '@lib/structures/api/ApiResponse';
+import { canManage } from '@utils/API';
 import { flattenChannel } from '@utils/Models/ApiTransform';
 import { authenticated, ratelimit } from '@utils/util';
-import { Permissions } from 'discord.js';
 import { Route, RouteStore } from 'klasa-dashboard-hooks';
-
-const { FLAGS: { MANAGE_GUILD } } = Permissions;
 
 export default class extends Route {
 
@@ -24,8 +22,7 @@ export default class extends Route {
 		const member = await guild.members.fetch(request.auth!.user_id).catch(() => null);
 		if (!member) return response.error(400);
 
-		const canManage = member.permissions.has(MANAGE_GUILD);
-		if (!canManage) return response.error(401);
+		if (!canManage(guild, member)) return response.error(403);
 
 		return response.json(guild.channels.map(flattenChannel));
 	}

--- a/src/routes/guilds/guild/channels/channel.ts
+++ b/src/routes/guilds/guild/channels/channel.ts
@@ -1,11 +1,9 @@
 import ApiRequest from '@lib/structures/api/ApiRequest';
 import ApiResponse from '@lib/structures/api/ApiResponse';
+import { canManage } from '@utils/API';
 import { flattenChannel } from '@utils/Models/ApiTransform';
 import { authenticated, ratelimit } from '@utils/util';
-import { Permissions } from 'discord.js';
 import { Route, RouteStore } from 'klasa-dashboard-hooks';
-
-const { FLAGS: { MANAGE_GUILD } } = Permissions;
 
 export default class extends Route {
 
@@ -24,8 +22,7 @@ export default class extends Route {
 		const member = await guild.members.fetch(request.auth!.user_id).catch(() => null);
 		if (!member) return response.error(400);
 
-		const canManage = member.permissions.has(MANAGE_GUILD);
-		if (!canManage) return response.error(401);
+		if (!canManage(guild, member)) return response.error(403);
 
 		const channelID = request.params.channel;
 		const channel = guild.channels.get(channelID);

--- a/src/routes/guilds/guild/roles.ts
+++ b/src/routes/guilds/guild/roles.ts
@@ -1,11 +1,9 @@
 import ApiRequest from '@lib/structures/api/ApiRequest';
 import ApiResponse from '@lib/structures/api/ApiResponse';
+import { canManage } from '@utils/API';
 import { flattenRole } from '@utils/Models/ApiTransform';
 import { authenticated, ratelimit } from '@utils/util';
-import { Permissions } from 'discord.js';
 import { Route, RouteStore } from 'klasa-dashboard-hooks';
-
-const { FLAGS: { MANAGE_GUILD } } = Permissions;
 
 export default class extends Route {
 
@@ -24,8 +22,7 @@ export default class extends Route {
 		const member = await guild.members.fetch(request.auth!.user_id).catch(() => null);
 		if (!member) return response.error(400);
 
-		const canManage = member.permissions.has(MANAGE_GUILD);
-		if (!canManage) return response.error(401);
+		if (!canManage(guild, member)) return response.error(403);
 
 		return response.json(guild.roles.map(flattenRole));
 	}

--- a/src/routes/guilds/guild/roles/role.ts
+++ b/src/routes/guilds/guild/roles/role.ts
@@ -1,11 +1,9 @@
 import ApiRequest from '@lib/structures/api/ApiRequest';
 import ApiResponse from '@lib/structures/api/ApiResponse';
+import { canManage } from '@utils/API';
 import { flattenRole } from '@utils/Models/ApiTransform';
 import { authenticated, ratelimit } from '@utils/util';
-import { Permissions } from 'discord.js';
 import { Route, RouteStore } from 'klasa-dashboard-hooks';
-
-const { FLAGS: { MANAGE_GUILD } } = Permissions;
 
 export default class extends Route {
 
@@ -24,8 +22,7 @@ export default class extends Route {
 		const member = await guild.members.fetch(request.auth!.user_id).catch(() => null);
 		if (!member) return response.error(400);
 
-		const canManage = member.permissions.has(MANAGE_GUILD);
-		if (!canManage) return response.error(401);
+		if (!canManage(guild, member)) return response.error(403);
 
 		const roleID = request.params.role;
 		const role = guild.roles.get(roleID);


### PR DESCRIPTION
Current situation:

People with the configured "Admin" role can see the guild, but get a 401 upon accessing due to a different way of checking permission

New situation:

- People with the `MANAGE_GUILD` permission will always see the guild, regardless of whether they have the configured "Admin" role or not.
- If the person does not have the `MANAGE_GUILD` permission then we get the configured "Admin" role, if configured and check if the member has that role. If they do, they get access (barring permission nodes).