### PR TITLE
refactor(user-entity): make profile and cooldowns not eager

### DIFF
--- a/src/lib/orm/entities/UserEntity.ts
+++ b/src/lib/orm/entities/UserEntity.ts
@@ -32,10 +32,10 @@ export class UserEntity extends BaseEntity {
 	@OneToOne(() => RpgUserEntity, rpgUsers => rpgUsers.user)
 	public game?: RpgUserEntity;
 
-	@OneToOne(() => UserProfileEntity, profile => profile.user, { cascade: true, eager: true })
+	@OneToOne(() => UserProfileEntity, profile => profile.user, { cascade: true })
 	public profile?: UserProfileEntity;
 
-	@OneToOne(() => UserCooldownEntity, cooldown => cooldown.user, { cascade: true, eager: true })
+	@OneToOne(() => UserCooldownEntity, cooldown => cooldown.user, { cascade: true })
 	public cooldowns?: UserCooldownEntity;
 
 	@ManyToMany(() => UserEntity, { cascade: true })

--- a/src/lib/orm/repositories/UserRepository.ts
+++ b/src/lib/orm/repositories/UserRepository.ts
@@ -20,7 +20,7 @@ export class UserRepository extends Repository<UserEntity> {
 	}
 
 	public async ensureProfile(id: string, options: FindOneOptions<UserEntity> = {}) {
-		const user = await this.ensure(id, options);
+		const user = await this.ensure(id, { ...options, relations: ['profile'] });
 		if (!user.profile) {
 			user.profile = new UserProfileEntity();
 			user.profile.user = user;
@@ -30,7 +30,7 @@ export class UserRepository extends Repository<UserEntity> {
 	}
 
 	public async ensureCooldowns(id: string, options: FindOneOptions<UserEntity> = {}) {
-		const user = await this.ensure(id, options);
+		const user = await this.ensure(id, { ...options, relations: ['cooldowns'] });
 		if (!user.cooldowns) {
 			user.cooldowns = new UserCooldownEntity();
 			user.cooldowns.user = user;
@@ -40,7 +40,7 @@ export class UserRepository extends Repository<UserEntity> {
 	}
 
 	public async ensureProfileAndCooldowns(id: string, options: FindOneOptions<UserEntity> = {}) {
-		const user = await this.ensure(id, options);
+		const user = await this.ensure(id, { ...options, relations: ['profile', 'cooldowns'] });
 		if (!user.profile) {
 			user.profile = new UserProfileEntity();
 			user.profile.user = user;


### PR DESCRIPTION
The `eager: true` were added in tests with the caching system, which later got removed.

To prevent extra overhead as eager relationships can be expensive, I have removed them.

No migrations are needed and the code works fine.