### PR TITLE
feat(routes): add route for public guild data

### DIFF
--- a/src/lib/structures/api/ApiResponse.ts
+++ b/src/lib/structures/api/ApiResponse.ts
@@ -43,7 +43,7 @@ export class ApiResponse extends ServerResponse {
 		return this;
 	}
 
-	public json(data: any): void {
+	public json<T = any>(data: T): void {
 		this.setContentType(Mime.Types.ApplicationJson).end(JSON.stringify(data));
 	}
 

--- a/src/lib/util/Models/ApiTransform.ts
+++ b/src/lib/util/Models/ApiTransform.ts
@@ -34,7 +34,6 @@ export function flattenGuild(guild: Guild): FlattenedGuild {
 		joinedTimestamp: guild.joinedTimestamp,
 		mfaLevel: guild.mfaLevel,
 		name: guild.name,
-		nameAcronym: guild.nameAcronym,
 		ownerID: guild.ownerID,
 		partnered: guild.partnered,
 		preferredLocale: guild.preferredLocale,
@@ -70,7 +69,6 @@ export interface FlattenedGuild
 		| 'joinedTimestamp'
 		| 'mfaLevel'
 		| 'name'
-		| 'nameAcronym'
 		| 'ownerID'
 		| 'partnered'
 		| 'preferredLocale'

--- a/src/lib/util/Models/ApiTransform.ts
+++ b/src/lib/util/Models/ApiTransform.ts
@@ -1,17 +1,14 @@
 import {
 	Channel,
 	DMChannel,
-	ExplicitContentFilterLevel,
 	Guild,
 	GuildChannel,
-	GuildFeatures,
 	GuildMember,
 	NewsChannel,
 	PermissionOverwrites,
 	Role,
 	TextChannel,
 	User,
-	VerificationLevel,
 	VoiceChannel
 } from 'discord.js';
 
@@ -19,61 +16,78 @@ import {
 
 export function flattenGuild(guild: Guild): FlattenedGuild {
 	return {
-		id: guild.id,
-		available: guild.available,
-		channels: guild.channels.cache.map(flattenChannel) as FlattenedGuildChannel[],
-		roles: guild.roles.cache.map(flattenRole),
-		name: guild.name,
-		icon: guild.icon,
-		splash: guild.splash,
-		region: guild.region,
-		features: guild.features,
-		applicationID: guild.applicationID,
-		afkTimeout: guild.afkTimeout,
 		afkChannelID: guild.afkChannelID,
-		systemChannelID: guild.systemChannelID,
-		embedEnabled: guild.embedEnabled,
-		premiumTier: guild.premiumTier,
-		premiumSubscriptionCount: guild.premiumSubscriptionCount,
-		verificationLevel: guild.verificationLevel,
-		explicitContentFilter: guild.explicitContentFilter,
-		mfaLevel: guild.mfaLevel,
-		joinedTimestamp: guild.joinedTimestamp,
-		defaultMessageNotifications: guild.defaultMessageNotifications,
-		vanityURLCode: guild.vanityURLCode,
-		description: guild.description,
+		afkTimeout: guild.afkTimeout,
+		applicationID: guild.applicationID,
+		approximateMemberCount: guild.approximateMemberCount,
+		approximatePresenceCount: guild.approximatePresenceCount,
+		available: guild.available,
 		banner: guild.banner,
-		ownerID: guild.ownerID
+		channels: guild.channels.cache.map(flattenChannel) as FlattenedGuildChannel[],
+		defaultMessageNotifications: guild.defaultMessageNotifications,
+		description: guild.description,
+		embedEnabled: guild.embedEnabled,
+		explicitContentFilter: guild.explicitContentFilter,
+		features: guild.features,
+		icon: guild.icon,
+		id: guild.id,
+		joinedTimestamp: guild.joinedTimestamp,
+		mfaLevel: guild.mfaLevel,
+		name: guild.name,
+		nameAcronym: guild.nameAcronym,
+		ownerID: guild.ownerID,
+		partnered: guild.partnered,
+		preferredLocale: guild.preferredLocale,
+		premiumSubscriptionCount: guild.premiumSubscriptionCount,
+		premiumTier: guild.premiumTier,
+		region: guild.region,
+		roles: guild.roles.cache.map(flattenRole),
+		splash: guild.splash,
+		systemChannelID: guild.systemChannelID,
+		vanityURLCode: guild.vanityURLCode,
+		verificationLevel: guild.verificationLevel,
+		verified: guild.verified
 	};
 }
 
-export interface FlattenedGuild {
-	id: string;
-	available: boolean;
+export interface FlattenedGuild
+	extends Pick<
+		Guild,
+		| 'afkChannelID'
+		| 'afkTimeout'
+		| 'applicationID'
+		| 'approximateMemberCount'
+		| 'approximatePresenceCount'
+		| 'available'
+		| 'banner'
+		| 'defaultMessageNotifications'
+		| 'description'
+		| 'embedEnabled'
+		| 'explicitContentFilter'
+		| 'features'
+		| 'icon'
+		| 'id'
+		| 'joinedTimestamp'
+		| 'mfaLevel'
+		| 'name'
+		| 'nameAcronym'
+		| 'ownerID'
+		| 'partnered'
+		| 'preferredLocale'
+		| 'premiumSubscriptionCount'
+		| 'premiumTier'
+		| 'region'
+		| 'splash'
+		| 'systemChannelID'
+		| 'vanityURLCode'
+		| 'verificationLevel'
+		| 'verified'
+	> {
 	channels: FlattenedGuildChannel[];
 	roles: FlattenedRole[];
-	name: string;
-	icon: string | null;
-	splash: string | null;
-	region: string;
-	features: GuildFeatures[];
-	applicationID: string | null;
-	afkTimeout: number;
-	afkChannelID: string | null;
-	systemChannelID: string | null;
-	embedEnabled: boolean;
-	premiumTier: number;
-	premiumSubscriptionCount: number | null;
-	verificationLevel: VerificationLevel;
-	explicitContentFilter: ExplicitContentFilterLevel;
-	mfaLevel: number;
-	joinedTimestamp: number;
-	defaultMessageNotifications: number | 'ALL' | 'MENTIONS';
-	vanityURLCode: string | null;
-	description: string | null;
-	banner: string | null;
-	ownerID: string;
 }
+
+export type PublicFlattenedGuild = Pick<FlattenedGuild, 'id' | 'name' | 'icon' | 'vanityURLCode' | 'description'>;
 
 // #endregion Guild
 

--- a/src/routes/guilds/guild/publicData.ts
+++ b/src/routes/guilds/guild/publicData.ts
@@ -1,0 +1,26 @@
+import { ApiRequest } from '@lib/structures/api/ApiRequest';
+import { ApiResponse } from '@lib/structures/api/ApiResponse';
+import { ApplyOptions } from '@skyra/decorators';
+import { flattenGuild, PublicFlattenedGuild } from '@utils/Models/ApiTransform';
+import { ratelimit } from '@utils/util';
+import { Route, RouteOptions } from 'klasa-dashboard-hooks';
+
+@ApplyOptions<RouteOptions>({ route: 'guilds/:guild/publicData' })
+export default class extends Route {
+	@ratelimit(2, 5000)
+	public get(request: ApiRequest, response: ApiResponse) {
+		const guildID = request.params.guild;
+
+		const guild = this.client.guilds.cache.get(guildID);
+		if (!guild) return response.error(400);
+
+		const flattenedGuild = flattenGuild(guild);
+		return response.json<PublicFlattenedGuild>({
+			description: flattenedGuild.description,
+			icon: flattenedGuild.icon,
+			id: flattenedGuild.id,
+			name: flattenedGuild.name,
+			vanityURLCode: flattenedGuild.vanityURLCode
+		});
+	}
+}

--- a/src/routes/oauth/oauthUser.ts
+++ b/src/routes/oauth/oauthUser.ts
@@ -103,7 +103,6 @@ export default class extends Route {
 							joinedTimestamp: null,
 							mfaLevel: 0,
 							name: oauthGuild.name,
-							nameAcronym: oauthGuild.name.slice(0, 2),
 							ownerID: oauthGuild.owner ? user.id : null,
 							partnered: false,
 							preferredLocale: 'en-US',

--- a/src/routes/oauth/oauthUser.ts
+++ b/src/routes/oauth/oauthUser.ts
@@ -88,6 +88,8 @@ export default class extends Route {
 							afkChannelID: null,
 							afkTimeout: 0,
 							applicationID: null,
+							approximateMemberCount: null,
+							approximatePresenceCount: null,
 							available: true,
 							banner: null,
 							channels: [],
@@ -101,7 +103,10 @@ export default class extends Route {
 							joinedTimestamp: null,
 							mfaLevel: 0,
 							name: oauthGuild.name,
+							nameAcronym: oauthGuild.name.slice(0, 2),
 							ownerID: oauthGuild.owner ? user.id : null,
+							partnered: false,
+							preferredLocale: 'en-US',
 							premiumSubscriptionCount: null,
 							premiumTier: 0,
 							region: null,
@@ -109,7 +114,8 @@ export default class extends Route {
 							splash: null,
 							systemChannelID: null,
 							vanityURLCode: null,
-							verificationLevel: 'NONE'
+							verificationLevel: 'NONE',
+							verified: false
 					  }
 					: flattenGuild(guild);
 


### PR DESCRIPTION
This will be required for the upcoming Dashboard rewrite.

This is retrieved server-sided so it can be used as meta tags, therefore there is no authentication available.
As far as I know the exposed fields are not of a sensitive nature so I think it should be fine.