### PR TITLE
fix: handle music join exceptions

### DIFF
--- a/src/commands/Music/join.ts
+++ b/src/commands/Music/join.ts
@@ -20,9 +20,9 @@ export default class extends MusicCommand {
 		if (!channel) throw message.language.tget('COMMAND_JOIN_NO_VOICECHANNEL');
 
 		// Check if the bot is already playing in this guild
-		if (message.guild!.music.playing) {
+		if (message.guild!.music.playing && message.guild!.music.voiceChannel !== null) {
 			throw message.language.tget(
-				channel.id === message.guild!.music.voiceChannel!.id
+				channel.id === message.guild!.music.voiceChannel.id
 					? 'COMMAND_JOIN_VOICE_SAME'
 					: 'COMMAND_JOIN_VOICE_DIFFERENT'
 			);

--- a/src/events/lavalink/lavalinkException.ts
+++ b/src/events/lavalink/lavalinkException.ts
@@ -8,9 +8,9 @@ export default class extends Event {
 
 	private kHeader = new Colors({ text: 'magenta' }).format('[LAVALINK]');
 
-	public run(manager: MusicHandler, payload: LavalinkExceptionEvent, context: MusicHandlerRequestContext | null = null) {
-		// Reset the manager for the guild by calling leave (keeps queue intact)
-		manager.handleException(context);
+	public async run(manager: MusicHandler, payload: LavalinkExceptionEvent, context: MusicHandlerRequestContext | null = null) {
+		// Destroy the instance for this guild
+		await manager.handleException(context);
 
 		// Emit an error message if there is an error message to emit
 		// The if case is because exceptions are also emitted when Skyra is disconnected by a moderator

--- a/src/events/lavalink/lavalinkException.ts
+++ b/src/events/lavalink/lavalinkException.ts
@@ -1,5 +1,5 @@
 import { Colors } from '@klasa/console';
-import { MusicHandler, MusicHandlerRequestContext } from '@lib/structures/music/MusicHandler';
+import { MusicHandler } from '@lib/structures/music/MusicHandler';
 import { Events } from '@lib/types/Enums';
 import { LavalinkExceptionEvent } from '@utils/LavalinkUtils';
 import { Event } from 'klasa';
@@ -8,13 +8,9 @@ export default class extends Event {
 
 	private kHeader = new Colors({ text: 'magenta' }).format('[LAVALINK]');
 
-	public async run(manager: MusicHandler, payload: LavalinkExceptionEvent, context: MusicHandlerRequestContext | null = null) {
-		// Destroy the instance for this guild
-		await manager.handleException(context);
-
+	public run(manager: MusicHandler, payload: LavalinkExceptionEvent) {
 		// Emit an error message if there is an error message to emit
-		// The if case is because exceptions are also emitted when Skyra is disconnected by a moderator
-		// and disconnect events are not really exceptions (also disconnects are handled by lavalinkWebsocketClosed event)
+		// The if case is because exceptions without error messages are pretty useless
 		if (payload.error) {
 			this.client.emit(Events.Error, [
 				`${this.kHeader} Exception (${manager.guild.id})`,

--- a/src/events/lavalink/lavalinkWebsocketClosed.ts
+++ b/src/events/lavalink/lavalinkWebsocketClosed.ts
@@ -1,7 +1,9 @@
 import { Colors } from '@klasa/console';
 import { MusicHandler } from '@lib/structures/music/MusicHandler';
 import { Events } from '@lib/types/Enums';
+import { DiscordVoiceCloseEventCodes } from '@lib/types/Events';
 import { LavalinkWebSocketClosedEvent } from '@utils/LavalinkUtils';
+import { floatPromise } from '@utils/util';
 import { Event } from 'klasa';
 
 export default class extends Event {
@@ -9,7 +11,9 @@ export default class extends Event {
 	private kHeader = new Colors({ text: 'magenta' }).format('[LAVALINK]');
 
 	public run(manager: MusicHandler, payload: LavalinkWebSocketClosedEvent) {
-		if (payload.code >= 4000) {
+		if (payload.code === DiscordVoiceCloseEventCodes.Disconnected) {
+			floatPromise({ client: this.client }, this.client.lavalink.leave(payload.guildId));
+		} else if (payload.code >= 4000) {
 			this.client.emit(Events.Error, [
 				`${this.kHeader} Websocket Close (${manager.guild.id})`,
 				`           Code  : ${payload.code}`,

--- a/src/lib/structures/music/MusicHandler.ts
+++ b/src/lib/structures/music/MusicHandler.ts
@@ -1,5 +1,6 @@
 import { SkyraClient } from '@lib/SkyraClient';
 import { Events } from '@lib/types/Enums';
+import { LavalinkPlayerEvents } from '@lib/types/Events';
 import { GuildSettings } from '@lib/types/settings/GuildSettings';
 import { flattenMusicHandler } from '@utils/Models/ApiTransform';
 import { enumerable, fetch, FetchResultTypes } from '@utils/util';
@@ -125,10 +126,10 @@ export class MusicHandler {
 		if (this.player) {
 			// Handle all the player events
 			this.player
-				.on('playerUpdate', data => this.client.emit(Events.LavalinkPlayerUpdate, this, data))
-				.on('start', data => this.client.emit(Events.LavalinkStart, this, data))
-				.on('error', data => this.client.emit(Events.LavalinkException, this, data))
-				.on('end', data => this.client.emit(Events.LavalinkEnd, this, data));
+				.on(LavalinkPlayerEvents.PlayerUpdate, data => this.client.emit(Events.LavalinkPlayerUpdate, this, data))
+				.on(LavalinkPlayerEvents.Start, data => this.client.emit(Events.LavalinkStart, this, data))
+				.on(LavalinkPlayerEvents.Error, data => this.client.emit(Events.LavalinkException, this, data, context))
+				.on(LavalinkPlayerEvents.End, data => this.client.emit(Events.LavalinkEnd, this, data));
 		}
 
 		// Emit that we connected to the websocket
@@ -264,6 +265,10 @@ export class MusicHandler {
 		this.systemPaused = false;
 		this.replay = false;
 		if (volume) this.volume = this.guild.settings.get(GuildSettings.Music.DefaultVolume);
+	}
+
+	public handleException(context: MusicHandlerRequestContext | null = null) {
+		return this.leave(context);
 	}
 
 	public async manageableFor(message: KlasaMessage) {

--- a/src/lib/structures/music/MusicHandler.ts
+++ b/src/lib/structures/music/MusicHandler.ts
@@ -267,14 +267,6 @@ export class MusicHandler {
 		if (volume) this.volume = this.guild.settings.get(GuildSettings.Music.DefaultVolume);
 	}
 
-	public async handleException(context: MusicHandlerRequestContext | null = null) {
-		// Destroy the lavalink instance
-		await this.leave(context);
-
-		// Empty the queue
-		this.queue = [];
-	}
-
 	public async manageableFor(message: KlasaMessage) {
 		const { listeners } = this;
 

--- a/src/lib/structures/music/MusicHandler.ts
+++ b/src/lib/structures/music/MusicHandler.ts
@@ -267,8 +267,12 @@ export class MusicHandler {
 		if (volume) this.volume = this.guild.settings.get(GuildSettings.Music.DefaultVolume);
 	}
 
-	public handleException(context: MusicHandlerRequestContext | null = null) {
-		return this.leave(context);
+	public async handleException(context: MusicHandlerRequestContext | null = null) {
+		// Destroy the lavalink instance
+		await this.leave(context);
+
+		// Empty the queue
+		this.queue = [];
 	}
 
 	public async manageableFor(message: KlasaMessage) {

--- a/src/lib/types/Events.d.ts
+++ b/src/lib/types/Events.d.ts
@@ -69,3 +69,28 @@ export const enum LavalinkPlayerEvents {
 	Error = 'error',
 	End = 'end'
 }
+
+export const enum DiscordVoiceCloseEventCodes {
+	/** You sent an invalid {@link https://discord.com/developers/ opcode}. */
+	UnknownOpcode = 4001,
+	/** You sent a payload before {@link https://discord.com/developers/docs/topics/gateway#gateway-identify identifying} with the Gateway. */
+	NotAuthenticated = 4003,
+	/** The token you sent in your {@link https://discord.com/developers/docs/topics/gateway#gateway-identify identify} payload is incorrect. */
+	AuthenticationFailed = 4004,
+	/** You sent more than one {@link https://discord.com/developers/docs/topics/gateway#gateway-identify identify} payload. Stahp. */
+	AlreadyAuthenticated = 4005,
+	/** Your session is no longer valid. */
+	SessionNoLongerValid = 4006,
+	/** Your session has timed out. */
+	SessionTimeout = 4009,
+	/** We can't find the server you're trying to connect to. */
+	ServerNotFound = 4011,
+	/** We didn't recognize the {@link https://discord.com/developers/ protocol} you sent. */
+	UnknownProtocol = 4012,
+	/** Either the channel was deleted or you were kicked. Should not reconnect. */
+	Disconnected = 4014,
+	/** The server crashed. Our bad! Try {@link https://discord.com/developers/ resuming}. */
+	VoiceServerCrashed = 4015,
+	/** We didn't recognize your {@link https://discord.com/developers/ encryption}. */
+	UnknownEncryptionMode = 4016,
+}

--- a/src/lib/types/Events.d.ts
+++ b/src/lib/types/Events.d.ts
@@ -62,3 +62,10 @@ export const enum LavalinkEvents {
 	Raw = 'raw',
 	Ready = 'ready'
 }
+
+export const enum LavalinkPlayerEvents {
+	PlayerUpdate = 'playerUpdate',
+	Start = 'start',
+	Error = 'error',
+	End = 'end'
+}


### PR DESCRIPTION
For some bizarre reason people were using "disconnect" for the bot which puts it in a half state of playing and not playing so instead we'll just call a full leave when an exception occurs.
