### PR TITLE
fix(UserRepository): check for gameName in gameIntegrations

### DIFF
--- a/src/lib/orm/repositories/UserRepository.ts
+++ b/src/lib/orm/repositories/UserRepository.ts
@@ -62,7 +62,8 @@ export class UserRepository extends Repository<UserEntity> {
 			where: {
 				user: {
 					id: user.id
-				}
+				},
+				game: gameName
 			}
 		})) as UserGameIntegrationEntity<T>;
 


### PR DESCRIPTION
`fetchGameIntegrations` method in `UserRepository` would always return the first entry it would've found for a user in `gameIntegrations`, this will fix that so it now fetches it along with the specified `gameName`.