### PR TITLE
refactor: rich display class

### DIFF
--- a/src/commands/Anime/anime.ts
+++ b/src/commands/Anime/anime.ts
@@ -1,4 +1,4 @@
-import { SkyraCommand, SkyraCommandOptions } from '@lib/structures/SkyraCommand';
+import { RichDisplayCommand, RichDisplayCommandOptions } from '@lib/structures/RichDisplayCommand';
 import { UserRichDisplay } from '@lib/structures/UserRichDisplay';
 import { Kitsu } from '@lib/types/definitions/Kitsu';
 import { TOKENS } from '@root/config';
@@ -11,14 +11,13 @@ import { stringify } from 'querystring';
 
 const API_URL = `https://${TOKENS.KITSU_ID}-dsn.algolia.net/1/indexes/production_media/query`;
 
-@ApplyOptions<SkyraCommandOptions>({
+@ApplyOptions<RichDisplayCommandOptions>({
 	cooldown: 10,
 	description: language => language.tget('COMMAND_ANIME_DESCRIPTION'),
 	extendedHelp: language => language.tget('COMMAND_ANIME_EXTENDED'),
-	requiredPermissions: ['EMBED_LINKS'],
 	usage: '<animeName:string>'
 })
-export default class extends SkyraCommand {
+export default class extends RichDisplayCommand {
 
 	private readonly kTimestamp = new Timestamp('MMMM d YYYY');
 

--- a/src/commands/Anime/manga.ts
+++ b/src/commands/Anime/manga.ts
@@ -1,4 +1,4 @@
-import { SkyraCommand, SkyraCommandOptions } from '@lib/structures/SkyraCommand';
+import { RichDisplayCommand, RichDisplayCommandOptions } from '@lib/structures/RichDisplayCommand';
 import { UserRichDisplay } from '@lib/structures/UserRichDisplay';
 import { Kitsu } from '@lib/types/definitions/Kitsu';
 import { TOKENS } from '@root/config';
@@ -11,14 +11,13 @@ import { stringify } from 'querystring';
 
 const API_URL = `https://${TOKENS.KITSU_ID}-dsn.algolia.net/1/indexes/production_media/query`;
 
-@ApplyOptions<SkyraCommandOptions>({
+@ApplyOptions<RichDisplayCommandOptions>({
 	cooldown: 10,
 	description: language => language.tget('COMMAND_MANGA_DESCRIPTION'),
 	extendedHelp: language => language.tget('COMMAND_MANGA_EXTENDED'),
-	requiredPermissions: ['EMBED_LINKS'],
 	usage: '<mangaName:string>'
 })
-export default class extends SkyraCommand {
+export default class extends RichDisplayCommand {
 
 	private readonly kTimestamp = new Timestamp('MMMM d YYYY');
 

--- a/src/commands/GameIntegration/clashofclans.ts
+++ b/src/commands/GameIntegration/clashofclans.ts
@@ -1,5 +1,5 @@
 import { toTitleCase } from '@klasa/utils';
-import { SkyraCommand, SkyraCommandOptions } from '@lib/structures/SkyraCommand';
+import { RichDisplayCommand, RichDisplayCommandOptions } from '@lib/structures/RichDisplayCommand';
 import { UserRichDisplay } from '@lib/structures/UserRichDisplay';
 import { TOKENS } from '@root/config';
 import { ApplyOptions } from '@skyra/decorators';
@@ -14,18 +14,17 @@ const enum ClashOfClansFetchCategories {
 	CLANS = 'clans'
 }
 
-@ApplyOptions<SkyraCommandOptions>({
+@ApplyOptions<RichDisplayCommandOptions>({
 	aliases: ['coc'],
 	cooldown: 10,
 	description: language => language.tget('COMMAND_CLASHOFCLANS_DESCRIPTION'),
 	extendedHelp: language => language.tget('COMMAND_CLASHOFCLANS_EXTENDED'),
-	requiredPermissions: ['EMBED_LINKS'],
 	runIn: ['text'],
 	subcommands: true,
 	usage: '<player|clan:default> <query:tagOrName>',
 	usageDelim: ' '
 })
-export default class extends SkyraCommand {
+export default class extends RichDisplayCommand {
 
 	private readonly kPlayerTagRegex = /#[A-Z0-9]{3,}/;
 

--- a/src/commands/GameIntegration/ffxiv.ts
+++ b/src/commands/GameIntegration/ffxiv.ts
@@ -1,26 +1,23 @@
-import { SkyraCommand } from '@lib/structures/SkyraCommand';
+import { RichDisplayCommand, RichDisplayCommandOptions } from '@lib/structures/RichDisplayCommand';
 import { UserRichDisplay } from '@lib/structures/UserRichDisplay';
+import { ApplyOptions } from '@skyra/decorators';
 import { BrandingColors } from '@utils/constants';
 import { FFXIV } from '@utils/GameIntegration/FFXIVTypings';
 import { FFXIVClasses, FFXIV_BASE_URL, getCharacterDetails, searchCharacter, searchItem, SubCategoryEmotes } from '@utils/GameIntegration/FFXIVUtils';
 import { getColor } from '@utils/util';
 import { EmbedField, MessageEmbed } from 'discord.js';
-import { CommandStore, KlasaMessage, Language } from 'klasa';
+import { KlasaMessage, Language } from 'klasa';
 
-export default class extends SkyraCommand {
-
-	public constructor(store: CommandStore, file: string[], directory: string) {
-		super(store, file, directory, {
-			aliases: ['finalfantasy'],
-			cooldown: 10,
-			description: language => language.tget('COMMAND_FFXIV_DESCRIPTION'),
-			extendedHelp: language => language.tget('COMMAND_FFXIV_EXTENDED'),
-			requiredPermissions: ['EMBED_LINKS'],
-			subcommands: true,
-			usage: '(item|character:default) <search:...string> ',
-			usageDelim: ' '
-		});
-	}
+@ApplyOptions<RichDisplayCommandOptions>({
+	aliases: ['finalfantasy'],
+	cooldown: 10,
+	description: language => language.tget('COMMAND_FFXIV_DESCRIPTION'),
+	extendedHelp: language => language.tget('COMMAND_FFXIV_EXTENDED'),
+	subcommands: true,
+	usage: '(item|character:default) <search:...string> ',
+	usageDelim: ' '
+})
+export default class extends RichDisplayCommand {
 
 	public async character(message: KlasaMessage, [name]: [string]) {
 		const response = await message.sendEmbed(new MessageEmbed()

--- a/src/commands/GameIntegration/fortnite.ts
+++ b/src/commands/GameIntegration/fortnite.ts
@@ -1,26 +1,23 @@
-import { SkyraCommand } from '@lib/structures/SkyraCommand';
+import { RichDisplayCommand, RichDisplayCommandOptions } from '@lib/structures/RichDisplayCommand';
 import { UserRichDisplay } from '@lib/structures/UserRichDisplay';
 import { TOKENS } from '@root/config';
+import { ApplyOptions } from '@skyra/decorators';
 import { BrandingColors } from '@utils/constants';
 import { Fortnite } from '@utils/GameIntegration/Fortnite';
 import { fetch, FetchResultTypes, getColor } from '@utils/util';
 import { MessageEmbed } from 'discord.js';
-import { CommandStore, KlasaMessage } from 'klasa';
+import { KlasaMessage } from 'klasa';
 
-export default class extends SkyraCommand {
+@ApplyOptions<RichDisplayCommandOptions>({
+	cooldown: 10,
+	description: language => language.tget('COMMAND_FORTNITE_DESCRIPTION'),
+	extendedHelp: language => language.tget('COMMAND_FORTNITE_EXTENDED'),
+	usage: '<xbox|psn|pc:default> <user:...string>',
+	usageDelim: ' '
+})
+export default class extends RichDisplayCommand {
 
 	private apiBaseUrl = 'https://api.fortnitetracker.com/v1/profile/';
-
-	public constructor(store: CommandStore, file: string[], directory: string) {
-		super(store, file, directory, {
-			cooldown: 10,
-			description: language => language.tget('COMMAND_FORTNITE_DESCRIPTION'),
-			extendedHelp: language => language.tget('COMMAND_FORTNITE_EXTENDED'),
-			requiredPermissions: ['EMBED_LINKS'],
-			usage: '<xbox|psn|pc:default> <user:...string>',
-			usageDelim: ' '
-		});
-	}
 
 	public async run(message: KlasaMessage, [platform, user]: [platform, string]) {
 		const response = await message.sendEmbed(new MessageEmbed()

--- a/src/commands/GameIntegration/overwatch.ts
+++ b/src/commands/GameIntegration/overwatch.ts
@@ -1,6 +1,6 @@
-import { SkyraCommand, SkyraCommandOptions } from '@lib/structures/SkyraCommand';
+import { RichDisplayCommand, RichDisplayCommandOptions } from '@lib/structures/RichDisplayCommand';
 import { UserRichDisplay } from '@lib/structures/UserRichDisplay';
-import { OverwatchDataSet, PlatformUnion, TopHero, OverwatchStatsTypeUnion } from '@lib/types/definitions/Overwatch';
+import { OverwatchDataSet, OverwatchStatsTypeUnion, PlatformUnion, TopHero } from '@lib/types/definitions/Overwatch';
 import { LanguageKeys } from '@lib/types/Languages';
 import { ApplyOptions } from '@skyra/decorators';
 import { BrandingColors, Time } from '@utils/constants';
@@ -8,16 +8,15 @@ import { fetch, FetchResultTypes, getColor } from '@utils/util';
 import { MessageEmbed } from 'discord.js';
 import { KlasaMessage, Timestamp } from 'klasa';
 
-@ApplyOptions<SkyraCommandOptions>({
+@ApplyOptions<RichDisplayCommandOptions>({
 	aliases: ['ow'],
 	cooldown: 10,
 	description: language => language.tget('COMMAND_OVERWATCH_DESCRIPTION'),
 	extendedHelp: language => language.tget('COMMAND_OVERWATCH_EXTENDED'),
-	requiredGuildPermissions: ['EMBED_LINKS'],
 	usage: '<xbl|psn|pc:default> <player:...overwatchplayer>',
 	usageDelim: ' '
 })
-export default class OverwatchCommand extends SkyraCommand {
+export default class extends RichDisplayCommand {
 
 	private readonly kPlayTimestamp = new Timestamp('H [hours] - m [minutes]');
 	private readonly kAuthorThumbnail = 'https://cdn.skyra.pw/img/overwatch/logo.png';

--- a/src/commands/General/Chat Bot Info/help.ts
+++ b/src/commands/General/Chat Bot Info/help.ts
@@ -1,11 +1,12 @@
 import { isFunction, isNumber } from '@klasa/utils';
-import { SkyraCommand } from '@lib/structures/SkyraCommand';
+import { RichDisplayCommand, RichDisplayCommandOptions } from '@lib/structures/RichDisplayCommand';
 import { UserRichDisplay } from '@lib/structures/UserRichDisplay';
 import { GuildSettings } from '@lib/types/settings/GuildSettings';
+import { ApplyOptions } from '@skyra/decorators';
 import { BrandingColors } from '@utils/constants';
 import { getColor, noop } from '@utils/util';
 import { Collection, MessageEmbed, Permissions, TextChannel } from 'discord.js';
-import { Command, CommandStore, KlasaMessage } from 'klasa';
+import { Command, KlasaMessage } from 'klasa';
 
 const PERMISSIONS_RICHDISPLAY = new Permissions([Permissions.FLAGS.MANAGE_MESSAGES, Permissions.FLAGS.ADD_REACTIONS]);
 
@@ -23,18 +24,16 @@ function sortCommandsAlphabetically(_: Command[], __: Command[], firstCategory: 
 	return 0;
 }
 
-export default class extends SkyraCommand {
+@ApplyOptions<RichDisplayCommandOptions>({
+	aliases: ['commands', 'cmd', 'cmds'],
+	description: language => language.tget('COMMAND_HELP_DESCRIPTION'),
+	guarded: true,
+	usage: '(Command:command|page:integer|category:category)',
+	flagSupport: true
+})
+export default class extends RichDisplayCommand {
 
-	public constructor(store: CommandStore, file: string[], directory: string) {
-		super(store, file, directory, {
-			aliases: ['commands', 'cmd', 'cmds'],
-			description: language => language.tget('COMMAND_HELP_DESCRIPTION'),
-			guarded: true,
-			requiredPermissions: ['EMBED_LINKS'],
-			usage: '(Command:command|page:integer|category:category)',
-			flagSupport: true
-		});
-
+	public async init() {
 		this.createCustomResolver('command', (arg, possible, message) => {
 			if (!arg) return undefined;
 			return this.client.arguments.get('commandname')!.run(arg, possible, message);

--- a/src/commands/Google/gimage.ts
+++ b/src/commands/Google/gimage.ts
@@ -1,4 +1,4 @@
-import { SkyraCommand, SkyraCommandOptions } from '@lib/structures/SkyraCommand';
+import { RichDisplayCommand, RichDisplayCommandOptions } from '@lib/structures/RichDisplayCommand';
 import { UserRichDisplay } from '@lib/structures/UserRichDisplay';
 import { ApplyOptions } from '@skyra/decorators';
 import { BrandingColors } from '@utils/constants';
@@ -7,16 +7,15 @@ import { getColor } from '@utils/util';
 import { MessageEmbed } from 'discord.js';
 import { KlasaMessage } from 'klasa';
 
-@ApplyOptions<SkyraCommandOptions>({
+@ApplyOptions<RichDisplayCommandOptions>({
 	aliases: ['googleimage', 'img'],
 	cooldown: 10,
 	nsfw: true, // Google will return explicit results when seaching for explicit terms, even when safe-search is on
 	description: language => language.tget('COMMAND_GIMAGE_DESCRIPTION'),
 	extendedHelp: language => language.tget('COMMAND_GIMAGE_EXTENDED'),
-	requiredPermissions: ['EMBED_LINKS'],
 	usage: '<query:query>'
 })
-export default class extends SkyraCommand {
+export default class extends RichDisplayCommand {
 
 	public async init() {
 		this.createCustomResolver('query', (arg, possible, message) => this.client.arguments.get('string')!.run(

--- a/src/commands/Google/gsearch.ts
+++ b/src/commands/Google/gsearch.ts
@@ -1,4 +1,4 @@
-import { SkyraCommand, SkyraCommandOptions } from '@lib/structures/SkyraCommand';
+import { RichDisplayCommand, RichDisplayCommandOptions } from '@lib/structures/RichDisplayCommand';
 import { UserRichDisplay } from '@lib/structures/UserRichDisplay';
 import { ApplyOptions } from '@skyra/decorators';
 import { BrandingColors } from '@utils/constants';
@@ -7,15 +7,14 @@ import { getColor, parseURL } from '@utils/util';
 import { MessageEmbed } from 'discord.js';
 import { KlasaMessage } from 'klasa';
 
-@ApplyOptions<SkyraCommandOptions>({
+@ApplyOptions<RichDisplayCommandOptions>({
 	aliases: ['google', 'googlesearch', 'g', 'search'],
 	cooldown: 10,
 	description: language => language.tget('COMMAND_GSEARCH_DESCRIPTION'),
 	extendedHelp: language => language.tget('COMMAND_GSEARCH_EXTENDED'),
-	requiredPermissions: ['EMBED_LINKS'],
 	usage: '<query:query>'
 })
-export default class extends SkyraCommand {
+export default class extends RichDisplayCommand {
 
 	public async init() {
 		this.createCustomResolver('query', (arg, possible, message) => this.client.arguments.get('string')!.run(

--- a/src/commands/Management/roles.ts
+++ b/src/commands/Management/roles.ts
@@ -1,26 +1,26 @@
-import { SkyraCommand } from '@lib/structures/SkyraCommand';
+import { RichDisplayCommand, RichDisplayCommandOptions } from '@lib/structures/RichDisplayCommand';
 import { UserRichDisplay } from '@lib/structures/UserRichDisplay';
 import { Events } from '@lib/types/Enums';
 import { GuildSettings } from '@lib/types/settings/GuildSettings';
+import { ApplyOptions } from '@skyra/decorators';
 import { BrandingColors } from '@utils/constants';
 import { FuzzySearch } from '@utils/FuzzySearch';
 import { getColor } from '@utils/util';
 import { MessageEmbed, Role } from 'discord.js';
-import { CommandStore, KlasaMessage } from 'klasa';
+import { KlasaMessage } from 'klasa';
 
-export default class extends SkyraCommand {
+@ApplyOptions<RichDisplayCommandOptions>({
+	cooldown: 5,
+	description: language => language.tget('COMMAND_ROLES_DESCRIPTION'),
+	extendedHelp: language => language.tget('COMMAND_ROLES_EXTENDED'),
+	requiredGuildPermissions: ['MANAGE_ROLES'],
+	requiredPermissions: ['MANAGE_MESSAGES'],
+	runIn: ['text'],
+	usage: '(roles:rolenames)'
+})
+export default class extends RichDisplayCommand {
 
-	public constructor(store: CommandStore, file: string[], directory: string) {
-		super(store, file, directory, {
-			cooldown: 5,
-			description: language => language.tget('COMMAND_ROLES_DESCRIPTION'),
-			extendedHelp: language => language.tget('COMMAND_ROLES_EXTENDED'),
-			requiredGuildPermissions: ['MANAGE_ROLES'],
-			requiredPermissions: ['MANAGE_MESSAGES', 'EMBED_LINKS'],
-			runIn: ['text'],
-			usage: '(roles:rolenames)'
-		});
-
+	public async init() {
 		this.createCustomResolver('rolenames', async (arg, _, message) => {
 			const rolesPublic = message.guild!.settings.get(GuildSettings.Roles.Public);
 			if (!rolesPublic.length) return null;
@@ -113,7 +113,7 @@ export default class extends SkyraCommand {
 		return message.sendMessage(output.join('\n'));
 	}
 
-	public async list(message: KlasaMessage, publicRoles: readonly string[]) {
+	private async list(message: KlasaMessage, publicRoles: readonly string[]) {
 		const remove: string[] = [];
 		const roles: string[] = [];
 		for (const roleID of publicRoles) {

--- a/src/commands/Moderation/Management/history.ts
+++ b/src/commands/Moderation/Management/history.ts
@@ -1,32 +1,29 @@
 import Collection from '@discordjs/collection';
 import { chunk } from '@klasa/utils';
 import { ModerationManagerEntry } from '@lib/structures/ModerationManagerEntry';
-import { SkyraCommand } from '@lib/structures/SkyraCommand';
+import { SkyraCommand, SkyraCommandOptions } from '@lib/structures/SkyraCommand';
 import { UserRichDisplay } from '@lib/structures/UserRichDisplay';
 import { PermissionLevels } from '@lib/types/Enums';
+import { ApplyOptions } from '@skyra/decorators';
 import { BrandingColors, Moderation } from '@utils/constants';
-import { getColor } from '@utils/util';
+import { getColor, requiredPermissions } from '@utils/util';
 import { MessageEmbed } from 'discord.js';
-import { CommandStore, KlasaMessage, KlasaUser } from 'klasa';
+import { KlasaMessage, KlasaUser } from 'klasa';
 
 const COLORS = [0x80F31F, 0xA5DE0B, 0xC7C101, 0xE39E03, 0xF6780F, 0xFE5326, 0xFB3244];
 
+@ApplyOptions<SkyraCommandOptions>({
+	bucket: 2,
+	cooldown: 10,
+	description: language => language.tget('COMMAND_HISTORY_DESCRIPTION'),
+	extendedHelp: language => language.tget('COMMAND_HISTORY_EXTENDED'),
+	permissionLevel: PermissionLevels.Moderator,
+	runIn: ['text'],
+	usage: '<details|overview:default> [user:username]',
+	usageDelim: ' ',
+	subcommands: true
+})
 export default class extends SkyraCommand {
-
-	public constructor(store: CommandStore, file: string[], directory: string) {
-		super(store, file, directory, {
-			bucket: 2,
-			cooldown: 10,
-			description: language => language.tget('COMMAND_HISTORY_DESCRIPTION'),
-			extendedHelp: language => language.tget('COMMAND_HISTORY_EXTENDED'),
-			permissionLevel: PermissionLevels.Moderator,
-			requiredPermissions: ['EMBED_LINKS'],
-			runIn: ['text'],
-			usage: '<details|overview:default> [user:username]',
-			usageDelim: ' ',
-			subcommands: true
-		});
-	}
 
 	public async overview(message: KlasaMessage, [target = message.author]: [KlasaUser]) {
 		const logs = await message.guild!.moderation.fetch(target.id);
@@ -56,6 +53,7 @@ export default class extends SkyraCommand {
 			.setFooter(message.language.tget('COMMAND_HISTORY_FOOTER', warnings, mutes, kicks, bans)));
 	}
 
+	@requiredPermissions(['ADD_REACTIONS', 'EMBED_LINKS', 'MANAGE_MESSAGES', 'READ_MESSAGE_HISTORY'])
 	public async details(message: KlasaMessage, [target = message.author]: [KlasaUser]) {
 		const response = await message.sendEmbed(new MessageEmbed()
 			.setDescription(message.language.tget('SYSTEM_LOADING'))

--- a/src/commands/Moderation/Management/moderations.ts
+++ b/src/commands/Moderation/Management/moderations.ts
@@ -1,27 +1,25 @@
 import { Collection } from '@discordjs/collection';
 import { ModerationManagerEntry } from '@lib/structures/ModerationManagerEntry';
-import { SkyraCommand } from '@lib/structures/SkyraCommand';
+import { RichDisplayCommand, RichDisplayCommandOptions } from '@lib/structures/RichDisplayCommand';
 import { UserRichDisplay } from '@lib/structures/UserRichDisplay';
 import { PermissionLevels } from '@lib/types/Enums';
+import { ApplyOptions } from '@skyra/decorators';
 import { BrandingColors, Moderation } from '@utils/constants';
 import { getColor } from '@utils/util';
 import { MessageEmbed } from 'discord.js';
-import { CommandStore, KlasaMessage, KlasaUser, util } from 'klasa';
+import { KlasaMessage, KlasaUser, util } from 'klasa';
 
-export default class extends SkyraCommand {
-
-	public constructor(store: CommandStore, file: string[], directory: string) {
-		super(store, file, directory, {
-			bucket: 2,
-			cooldown: 10,
-			description: language => language.tget('COMMAND_MODERATIONS_DESCRIPTION'),
-			extendedHelp: language => language.tget('COMMAND_MODERATIONS_EXTENDED'),
-			permissionLevel: PermissionLevels.Moderator,
-			requiredPermissions: ['EMBED_LINKS', 'MANAGE_MESSAGES'],
-			runIn: ['text'],
-			usage: '<mutes|warnings|all:default> [user:username]'
-		});
-	}
+@ApplyOptions<RichDisplayCommandOptions>({
+	bucket: 2,
+	cooldown: 10,
+	description: language => language.tget('COMMAND_MODERATIONS_DESCRIPTION'),
+	extendedHelp: language => language.tget('COMMAND_MODERATIONS_EXTENDED'),
+	permissionLevel: PermissionLevels.Moderator,
+	requiredPermissions: ['MANAGE_MESSAGES'],
+	runIn: ['text'],
+	usage: '<mutes|warnings|all:default> [user:username]'
+})
+export default class extends RichDisplayCommand {
 
 	public async run(message: KlasaMessage, [action, target]: ['mutes' | 'warnings' | 'all', KlasaUser?]) {
 		const response = await message.sendEmbed(new MessageEmbed()

--- a/src/commands/Music/queue.ts
+++ b/src/commands/Music/queue.ts
@@ -1,22 +1,20 @@
 import { chunk } from '@klasa/utils';
-import { MusicCommand } from '@lib/structures/MusicCommand';
+import { Song } from '@lib/structures/music/Song';
+import { MusicCommand, MusicCommandOptions } from '@lib/structures/MusicCommand';
 import { UserRichDisplay } from '@lib/structures/UserRichDisplay';
+import { ApplyOptions } from '@skyra/decorators';
+import { BrandingColors } from '@utils/constants';
 import { getColor, showSeconds } from '@utils/util';
 import { MessageEmbed, Util } from 'discord.js';
-import { CommandStore, KlasaMessage } from 'klasa';
-import { BrandingColors } from '@utils/constants';
-import { Song } from '@lib/structures/music/Song';
+import { KlasaMessage } from 'klasa';
 
+@ApplyOptions<MusicCommandOptions>({
+	aliases: ['q'],
+	description: language => language.tget('COMMAND_QUEUE_DESCRIPTION'),
+	music: ['QUEUE_NOT_EMPTY'],
+	requiredPermissions: ['ADD_REACTIONS', 'MANAGE_MESSAGES', 'EMBED_LINKS', 'READ_MESSAGE_HISTORY']
+})
 export default class extends MusicCommand {
-
-	public constructor(store: CommandStore, file: string[], directory: string) {
-		super(store, file, directory, {
-			aliases: ['q'],
-			description: language => language.tget('COMMAND_QUEUE_DESCRIPTION'),
-			music: ['QUEUE_NOT_EMPTY'],
-			requiredPermissions: ['EMBED_LINKS']
-		});
-	}
 
 	public async run(message: KlasaMessage) {
 		const { queue, song } = message.guild!.music;

--- a/src/commands/Pokemon/flavors.ts
+++ b/src/commands/Pokemon/flavors.ts
@@ -1,6 +1,6 @@
 import { DexDetails } from '@favware/graphql-pokemon';
 import { toTitleCase } from '@klasa/utils';
-import { SkyraCommand, SkyraCommandOptions } from '@lib/structures/SkyraCommand';
+import { RichDisplayCommand, RichDisplayCommandOptions } from '@lib/structures/RichDisplayCommand';
 import { UserRichDisplay } from '@lib/structures/UserRichDisplay';
 import { ApplyOptions } from '@skyra/decorators';
 import { BrandingColors } from '@utils/constants';
@@ -8,16 +8,15 @@ import { fetchGraphQLPokemon, getPokemonFlavorTextsByFuzzy, POKEMON_EMBED_THUMBN
 import { MessageEmbed } from 'discord.js';
 import { KlasaMessage } from 'klasa';
 
-@ApplyOptions<SkyraCommandOptions>({
+@ApplyOptions<RichDisplayCommandOptions>({
 	aliases: ['flavor', 'flavour', 'flavours'],
 	cooldown: 10,
 	description: language => language.tget('COMMAND_FLAVORS_DESCRIPTION'),
 	extendedHelp: language => language.tget('COMMAND_FLAVORS_EXTENDED'),
-	requiredPermissions: ['EMBED_LINKS'],
 	usage: '<pokemon:str>',
 	flagSupport: true
 })
-export default class Flavors extends SkyraCommand {
+export default class extends RichDisplayCommand {
 
 	public async run(message: KlasaMessage, [pokemon]: [string]) {
 		const response = await message.sendEmbed(new MessageEmbed()

--- a/src/commands/Pokemon/learn.ts
+++ b/src/commands/Pokemon/learn.ts
@@ -1,6 +1,6 @@
 import { LearnsetEntry, LearnsetLevelUpMove } from '@favware/graphql-pokemon';
 import { toTitleCase } from '@klasa/utils';
-import { SkyraCommand, SkyraCommandOptions } from '@lib/structures/SkyraCommand';
+import { RichDisplayCommand, RichDisplayCommandOptions } from '@lib/structures/RichDisplayCommand';
 import { UserRichDisplay } from '@lib/structures/UserRichDisplay';
 import { ApplyOptions } from '@skyra/decorators';
 import { BrandingColors } from '@utils/constants';
@@ -8,25 +8,22 @@ import { fetchGraphQLPokemon, getPokemonLearnsetByFuzzy, POKEMON_EMBED_THUMBNAIL
 import { MessageEmbed } from 'discord.js';
 import { KlasaMessage } from 'klasa';
 
-@ApplyOptions<SkyraCommandOptions>({
+@ApplyOptions<RichDisplayCommandOptions>({
 	aliases: ['learnset', 'learnall'],
 	cooldown: 10,
 	description: language => language.tget('COMMAND_LEARN_DESCRIPTION'),
 	extendedHelp: language => language.tget('COMMAND_LEARN_EXTENDED'),
-	requiredPermissions: ['EMBED_LINKS'],
 	usage: '(generation:generation) <pokemon:string> <moves:...string> ',
 	usageDelim: ' ',
 	flagSupport: true
 })
-export default class Learn extends SkyraCommand {
+export default class extends RichDisplayCommand {
 
 	private kPokemonGenerations = new Set(['1', '2', '3', '4', '5', '6', '7', '8']);
-	// eslint-disable-next-line @typescript-eslint/no-invalid-this
-	private kClientIntegerArg = this.client.arguments.get('integer')!;
 
 	public async init() {
 		this.createCustomResolver('generation', (arg, possible, message) => {
-			if (this.kPokemonGenerations.has(arg)) return this.kClientIntegerArg.run(arg, possible, message);
+			if (this.kPokemonGenerations.has(arg)) return this.client.arguments.get('integer')!.run(arg, possible, message);
 			throw message.language.tget('COMMAND_LEARN_INVALID_GENERATION', arg);
 		});
 	}

--- a/src/commands/Pokemon/move.ts
+++ b/src/commands/Pokemon/move.ts
@@ -1,6 +1,6 @@
 import { MoveEntry } from '@favware/graphql-pokemon';
 import { toTitleCase } from '@klasa/utils';
-import { SkyraCommand, SkyraCommandOptions } from '@lib/structures/SkyraCommand';
+import { RichDisplayCommand, RichDisplayCommandOptions } from '@lib/structures/RichDisplayCommand';
 import { UserRichDisplay } from '@lib/structures/UserRichDisplay';
 import { ApplyOptions } from '@skyra/decorators';
 import { BrandingColors } from '@utils/constants';
@@ -9,14 +9,13 @@ import { getColor } from '@utils/util';
 import { MessageEmbed } from 'discord.js';
 import { KlasaMessage } from 'klasa';
 
-@ApplyOptions<SkyraCommandOptions>({
+@ApplyOptions<RichDisplayCommandOptions>({
 	cooldown: 10,
 	description: language => language.tget('COMMAND_MOVE_DESCRIPTION'),
 	extendedHelp: language => language.tget('COMMAND_MOVE_EXTENDED'),
-	requiredPermissions: ['EMBED_LINKS'],
 	usage: '<move:str>'
 })
-export default class extends SkyraCommand {
+export default class extends RichDisplayCommand {
 
 	public async run(message: KlasaMessage, [move]: [string]) {
 		const response = await message.sendEmbed(new MessageEmbed()

--- a/src/commands/Pokemon/pokedex.ts
+++ b/src/commands/Pokemon/pokedex.ts
@@ -1,6 +1,6 @@
 import { AbilitiesEntry, DexDetails, GenderEntry, StatsEntry } from '@favware/graphql-pokemon';
 import { toTitleCase } from '@klasa/utils';
-import { SkyraCommand, SkyraCommandOptions } from '@lib/structures/SkyraCommand';
+import { RichDisplayCommand, RichDisplayCommandOptions } from '@lib/structures/RichDisplayCommand';
 import { UserRichDisplay } from '@lib/structures/UserRichDisplay';
 import { ApplyOptions } from '@skyra/decorators';
 import { BrandingColors } from '@utils/constants';
@@ -17,7 +17,7 @@ enum BaseStats {
 	speed = 'SPE'
 }
 
-@ApplyOptions<SkyraCommandOptions>({
+@ApplyOptions<RichDisplayCommandOptions>({
 	aliases: ['pokemon', 'dex', 'mon', 'poke', 'dexter'],
 	cooldown: 10,
 	description: language => language.tget('COMMAND_POKEDEX_DESCRIPTION'),
@@ -26,7 +26,7 @@ enum BaseStats {
 	usage: '<pokemon:str>',
 	flagSupport: true
 })
-export default class extends SkyraCommand {
+export default class extends RichDisplayCommand {
 
 	public async run(message: KlasaMessage, [pokemon]: [string]) {
 		const response = await message.sendEmbed(new MessageEmbed()

--- a/src/commands/Pokemon/type.ts
+++ b/src/commands/Pokemon/type.ts
@@ -1,5 +1,5 @@
 import { TypeEntry, TypeMatchups, Types } from '@favware/graphql-pokemon';
-import { SkyraCommand, SkyraCommandOptions } from '@lib/structures/SkyraCommand';
+import { RichDisplayCommand, RichDisplayCommandOptions } from '@lib/structures/RichDisplayCommand';
 import { UserRichDisplay } from '@lib/structures/UserRichDisplay';
 import { ApplyOptions } from '@skyra/decorators';
 import { BrandingColors } from '@utils/constants';
@@ -8,15 +8,14 @@ import { getColor } from '@utils/util';
 import { MessageEmbed } from 'discord.js';
 import { KlasaMessage } from 'klasa';
 
-@ApplyOptions<SkyraCommandOptions>({
+@ApplyOptions<RichDisplayCommandOptions>({
 	aliases: ['matchup', 'weakness', 'advantage'],
 	cooldown: 10,
 	description: language => language.tget('COMMAND_TYPE_DESCRIPTION'),
 	extendedHelp: language => language.tget('COMMAND_TYPE_EXTENDED'),
-	requiredPermissions: ['EMBED_LINKS'],
 	usage: '<types:type{2}>'
 })
-export default class extends SkyraCommand {
+export default class extends RichDisplayCommand {
 
 	private kPokemonTypes = new Set([
 		'bug', 'dark', 'dragon', 'electric', 'fairy', 'fighting', 'fire', 'flying',

--- a/src/commands/Social/Profile Management/banner.ts
+++ b/src/commands/Social/Profile Management/banner.ts
@@ -6,7 +6,7 @@ import { RawBannerSettings } from '@lib/types/settings/raw/RawBannerSettings';
 import { UserSettings } from '@lib/types/settings/UserSettings';
 import { ApplyOptions } from '@skyra/decorators';
 import { BrandingColors, Emojis } from '@utils/constants';
-import { getColor } from '@utils/util';
+import { getColor, requiredPermissions } from '@utils/util';
 import { MessageEmbed } from 'discord.js';
 import { KlasaMessage } from 'klasa';
 
@@ -18,7 +18,7 @@ const CDN_URL = 'https://cdn.skyra.pw/img/banners/';
 	cooldown: 10,
 	description: language => language.tget('COMMAND_BANNER_DESCRIPTION'),
 	extendedHelp: language => language.tget('COMMAND_BANNER_EXTENDED'),
-	requiredPermissions: ['MANAGE_MESSAGES', 'EMBED_LINKS'],
+	requiredPermissions: ['MANAGE_MESSAGES'],
 	runIn: ['text'],
 	subcommands: true,
 	usage: '<buy|reset|set|show:default> (banner:banner)',
@@ -31,6 +31,7 @@ export default class extends SkyraCommand {
 	private readonly banners: Map<string, BannerCache> = new Map();
 	private display: UserRichDisplay | null = null;
 
+	@requiredPermissions(['EMBED_LINKS'])
 	public async buy(message: KlasaMessage, [banner]: [BannerCache]) {
 		const banners = new Set(message.author.settings.get(UserSettings.BannerList));
 		if (banners.has(banner.id)) throw message.language.tget('COMMAND_BANNER_BOUGHT', message.guild!.settings.get(GuildSettings.Prefix), banner.id);
@@ -83,6 +84,7 @@ export default class extends SkyraCommand {
 		return message.sendLocale('COMMAND_BANNER_SET', [banner.title]);
 	}
 
+	@requiredPermissions(['ADD_REACTIONS', 'EMBED_LINKS', 'MANAGE_MESSAGES', 'READ_MESSAGE_HISTORY'])
 	public async show(message: KlasaMessage) {
 		const [response] = await this.listPrompt.createPrompt(message).run(message.language.tget('COMMAND_BANNER_PROMPT'));
 		return response === 'all' ? this.buyList(message) : this.userList(message);

--- a/src/commands/Social/remindme.ts
+++ b/src/commands/Social/remindme.ts
@@ -1,10 +1,10 @@
 import { SkyraCommand, SkyraCommandOptions } from '@lib/structures/SkyraCommand';
 import { UserRichDisplay } from '@lib/structures/UserRichDisplay';
+import { ApplyOptions } from '@skyra/decorators';
 import { BrandingColors, Time } from '@utils/constants';
 import { cutText, getColor, requiredPermissions } from '@utils/util';
 import { MessageEmbed } from 'discord.js';
 import { KlasaMessage, ScheduledTask, Timestamp, util } from 'klasa';
-import { ApplyOptions } from '@skyra/decorators';
 
 const enum Actions {
 	List = 'list',

--- a/src/commands/Tags/tag.ts
+++ b/src/commands/Tags/tag.ts
@@ -9,7 +9,7 @@ import { CustomCommand, GuildSettings } from '@lib/types/settings/GuildSettings'
 import { ApplyOptions, requiresPermission } from '@skyra/decorators';
 import { parse as parseColour } from '@utils/Color';
 import { BrandingColors } from '@utils/constants';
-import { cutText, getColor } from '@utils/util';
+import { cutText, getColor, requiredPermissions } from '@utils/util';
 import { MessageEmbed } from 'discord.js';
 import { CommandOptions, KlasaMessage } from 'klasa';
 
@@ -20,7 +20,7 @@ import { CommandOptions, KlasaMessage } from 'klasa';
 	runIn: ['text'],
 	subcommands: true,
 	flagSupport: true,
-	requiredPermissions: ['EMBED_LINKS', 'MANAGE_MESSAGES'],
+	requiredPermissions: ['MANAGE_MESSAGES'],
 	usage: '<add|remove|edit|source|list|reset|show:default> (tag:tagname) [content:...string]',
 	usageDelim: ' '
 })
@@ -35,8 +35,6 @@ export default class extends SkyraCommand {
 			if (!arg) throw message.language.tget('RESOLVER_INVALID_STRING', possible.name);
 			return arg.toLowerCase();
 		});
-
-		return Promise.resolve();
 	}
 
 	@requiresPermission(PermissionLevels.Moderator, (message: KlasaMessage) => { throw message.language.tget('COMMAND_TAG_PERMISSIONLEVEL'); })
@@ -92,6 +90,7 @@ export default class extends SkyraCommand {
 		return message.sendLocale('COMMAND_TAG_EDITED', [id, cutText(content, 1000)]);
 	}
 
+	@requiredPermissions(['ADD_REACTIONS', 'EMBED_LINKS', 'MANAGE_MESSAGES', 'READ_MESSAGE_HISTORY'])
 	public async list(message: KlasaMessage) {
 		const tags = message.guild!.settings.get(GuildSettings.CustomCommands);
 		if (!tags.length) throw message.language.tget('COMMAND_TAG_LIST_EMPTY');
@@ -116,6 +115,7 @@ export default class extends SkyraCommand {
 		return response;
 	}
 
+	@requiredPermissions(['EMBED_LINKS'])
 	public show(message: KlasaMessage, [tagName]: [string]) {
 		const tags = message.guild!.settings.get(GuildSettings.CustomCommands);
 		const tag = tags.find(command => command.id === tagName);

--- a/src/commands/Tools/Dictionary/urban.ts
+++ b/src/commands/Tools/Dictionary/urban.ts
@@ -1,26 +1,23 @@
-import { SkyraCommand } from '@lib/structures/SkyraCommand';
+import { RichDisplayCommand, RichDisplayCommandOptions } from '@lib/structures/RichDisplayCommand';
 import { UserRichDisplay } from '@lib/structures/UserRichDisplay';
+import { ApplyOptions } from '@skyra/decorators';
 import { BrandingColors } from '@utils/constants';
 import { cutText, fetch, FetchResultTypes, getColor } from '@utils/util';
 import { MessageEmbed } from 'discord.js';
-import { CommandStore, KlasaMessage, Language, util } from 'klasa';
+import { KlasaMessage, Language, util } from 'klasa';
 
 const ZWS = '\u200B';
 
-export default class extends SkyraCommand {
-
-	public constructor(store: CommandStore, file: string[], directory: string) {
-		super(store, file, directory, {
-			aliases: ['ud', 'urbandictionary'],
-			cooldown: 15,
-			description: language => language.tget('COMMAND_URBAN_DESCRIPTION'),
-			extendedHelp: language => language.tget('COMMAND_URBAN_EXTENDED'),
-			nsfw: true,
-			requiredPermissions: ['EMBED_LINKS'],
-			runIn: ['text'],
-			usage: '<query:string>'
-		});
-	}
+@ApplyOptions<RichDisplayCommandOptions>({
+	aliases: ['ud', 'urbandictionary'],
+	cooldown: 15,
+	description: language => language.tget('COMMAND_URBAN_DESCRIPTION'),
+	extendedHelp: language => language.tget('COMMAND_URBAN_EXTENDED'),
+	nsfw: true,
+	runIn: ['text'],
+	usage: '<query:string>'
+})
+export default class extends RichDisplayCommand {
 
 	public async run(message: KlasaMessage, [query]: [string]) {
 		const response = await message.sendEmbed(new MessageEmbed()

--- a/src/commands/Tools/Websearch/eshop.ts
+++ b/src/commands/Tools/Websearch/eshop.ts
@@ -1,28 +1,25 @@
-import { SkyraCommand } from '@lib/structures/SkyraCommand';
+import { RichDisplayCommand, RichDisplayCommandOptions } from '@lib/structures/RichDisplayCommand';
 import { UserRichDisplay } from '@lib/structures/UserRichDisplay';
 import { TOKENS } from '@root/config';
+import { ApplyOptions } from '@skyra/decorators';
 import { BrandingColors } from '@utils/constants';
 import { cutText, fetch, FetchMethods, FetchResultTypes, getColor } from '@utils/util';
 import { MessageEmbed } from 'discord.js';
 import { decode } from 'he';
-import { CommandStore, KlasaMessage, Timestamp, util } from 'klasa';
+import { KlasaMessage, Timestamp, util } from 'klasa';
 import { stringify } from 'querystring';
 
 const API_URL = `https://${TOKENS.NINTENDO_ID}-dsn.algolia.net/1/indexes/*/queries`;
 
-export default class extends SkyraCommand {
+@ApplyOptions<RichDisplayCommandOptions>({
+	cooldown: 10,
+	description: language => language.tget('COMMAND_ESHOP_DESCRIPTION'),
+	extendedHelp: language => language.tget('COMMAND_ESHOP_EXTENDED'),
+	usage: '<gameName:string>'
+})
+export default class extends RichDisplayCommand {
 
 	private releaseDateTimestamp = new Timestamp('MMMM d YYYY');
-
-	public constructor(store: CommandStore, file: string[], directory: string) {
-		super(store, file, directory, {
-			cooldown: 10,
-			description: language => language.tget('COMMAND_ESHOP_DESCRIPTION'),
-			extendedHelp: language => language.tget('COMMAND_ESHOP_EXTENDED'),
-			requiredPermissions: ['EMBED_LINKS'],
-			usage: '<gameName:string>'
-		});
-	}
 
 	public async run(message: KlasaMessage, [gameName]: [string]) {
 		const response = await message.sendEmbed(new MessageEmbed()

--- a/src/commands/Tools/Websearch/igdb.ts
+++ b/src/commands/Tools/Websearch/igdb.ts
@@ -1,12 +1,13 @@
 import { isNumber } from '@klasa/utils';
-import { SkyraCommand } from '@lib/structures/SkyraCommand';
+import { RichDisplayCommand, RichDisplayCommandOptions } from '@lib/structures/RichDisplayCommand';
 import { UserRichDisplay } from '@lib/structures/UserRichDisplay';
 import { TOKENS } from '@root/config';
+import { ApplyOptions } from '@skyra/decorators';
 import { BrandingColors } from '@utils/constants';
 import { AgeRatingRatingEnum, Company, Game } from '@utils/External/IgdbTypes';
 import { cutText, fetch, FetchMethods, FetchResultTypes, getColor, roundNumber } from '@utils/util';
 import { MessageEmbed } from 'discord.js';
-import { CommandStore, KlasaMessage, Timestamp } from 'klasa';
+import { KlasaMessage, Timestamp } from 'klasa';
 
 const API_URL = 'https://api-v3.igdb.com/games';
 
@@ -18,20 +19,16 @@ function isIgdbCompany(company: unknown): company is Company {
 	return (company as Company).id !== undefined;
 }
 
-export default class extends SkyraCommand {
+@ApplyOptions<RichDisplayCommandOptions>({
+	cooldown: 10,
+	description: language => language.tget('COMMAND_IGDB_DESCRIPTION'),
+	extendedHelp: language => language.tget('COMMAND_IGDB_EXTENDED'),
+	usage: '<game:str>'
+})
+export default class extends RichDisplayCommand {
 
 	private releaseDateTimestamp = new Timestamp('MMMM d YYYY');
 	private urlRegex = /https?:/i;
-
-	public constructor(store: CommandStore, file: string[], directory: string) {
-		super(store, file, directory, {
-			cooldown: 10,
-			description: language => language.tget('COMMAND_IGDB_DESCRIPTION'),
-			extendedHelp: language => language.tget('COMMAND_IGDB_EXTENDED'),
-			requiredPermissions: ['EMBED_LINKS'],
-			usage: '<game:str>'
-		});
-	}
 
 	public async run(message: KlasaMessage, [game]: [string]) {
 		const response = await message.sendEmbed(new MessageEmbed()

--- a/src/commands/Tools/Websearch/itunes.ts
+++ b/src/commands/Tools/Websearch/itunes.ts
@@ -1,23 +1,20 @@
-import { SkyraCommand } from '@lib/structures/SkyraCommand';
+import { RichDisplayCommand, RichDisplayCommandOptions } from '@lib/structures/RichDisplayCommand';
 import { UserRichDisplay } from '@lib/structures/UserRichDisplay';
+import { ApplyOptions } from '@skyra/decorators';
 import { BrandingColors } from '@utils/constants';
 import { fetch, FetchResultTypes, getColor } from '@utils/util';
 import { MessageEmbed } from 'discord.js';
-import { CommandStore, KlasaMessage, Timestamp } from 'klasa';
+import { KlasaMessage, Timestamp } from 'klasa';
 
-export default class extends SkyraCommand {
+@ApplyOptions<RichDisplayCommandOptions>({
+	cooldown: 10,
+	description: language => language.tget('COMMAND_ITUNES_DESCRIPTION'),
+	extendedHelp: language => language.tget('COMMAND_ITUNES_EXTENDED'),
+	usage: '<song:str>'
+})
+export default class extends RichDisplayCommand {
 
 	private releaseDateTimestamp = new Timestamp('MMMM d YYYY');
-
-	public constructor(store: CommandStore, file: string[], directory: string) {
-		super(store, file, directory, {
-			cooldown: 10,
-			description: language => language.tget('COMMAND_ITUNES_DESCRIPTION'),
-			extendedHelp: language => language.tget('COMMAND_ITUNES_EXTENDED'),
-			requiredPermissions: ['EMBED_LINKS'],
-			usage: '<song:str>'
-		});
-	}
 
 	public async run(message: KlasaMessage, [song]: [string]) {
 		const response = await message.sendEmbed(new MessageEmbed()

--- a/src/commands/Tools/Websearch/movies.ts
+++ b/src/commands/Tools/Websearch/movies.ts
@@ -1,27 +1,24 @@
-import { SkyraCommand } from '@lib/structures/SkyraCommand';
+import { RichDisplayCommand, RichDisplayCommandOptions } from '@lib/structures/RichDisplayCommand';
 import { UserRichDisplay } from '@lib/structures/UserRichDisplay';
 import { Tmdb } from '@lib/types/definitions/Tmdb';
 import { TOKENS } from '@root/config';
+import { ApplyOptions } from '@skyra/decorators';
 import { BrandingColors } from '@utils/constants';
 import { cutText, fetch, FetchResultTypes, getColor } from '@utils/util';
 import { MessageEmbed } from 'discord.js';
-import { CommandStore, KlasaMessage, Timestamp } from 'klasa';
+import { KlasaMessage, Timestamp } from 'klasa';
 
-export default class extends SkyraCommand {
+@ApplyOptions<RichDisplayCommandOptions>({
+	aliases: ['movie', 'tmdb'],
+	cooldown: 10,
+	description: language => language.tget('COMMAND_MOVIES_DESCRIPTION'),
+	extendedHelp: language => language.tget('COMMAND_MOVIES_EXTENDED'),
+	usage: '<movie:str> [year:str]',
+	usageDelim: 'y:'
+})
+export default class extends RichDisplayCommand {
 
 	private releaseDateTimestamp = new Timestamp('MMMM d YYYY');
-
-	public constructor(store: CommandStore, file: string[], directory: string) {
-		super(store, file, directory, {
-			aliases: ['movie', 'tmdb'],
-			cooldown: 10,
-			description: language => language.tget('COMMAND_MOVIES_DESCRIPTION'),
-			extendedHelp: language => language.tget('COMMAND_MOVIES_EXTENDED'),
-			requiredPermissions: ['EMBED_LINKS'],
-			usage: '<movie:str> [year:str]',
-			usageDelim: 'y:'
-		});
-	}
 
 	public async run(message: KlasaMessage, [movie, year]: [string, string?]) {
 		const response = await message.sendEmbed(new MessageEmbed()

--- a/src/commands/Tools/Websearch/shows.ts
+++ b/src/commands/Tools/Websearch/shows.ts
@@ -1,27 +1,24 @@
-import { SkyraCommand } from '@lib/structures/SkyraCommand';
+import { RichDisplayCommand, RichDisplayCommandOptions } from '@lib/structures/RichDisplayCommand';
 import { UserRichDisplay } from '@lib/structures/UserRichDisplay';
 import { Tmdb } from '@lib/types/definitions/Tmdb';
 import { TOKENS } from '@root/config';
+import { ApplyOptions } from '@skyra/decorators';
 import { BrandingColors } from '@utils/constants';
 import { cutText, fetch, FetchResultTypes, getColor } from '@utils/util';
 import { MessageEmbed } from 'discord.js';
-import { CommandStore, KlasaMessage, Timestamp } from 'klasa';
+import { KlasaMessage, Timestamp } from 'klasa';
 
-export default class extends SkyraCommand {
+@ApplyOptions<RichDisplayCommandOptions>({
+	aliases: ['show', 'tvdb', 'tv'],
+	cooldown: 10,
+	description: language => language.tget('COMMAND_SHOWS_DESCRIPTION'),
+	extendedHelp: language => language.tget('COMMAND_SHOWS_EXTENDED'),
+	usage: '<show:str> [year:str]',
+	usageDelim: 'y:'
+})
+export default class extends RichDisplayCommand {
 
 	private releaseDateTimestamp = new Timestamp('MMMM d YYYY');
-
-	public constructor(store: CommandStore, file: string[], directory: string) {
-		super(store, file, directory, {
-			aliases: ['show', 'tvdb', 'tv'],
-			cooldown: 10,
-			description: language => language.tget('COMMAND_SHOWS_DESCRIPTION'),
-			extendedHelp: language => language.tget('COMMAND_SHOWS_EXTENDED'),
-			requiredPermissions: ['EMBED_LINKS'],
-			usage: '<show:str> [year:str]',
-			usageDelim: 'y:'
-		});
-	}
 
 	public async run(message: KlasaMessage, [show, year]: [string, string?]) {
 		const response = await message.sendEmbed(new MessageEmbed()

--- a/src/commands/Tools/emotes.ts
+++ b/src/commands/Tools/emotes.ts
@@ -1,23 +1,20 @@
 import { chunk } from '@klasa/utils';
-import { SkyraCommand } from '@lib/structures/SkyraCommand';
+import { RichDisplayCommand, RichDisplayCommandOptions } from '@lib/structures/RichDisplayCommand';
 import { UserRichDisplay } from '@lib/structures/UserRichDisplay';
+import { ApplyOptions } from '@skyra/decorators';
 import { BrandingColors } from '@utils/constants';
 import { getColor } from '@utils/util';
 import { MessageEmbed } from 'discord.js';
-import { CommandStore, KlasaMessage } from 'klasa';
+import { KlasaMessage } from 'klasa';
 
-export default class extends SkyraCommand {
-
-	public constructor(store: CommandStore, file: string[], directory: string) {
-		super(store, file, directory, {
-			aliases: ['emojis'],
-			cooldown: 10,
-			description: language => language.tget('COMMAND_EMOTES_DESCRIPTION'),
-			extendedHelp: language => language.tget('COMMAND_EMOTES_EXTENDED'),
-			requiredPermissions: ['EMBED_LINKS'],
-			runIn: ['text']
-		});
-	}
+@ApplyOptions<RichDisplayCommandOptions>({
+	aliases: ['emojis'],
+	cooldown: 10,
+	description: language => language.tget('COMMAND_EMOTES_DESCRIPTION'),
+	extendedHelp: language => language.tget('COMMAND_EMOTES_EXTENDED'),
+	runIn: ['text']
+})
+export default class extends RichDisplayCommand {
 
 	public async run(message: KlasaMessage) {
 		const response = await message.sendEmbed(new MessageEmbed()

--- a/src/commands/Tools/topinvites.ts
+++ b/src/commands/Tools/topinvites.ts
@@ -1,4 +1,4 @@
-import { SkyraCommand, SkyraCommandOptions } from '@lib/structures/SkyraCommand';
+import { RichDisplayCommand, RichDisplayCommandOptions } from '@lib/structures/RichDisplayCommand';
 import { UserRichDisplay } from '@lib/structures/UserRichDisplay';
 import { ApplyOptions } from '@skyra/decorators';
 import { BrandingColors, Emojis } from '@utils/constants';
@@ -6,16 +6,15 @@ import { getColor } from '@utils/util';
 import { Invite, MessageEmbed } from 'discord.js';
 import { KlasaMessage, Timestamp } from 'klasa';
 
-@ApplyOptions<SkyraCommandOptions>({
+@ApplyOptions<RichDisplayCommandOptions>({
 	aliases: ['topinvs'],
 	cooldown: 10,
 	description: language => language.tget('COMMAND_TOPINVITES_DESCRIPTION'),
 	extendedHelp: language => language.tget('COMMAND_TOPINVITES_EXTENDED'),
 	requiredGuildPermissions: ['MANAGE_GUILD'],
-	requiredPermissions: ['EMBED_LINKS'],
 	runIn: ['text']
 })
-export default class extends SkyraCommand {
+export default class extends RichDisplayCommand {
 
 	private inviteTimestamp = new Timestamp('YYYY/MM/DD HH:mm');
 

--- a/src/commands/Twitch/twitchsubscription.ts
+++ b/src/commands/Twitch/twitchsubscription.ts
@@ -8,7 +8,7 @@ import { GuildSettings, NotificationsStreamsTwitchEventStatus, NotificationsStre
 import { ApplyOptions } from '@skyra/decorators';
 import { BrandingColors } from '@utils/constants';
 import { TwitchHooksAction } from '@utils/Notifications/Twitch';
-import { getColor } from '@utils/util';
+import { getColor, requiredPermissions } from '@utils/util';
 import { MessageEmbed, TextChannel } from 'discord.js';
 import { KlasaMessage } from 'klasa';
 
@@ -221,6 +221,7 @@ export default class extends SkyraCommand {
 		return message.sendLocale('COMMAND_TWITCHSUBSCRIPTION_RESET_CHANNEL_SUCCESS', [streamer.display_name, entries]);
 	}
 
+	@requiredPermissions(['ADD_REACTIONS', 'EMBED_LINKS', 'MANAGE_MESSAGES', 'READ_MESSAGE_HISTORY'])
 	public async show(message: KlasaMessage, [streamer]: [Streamer?]) {
 		// Create the response message.
 		const response = await message.sendEmbed(new MessageEmbed()

--- a/src/lib/structures/RichDisplayCommand.ts
+++ b/src/lib/structures/RichDisplayCommand.ts
@@ -1,0 +1,31 @@
+import { PermissionResolvable } from 'discord.js';
+import { CommandStore, KlasaMessage } from 'klasa';
+import { SkyraCommand, SkyraCommandOptions } from './SkyraCommand';
+
+export abstract class RichDisplayCommand extends SkyraCommand {
+
+	public constructor(store: CommandStore, file: string[], directory: string, options: SkyraCommandOptions = {}) {
+		super(
+			store, file, directory,
+			{
+				// Merge in all given options
+				...options,
+				// Add all requiredPermissions set in the command, along with the permissions required for UserRichDisplay
+				requiredPermissions: [
+					...options.requiredPermissions as PermissionResolvable[], 'ADD_REACTIONS', 'MANAGE_MESSAGES', 'EMBED_LINKS', 'READ_MESSAGE_HISTORY'
+				]
+			}
+		);
+	}
+
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	public run(message: KlasaMessage, _params: any[]): any { return message; }
+
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	public inhibit(_message: KlasaMessage): Promise<boolean> | boolean {
+		return false;
+	}
+
+}
+
+export type RichDisplayCommandOptions = SkyraCommandOptions;


### PR DESCRIPTION
This introduces the `RichDisplayCommand` and `RichDisplayCommandOptions` (currently just an alias of `SkyraCommandOptions` but made this way to be scalable in case we need to add options in the future) which sets the correct required permissions for when using `UserRichDisplay` in a command without having to do so for every command individually.