### PR TITLE
refactor(audio): allow no redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 -   [`InfluxDB`]: Metrics platform
 -   [`GraphQL-Pokemon`]: Pokemon API
 -   [`Saelem`]: Horoscope API
--   [`Redis`]: Caching for [`Saelem`]
+-   [`Redis`]: Caching for [`Saelem`] and queueing for [`Lavalink`]
 
 ### [Set-Up - Refer to CONTRIBUTING.md]
 

--- a/src/events/analytics/analyticsSync.ts
+++ b/src/events/analytics/analyticsSync.ts
@@ -50,10 +50,7 @@ export default class extends AnalyticsEvent {
 			new Point(AnalyticsSchema.Points.VoiceConnections)
 				.tag(AnalyticsSchema.Tags.Action, AnalyticsSchema.Actions.Sync)
 				// TODO: Adjust for traditional sharding
-				.intField(
-					'value',
-					this.client.audio.queues.reduce((acc, queue) => (queue.player.playing ? acc + 1 : acc), 0)
-				)
+				.intField('value', this.client.audio.queues?.reduce((acc, queue) => (queue.player.playing ? acc + 1 : acc), 0) ?? 0)
 		);
 	}
 

--- a/src/events/klasaReady.ts
+++ b/src/events/klasaReady.ts
@@ -68,7 +68,7 @@ export default class extends Event {
 	private async connectLavalink() {
 		if (ENABLE_LAVALINK) {
 			await this.client.audio.connect();
-			await this.client.audio.queues.start();
+			await this.client.audio.queues!.start();
 		}
 	}
 }

--- a/src/events/lavalink/rawLavalinkPlayerUpdate.ts
+++ b/src/events/lavalink/rawLavalinkPlayerUpdate.ts
@@ -5,7 +5,7 @@ import { Event, EventOptions } from 'klasa';
 @ApplyOptions<EventOptions>({ emitter: 'audio', event: 'playerUpdate' })
 export default class extends Event {
 	public async run(payload: IncomingPlayerUpdatePayload) {
-		const queue = this.client.audio.queues.get(payload.guildId);
+		const queue = this.client.audio.queues!.get(payload.guildId);
 		await queue.store.redis.set(queue.keys.position, payload.state.position);
 	}
 }

--- a/src/events/lavalink/rawTrackEndEvent.ts
+++ b/src/events/lavalink/rawTrackEndEvent.ts
@@ -6,7 +6,7 @@ import { Event, EventOptions } from 'klasa';
 @ApplyOptions<EventOptions>({ event: 'TrackEndEvent' })
 export default class extends Event {
 	public async run(payload: IncomingEventTrackEndPayload) {
-		const queue = this.client.audio.queues.get(payload.guildId);
+		const queue = this.client.audio.queues!.get(payload.guildId);
 		this.store.client.emit(Events.MusicQueueSync, queue);
 
 		// If the track wasn't replaced nor stopped, play next track:

--- a/src/events/lavalink/rawTrackExceptionEvent.ts
+++ b/src/events/lavalink/rawTrackExceptionEvent.ts
@@ -19,7 +19,7 @@ export default class extends Event {
 			]);
 		}
 
-		const queue = this.client.audio.queues.get(payload.guildId);
+		const queue = this.client.audio.queues!.get(payload.guildId);
 		await queue.next();
 	}
 }

--- a/src/lib/audio/QueueClient.ts
+++ b/src/lib/audio/QueueClient.ts
@@ -1,3 +1,4 @@
+import { ENABLE_LAVALINK } from '@root/config';
 import { Node, NodeOptions, NodeSend } from '@skyra/audio';
 import * as Redis from 'ioredis';
 import { QueueStore } from './QueueStore';
@@ -7,10 +8,12 @@ export interface QueueClientOptions extends NodeOptions {
 }
 
 export class QueueClient extends Node {
-	public readonly queues: QueueStore;
+	public readonly queues?: QueueStore;
 
 	public constructor(options: QueueClientOptions, send: NodeSend) {
 		super(options, send);
-		this.queues = new QueueStore(this, options.redis instanceof Redis ? options.redis : new Redis(options.redis));
+		if (ENABLE_LAVALINK) {
+			this.queues = new QueueStore(this, options.redis instanceof Redis ? options.redis : new Redis(options.redis));
+		}
 	}
 }

--- a/src/lib/extensions/SkyraGuild.ts
+++ b/src/lib/extensions/SkyraGuild.ts
@@ -16,7 +16,7 @@ export class SkyraGuild extends Structures.get('Guild') {
 	public readonly stickyRoles: StickyRoleManager = new StickyRoleManager(this);
 
 	public get audio(): Queue {
-		return this.client.audio.queues.get(this.id);
+		return this.client.audio.queues!.get(this.id);
 	}
 }
 


### PR DESCRIPTION
This was previously coded to always try to connect to Redis, even when
Lavalink was disabled. This causes issues in development.

`!.` is safe for events because they are never emitted if Lavalink is
off

`!.` is save for `klasaReady` and `SkyraGuild` because those are not
accessed when Lavalink is off

`?.`  plus ?? is required for Analytics because Influx expects the
function to return points in integer.