### PR TITLE
fix(banner): fixed 2 critical bugs

### DIFF
--- a/src/commands/Social/Profile Management/banner.ts
+++ b/src/commands/Social/Profile Management/banner.ts
@@ -6,6 +6,7 @@ import { GuildSettings } from '@lib/types/settings/GuildSettings';
 import { UserEntity } from '@orm/entities/UserEntity';
 import { ApplyOptions, requiredPermissions } from '@skyra/decorators';
 import { BrandingColors, Emojis } from '@utils/constants';
+import { roundNumber } from '@utils/util';
 import { MessageEmbed } from 'discord.js';
 import { KlasaMessage } from 'klasa';
 import { getManager } from 'typeorm';
@@ -48,17 +49,18 @@ export default class extends SkyraCommand {
 		await getManager().transaction(async (em) => {
 			const existingbannerAuthor = await em.findOne(UserEntity, banner.author);
 			if (existingbannerAuthor) {
-				existingbannerAuthor.money += banner.price * 0.1;
+				existingbannerAuthor.money += roundNumber(banner.price * 0.1);
 				await em.save(existingbannerAuthor);
 			} else {
 				await em.insert(UserEntity, {
 					id: banner.author,
-					money: banner.price * 0.1
+					money: roundNumber(banner.price * 0.1)
 				});
 			}
 
 			banners.add(banner.id);
 			author.profile.banners = [...banners];
+			author.money -= banner.price;
 			await em.save(author);
 		});
 


### PR DESCRIPTION
- If a banner had any price that did not end in 0 it would cause an issue saving the money because that column is bigint so it doesn't support decimals. (i.e. 5005 * 0.1 = 500,5)

- buyer's shinies weren't being decreased when buying﻿
