### PR TITLE
refactor(pokemon): new data & better querying

### DIFF
--- a/.gqlconfig
+++ b/.gqlconfig
@@ -1,14 +1,14 @@
 /* .gqlconfig */
 {
   schema: {
-    files: "node_modules/@favware/graphql-pokemon/generated/ts/graphql-pokemon.graphql"
+    files: "node_modules/@favware/graphql-pokemon/generated/ts/graphql-pokemon.graphql",
   },
   query: {
-    files: [ /* define file paths which you'd like the gql parser to watch and give autocomplete suggestions for */
+    files: [
       {
-        match: 'src/lib/util/*.ts', // match multiple extensions
-        parser: ['EmbeddedQueryParser', { startTag: '/* GraphQL */ `', endTag: '`' }], // parse any query inside gql template literal
-      },
+		match: { include: 'src/lib/util/Pokemon.ts' },
+		parser: [ 'EmbeddedQueryParser', { startTag: 'gql`', endTag: '`' } ],
+      }
     ],
   },
-}	
+}

--- a/docker/bash-skyra.sh
+++ b/docker/bash-skyra.sh
@@ -48,6 +48,7 @@ logs) docker-compose -p skyra -f ${CURRENT_DIR}/docker-compose.yml logs ${@:2:99
 tail) docker-compose -p skyra -f ${CURRENT_DIR}/docker-compose.yml logs -f ${@:2:99} ;;
 push) docker push ${@:2:99} ;;
 remove) docker-compose -p skyra -f ${CURRENT_DIR}/docker-compose.yml rm -fv ${@:2:99} ;;
+update) docker-compose -p skyra -f ${CURRENT_DIR}/docker-compose.yml pull ${@:2:99} && docker-compose -p skyra -f ${CURRENT_DIR}/docker-compose.yml up -d --force-recreate ${@:2:99} ;;
 removeall) removeAllContainers ;;
 *) help ;;
 esac

--- a/docker/ps-skyra.ps1
+++ b/docker/ps-skyra.ps1
@@ -44,6 +44,7 @@ function Step-Run {
 			tail { docker-compose -p skyra -f "$($PSScriptRoot)\docker-compose.yml" logs -f $service }
 			push { docker push $service }
 			remove { docker-compose -p skyra -f "$($PSScriptRoot)\docker-compose.yml" rm -fv $service }
+			update { docker-compose -p skyra -f "$($PSScriptRoot)\docker-compose.yml" pull $service; docker-compose -p skyra -f "$($PSScriptRoot)\docker-compose.yml" up -d --force-recreate $service }
 			removeall { Remove-All-Containers }
 			default { Show-Help }
 		}

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
 	},
 	"devDependencies": {
 		"@discordjs/collection": "^0.1.5",
-		"@favware/graphql-pokemon": "^4.0.3",
+		"@favware/graphql-pokemon": "^4.0.4",
 		"@playlyfe/gql": "^2.6.2",
 		"@types/backoff": "^2.5.1",
 		"@types/diff": "^4.0.2",

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -2044,7 +2044,8 @@ export default class extends Language {
 			explainedUsage: [
 				['pokemon', 'The Pokémon for which you want to find data']
 			],
-			examples: ['dragonite', 'pikachu', 'pikachu --shiny']
+			examples: ['dragonite', 'pikachu', 'pikachu --shiny'],
+			reminder: 'If there are any "Other forme(s)" on the optional fourth page, those can be requested as well. Cosmetic Formes on that page list purely cosmetic changes and these do not have seperate entries in the Pokédex.'
 		}),
 		COMMAND_POKEDEX_EMBED_DATA: {
 			TYPES: 'Type(s)',
@@ -2055,12 +2056,14 @@ export default class extends Language {
 			HEIGHT: 'Height',
 			WEIGHT: 'Weight',
 			EGG_GROUPS: 'Egg group(s)',
-			OTHER_FORMES: 'Other forme(s)',
 			EVOLUTIONARY_LINE: 'Evolutionary line',
 			BASE_STATS: 'Base stats',
 			BASE_STATS_TOTAL: 'BST',
 			FLAVOUR_TEXT: 'Pokdex entry',
-			EXTERNAL_RESOURCES: 'External resources'
+			EXTERNAL_RESOURCES: 'External resources',
+			OTHER_FORMES_TITLE: 'Other forme(s)',
+			COSMETIC_FORMES_TITLE: 'Cosmetic Formes',
+			FORMES_LIST: formes => this.list(formes, 'and')
 		},
 		COMMAND_POKEDEX_QUERY_FAIL: pokemon => `I am sorry, but that query failed. Are you sure \`${pokemon}\` is actually a Pokémon?`,
 		COMMAND_TYPE_DESCRIPTION: 'Gives the type matchups for one or two Pokémon types',

--- a/src/languages/es-ES.ts
+++ b/src/languages/es-ES.ts
@@ -2053,7 +2053,8 @@ export default class extends Language {
 			explainedUsage: [
 				['Pokémon', 'El Pokémon para el que quieres encontrar datos']
 			],
-			examples: ['dragonite', 'pikachu']
+			examples: ['dragonite', 'pikachu'],
+			reminder: 'Si hay algún "Otro (s) formulario (s)" en la cuarta página opcional, también se pueden solicitar. Las formas cosméticas en esa página enumeran cambios puramente cosméticos y estos no tienen entradas separadas en la Pokédex.'
 		}),
 		COMMAND_POKEDEX_EMBED_DATA: {
 			TYPES: 'Tipo(s)',
@@ -2064,12 +2065,14 @@ export default class extends Language {
 			HEIGHT: 'Altura',
 			WEIGHT: 'Peso',
 			EGG_GROUPS: 'Grupo (s) de huevo',
-			OTHER_FORMES: 'Otras formas',
 			EVOLUTIONARY_LINE: 'Línea evolutiva',
 			BASE_STATS: 'Puntos de base',
 			BASE_STATS_TOTAL: 'TDPB',
 			FLAVOUR_TEXT: 'Entrada de Pokédex',
-			EXTERNAL_RESOURCES: 'Recursos externos'
+			EXTERNAL_RESOURCES: 'Recursos externos',
+			OTHER_FORMES_TITLE: 'Otras formas',
+			COSMETIC_FORMES_TITLE: 'Formas cosméticas',
+			FORMES_LIST: formes => this.list(formes, 'y')
 		},
 		COMMAND_POKEDEX_QUERY_FAIL: pokemon => `Lo siento, pero esa consulta falló. ¿Estás seguro de que \`${pokemon}\` es en realidad un Pokémon?`,
 		COMMAND_TYPE_DESCRIPTION: 'Da los emparejamientos de tipos para uno o dos tipos de Pokémon.',

--- a/src/lib/types/Languages.d.ts
+++ b/src/lib/types/Languages.d.ts
@@ -279,12 +279,14 @@ export interface LanguageKeys {
 		HEIGHT: string;
 		WEIGHT: string;
 		EGG_GROUPS: string;
-		OTHER_FORMES: string;
 		EVOLUTIONARY_LINE: string;
 		BASE_STATS: string;
 		BASE_STATS_TOTAL: string;
 		FLAVOUR_TEXT: string;
 		EXTERNAL_RESOURCES: string;
+		OTHER_FORMES_TITLE: string;
+		COSMETIC_FORMES_TITLE: string;
+		FORMES_LIST: (formes: readonly string[]) => string;
 	};
 	COMMAND_POKEDEX_QUERY_FAIL: (pokemon: string) => string;
 	COMMAND_TYPE_DESCRIPTION: string;

--- a/src/lib/util/Pokemon.ts
+++ b/src/lib/util/Pokemon.ts
@@ -1,26 +1,25 @@
 import { Query, QueryGetAbilityDetailsByFuzzyArgs, QueryGetItemDetailsByFuzzyArgs, QueryGetMoveDetailsByFuzzyArgs, QueryGetPokemonDetailsByFuzzyArgs, QueryGetPokemonLearnsetByFuzzyArgs, QueryGetTypeMatchupArgs } from '@favware/graphql-pokemon';
 import { ENABLE_LOCAL_POKEDEX } from '@root/config';
-import { fetch, FetchMethods, FetchResultTypes } from './util';
+import { fetch, FetchMethods, FetchResultTypes, gql } from './util';
 
-const AbilityFragment = /* GraphQL */ `
-fragment ability on AbilityEntry {
-    desc
-    shortDesc
-    name
-    bulbapediaPage
-    serebiiPage
-    smogonPage
+const FlavorsFrament = gql`
+fragment flavors on FlavorEntry {
+  game
+  flavor
 }`;
 
-const AbilitiesFragment = /* GraphQL */ `
+export const getPokemonDetailsByFuzzy = gql`
+
+${FlavorsFrament}
+
 fragment abilities on AbilitiesEntry {
     first
+	
     second
     hidden
     special
-}`;
+}
 
-const StatsFragment = /* GraphQL */ `
 fragment stats on StatsEntry {
     hp
     attack
@@ -28,33 +27,12 @@ fragment stats on StatsEntry {
     specialattack
     specialdefense
     speed
-}`;
+}
 
-const GendersFragment = /* GraphQL */ `
 fragment genders on GenderEntry {
   male
   female
-}`;
-
-const FlavorsFrament = /* GraphQL */ `
-fragment flavors on FlavorEntry {
-  game
-  flavor
-}`;
-
-const FlavorTextFragment = /* GraphQL */ `
-${FlavorsFrament}
-fragment flavortexts on DexDetails {
-    flavorTexts {
-        ...flavors
-    }
-}`;
-
-const DexDetailsFragment = /* GraphQL */ `
-${AbilitiesFragment}
-${StatsFragment}
-${GendersFragment}
-${FlavorsFrament}
+}
 
 fragment dexdetails on DexDetails {
     num
@@ -76,6 +54,7 @@ fragment dexdetails on DexDetails {
     height
     weight
     otherFormes
+	cosmeticFormes
     sprite
     shinySprite
     smogonTier
@@ -85,17 +64,12 @@ fragment dexdetails on DexDetails {
     flavorTexts {
         ...flavors
     }
-}`;
+}
 
-const EvolutionsDataFragment = /* GraphQL */ `
 fragment evolutionsData on DexDetails {
     species
     evolutionLevel
-}`;
-
-const EvolutionsFragment = /* GraphQL */ `
-${DexDetailsFragment}
-${EvolutionsDataFragment}
+}
 
 fragment evolutions on DexDetails {
     evolutions {
@@ -110,9 +84,55 @@ fragment evolutions on DexDetails {
           ...evolutionsData
         }
       }
+}
+
+query getPokemonDetails ($pokemon: String!)  {
+	getPokemonDetailsByFuzzy(pokemon: $pokemon skip: 0 take: 1 reverse: true) {
+        ...dexdetails
+        ...evolutions
+    }
 }`;
 
-const ItemsFragment = /* GraphQL */ `
+export const getPokemonFlavorTextsByFuzzy = gql`
+
+${FlavorsFrament}
+
+fragment flavortexts on DexDetails {
+    flavorTexts {
+        ...flavors
+    }
+}
+
+query getPokemonFlavors ($pokemon: String!) {
+    getPokemonDetailsByFuzzy(pokemon: $pokemon skip: 0 reverse: true) {
+        sprite
+		shinySprite
+		num
+		species
+		color
+        ...flavortexts
+    }
+}`;
+
+export const getAbilityDetailsByFuzzy = gql`
+
+fragment ability on AbilityEntry {
+    desc
+    shortDesc
+    name
+    bulbapediaPage
+    serebiiPage
+    smogonPage
+}
+
+query getAbilityDetails ($ability: String!) {
+  getAbilityDetailsByFuzzy(ability: $ability skip: 0 take: 1 ) {
+    ...ability
+  }
+}`;
+
+export const getItemDetailsByFuzzy = gql`
+
 fragment items on ItemEntry {
     desc
     name
@@ -122,24 +142,25 @@ fragment items on ItemEntry {
     sprite
     isNonstandard
     generationIntroduced
+}
+
+query getItemDetails ($item: String!) {
+    getItemDetailsByFuzzy(item: $item skip: 0 take: 1) {
+        ...items
+    }
 }`;
 
-const LearnsetLevelupMoveFragment = /* GraphQL */ `
+export const getPokemonLearnsetByFuzzy = gql`
+
 fragment learnsetLevelupMove on LearnsetLevelUpMove {
     name
     generation
     level
-}`;
-
-const LearnsetMoveFragment = /* GraphQL */ `
+}
 fragment learnsetMove on LearnsetMove {
     name
     generation
-}`;
-
-const LearnsetFragment = /* GraphQL */ `
-${LearnsetLevelupMoveFragment}
-${LearnsetMoveFragment}
+}
 
 fragment learnset on LearnsetEntry {
     num
@@ -168,9 +189,16 @@ fragment learnset on LearnsetEntry {
     dreamworldMoves {
         ...learnsetMove
     }
+}
+
+query getLearnsetDetails ($pokemon: String! $moves: [String!]! $generation: Int) {
+    getPokemonLearnsetByFuzzy(pokemon: $pokemon moves: $moves generation: $generation) {
+      ...learnset
+    }
 }`;
 
-const MoveFragment = /* GraphQL */ `
+export const getMoveDetailsByFuzzy = gql`
+
 fragment moves on MoveEntry {
     name
     shortDesc
@@ -189,9 +217,16 @@ fragment moves on MoveEntry {
     isZ
     isGMax
     desc
+}
+
+query getMoveDetails ($move: String!) {
+  getMoveDetailsByFuzzy(move: $move, skip: 0, take: 1) {
+    ...moves
+  }
 }`;
 
-const TypeEntryFragment = /* GraphQL */ `
+export const getTypeMatchup = gql`
+
 fragment typeEntry on TypeEntry {
     doubleEffectiveTypes
     effectiveTypes
@@ -199,10 +234,7 @@ fragment typeEntry on TypeEntry {
     resistedTypes
     doubleResistedTypes
     effectlessTypes
-}`;
-
-const TypeMatchupFragment = /* GraphQL */ `
-${TypeEntryFragment}
+}
 
 fragment typesMatchups on TypeMatchups {
     attacking {
@@ -211,71 +243,9 @@ fragment typesMatchups on TypeMatchups {
     defending {
       ...typeEntry
     }
-}`;
+}
 
-export const getPokemonDetailsByFuzzy = /* GraphQL */ `
-${EvolutionsFragment}
-query($pokemon: String!)  {
-	getPokemonDetailsByFuzzy(pokemon: $pokemon skip: 0 take: 1 reverse: true) {
-        ...dexdetails
-        ...evolutions
-    }
-}`;
-
-export const getPokemonFlavorTextsByFuzzy = /* GraphQL */ `
-${FlavorTextFragment}
-
-query($pokemon: String!) {
-    getPokemonDetailsByFuzzy(pokemon: $pokemon skip: 0 reverse: true) {
-        sprite
-		shinySprite
-		num
-		species
-		color
-        ...flavortexts
-    }
-}`;
-
-export const getAbilityDetailsByFuzzy = /* GraphQL */ `
-${AbilityFragment}
-
-query($ability: String!) {
-  getAbilityDetailsByFuzzy(ability: $ability skip: 0 take: 1 ) {
-    ...ability
-  }
-}`;
-
-export const getItemDetailsByFuzzy = /* GraphQL */ `
-${ItemsFragment}
-
-query($item: String!) {
-    getItemDetailsByFuzzy(item: $item skip: 0 take: 1) {
-        ...items
-    }
-}`;
-
-export const getPokemonLearnsetByFuzzy = /* GraphQL */`
-${LearnsetFragment}
-
-query($pokemon: String! $moves: [String!]! $generation: Int) {
-    getPokemonLearnsetByFuzzy(pokemon: $pokemon moves: $moves generation: $generation) {
-      ...learnset
-    }
-}`;
-
-export const getMoveDetailsByFuzzy = /* GraphQL */ `
-${MoveFragment}
-
-query($move: String!) {
-  getMoveDetailsByFuzzy(move: $move, skip: 0, take: 1) {
-    ...moves
-  }
-}`;
-
-export const getTypeMatchup = /* GraphQL */`
-${TypeMatchupFragment}
-
-query($types: [Types!]!) {
+query getTypeMatchups ($types: [Types!]!) {
   getTypeMatchup(types: $types) {
     ...typesMatchups
   }

--- a/src/lib/util/util.ts
+++ b/src/lib/util/util.ts
@@ -693,6 +693,19 @@ export function getHighestRole(guild: KlasaGuild, roles: readonly string[]) {
 }
 
 /**
+ * Fake GraphQL tag that just returns everything passed in as a single combined string
+ * @remark used to trick the GraphQL parser into treating some code as GraphQL parseable data for syntax checking
+ * @param gqlData data to pass off as GraphQL code
+ */
+export function gql(...args: any[]): string {
+	return args[0].reduce((acc: string, str: string, idx: number) => {
+		acc += str;
+		if (Reflect.has(args, idx + 1)) acc += args[idx + 1];
+		return acc;
+	}, '');
+}
+
+/**
  * Checks whether a channel is either a guild text channel, guild news channel or guild store channel
  * This ensures the channel is *not* a DM / group DM / unknown / something else
  * @param channel The channel to validate

--- a/tests/lib/util/util.test.ts
+++ b/tests/lib/util/util.test.ts
@@ -420,4 +420,38 @@ describe('Utils', () => {
 		});
 	});
 
+	describe('gql', () => {
+		test('GIVEN gql tag THEN returns unmodified code', () => {
+			expect(utils.gql`
+			fragment one on two {
+				one
+				two
+			}`).toEqual(`
+			fragment one on two {
+				one
+				two
+			}`);
+		});
+
+		test('GIVEN nested gql tag THEN returns unmodified code', () => {
+			const nestableCode = utils.gql`
+				fragment two on three {
+					three
+					four
+				}`;
+
+			expect(utils.gql`
+			${nestableCode}
+			fragment one on two {
+				one
+				two
+			}`).toEqual(`
+			${nestableCode}
+			fragment one on two {
+				one
+				two
+			}`);
+		});
+	});
+
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -270,7 +270,7 @@
   resolved "https://registry.yarnpkg.com/@discordjs/collection/-/collection-0.1.5.tgz#1781c620b4c88d619bd0373a1548e5a6025e3d3a"
   integrity sha512-CU1q0UXQUpFNzNB7gufgoisDHP7n+T3tkqTsp3MNUkVJ5+hS3BCvME8uCXAUFlz+6T2FbTCu75A+yQ7HMKqRKw==
 
-"@favware/graphql-pokemon@^4.0.3":
+"@favware/graphql-pokemon@^4.0.4":
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/@favware/graphql-pokemon/-/graphql-pokemon-4.0.4.tgz#aa3e7aab6de9df8bc2627f709c1a13381cbba8ca"
   integrity sha512-HLtacNft1Lbsr4CO5oZTgt5sao5tHz+E79dbe8nM3bJnWG3IHFWR3Fk1pwHvECfwi4rIAf9puX43sRNG1NyWww==


### PR DESCRIPTION
# Better Querying

Finally found out what was making the GraphQL Schema integration not work. Apparently the parser doesn't like the comment based style of declaring the start of a GraphQL code block. For this purpose there is actually the lib `fake-tag` but since it is untyped I just implemented that code in utils instead. The `gql` tag tricks the parser into thinking Apollo's `graphql-tag` library is being used and so it now gives proper type checking for the GraphQL queries:

![image](https://user-images.githubusercontent.com/4019718/84603096-0a51aa00-ae8c-11ea-8c36-96ceedfabe08.png)

# New Data

I recently added `cosmeticFormes` to the API, which distinguish themselves from `otherFormes` in that `otherFormes` are themselves also entries in the database (for example `venusaurmega` is a form of `venusaur`) while `cosmeticFormes` are purely that, cosmetic. For example a different colour while not changing anything else for the pokémon. This is also clarified in the reminder help message.

# Other stuff

Added the `update` command to the docker control files.