### PR TITLE
refactor(music): changes for music dashboard

### DIFF
--- a/src/commands/Moderation/dehoist.ts
+++ b/src/commands/Moderation/dehoist.ts
@@ -1,6 +1,5 @@
 import { DbSet } from '@lib/structures/DbSet';
-import { MusicCommandOptions } from '@lib/structures/MusicCommand';
-import { SkyraCommand } from '@lib/structures/SkyraCommand';
+import { SkyraCommand, SkyraCommandOptions } from '@lib/structures/SkyraCommand';
 import { PermissionLevels } from '@lib/types/Enums';
 import { LanguageKeys } from '@lib/types/namespaces/LanguageKeys';
 import { codeBlock } from '@sapphire/utilities';
@@ -12,7 +11,7 @@ import { KlasaMessage } from 'klasa';
 
 const [kLowestNumberCode, kHighestNumberCode] = ['0'.charCodeAt(0), '9'.charCodeAt(0)];
 
-@ApplyOptions<MusicCommandOptions>({
+@ApplyOptions<SkyraCommandOptions>({
 	aliases: ['dh'],
 	cooldown: 5,
 	description: (language) => language.get(LanguageKeys.Commands.Moderation.DehoistDescription),

--- a/src/commands/Music/add.ts
+++ b/src/commands/Music/add.ts
@@ -1,10 +1,10 @@
-import { MusicCommand, MusicCommandOptions } from '@lib/structures/MusicCommand';
+import { MusicCommand } from '@lib/structures/MusicCommand';
 import { GuildMessage } from '@lib/types/Discord';
 import { Events } from '@lib/types/Enums';
 import { LanguageKeys } from '@lib/types/namespaces/LanguageKeys';
 import { ApplyOptions } from '@skyra/decorators';
 
-@ApplyOptions<MusicCommandOptions>({
+@ApplyOptions<MusicCommand.Options>({
 	description: (language) => language.get(LanguageKeys.Commands.Music.AddDescription),
 	extendedHelp: (language) => language.get(LanguageKeys.Commands.Music.AddExtended),
 	usage: '<song:song>',

--- a/src/commands/Music/importqueue.ts
+++ b/src/commands/Music/importqueue.ts
@@ -1,6 +1,6 @@
 import { QueueEntry } from '@lib/audio';
 import { empty, filter, map, take } from '@lib/misc';
-import { MusicCommand, MusicCommandOptions } from '@lib/structures/MusicCommand';
+import { MusicCommand } from '@lib/structures/MusicCommand';
 import { GuildMessage } from '@lib/types/Discord';
 import { Events } from '@lib/types/Enums';
 import { GuildSettings } from '@lib/types/namespaces/GuildSettings';
@@ -11,7 +11,7 @@ import { fetch, FetchResultTypes } from '@utils/util';
 import { deserialize } from 'binarytf';
 import { maximumExportQueueSize } from './exportqueue';
 
-@ApplyOptions<MusicCommandOptions>({
+@ApplyOptions<MusicCommand.Options>({
 	aliases: ['iq'],
 	cooldown: 30,
 	description: (language) => language.get(LanguageKeys.Commands.Music.ImportQueueDescription),

--- a/src/commands/Music/join.ts
+++ b/src/commands/Music/join.ts
@@ -1,5 +1,5 @@
 import { Queue } from '@lib/audio';
-import { MusicCommand, MusicCommandOptions } from '@lib/structures/MusicCommand';
+import { MusicCommand } from '@lib/structures/MusicCommand';
 import { GuildMessage } from '@lib/types/Discord';
 import { LanguageKeys } from '@lib/types/namespaces/LanguageKeys';
 import { ApplyOptions } from '@skyra/decorators';
@@ -7,7 +7,7 @@ import { requireUserInVoiceChannel } from '@utils/Music/Decorators';
 import { Permissions, VoiceChannel } from 'discord.js';
 const { FLAGS } = Permissions;
 
-@ApplyOptions<MusicCommandOptions>({
+@ApplyOptions<MusicCommand.Options>({
 	aliases: ['connect'],
 	description: (language) => language.get(LanguageKeys.Commands.Music.JoinDescription)
 })

--- a/src/commands/Music/leave.ts
+++ b/src/commands/Music/leave.ts
@@ -1,10 +1,10 @@
-import { MusicCommand, MusicCommandOptions } from '@lib/structures/MusicCommand';
+import { MusicCommand } from '@lib/structures/MusicCommand';
 import { GuildMessage } from '@lib/types/Discord';
 import { LanguageKeys } from '@lib/types/namespaces/LanguageKeys';
 import { ApplyOptions } from '@skyra/decorators';
 import { requireDj, requireSkyraInVoiceChannel } from '@utils/Music/Decorators';
 
-@ApplyOptions<MusicCommandOptions>({
+@ApplyOptions<MusicCommand.Options>({
 	description: (language) => language.get(LanguageKeys.Commands.Music.LeaveDescription),
 	extendedHelp: (language) => language.get(LanguageKeys.Commands.Music.LeaveExtended),
 	flagSupport: true

--- a/src/commands/Music/pause.ts
+++ b/src/commands/Music/pause.ts
@@ -1,4 +1,4 @@
-import { MusicCommand, MusicCommandOptions } from '@lib/structures/MusicCommand';
+import { MusicCommand } from '@lib/structures/MusicCommand';
 import { GuildMessage } from '@lib/types/Discord';
 import { Events } from '@lib/types/Enums';
 import { LanguageKeys } from '@lib/types/namespaces/LanguageKeys';
@@ -11,7 +11,7 @@ import {
 	requireUserInVoiceChannel
 } from '@utils/Music/Decorators';
 
-@ApplyOptions<MusicCommandOptions>({
+@ApplyOptions<MusicCommand.Options>({
 	description: (language) => language.get(LanguageKeys.Commands.Music.PauseDescription)
 })
 export default class extends MusicCommand {

--- a/src/commands/Music/play.ts
+++ b/src/commands/Music/play.ts
@@ -1,10 +1,10 @@
-import { MusicCommand, MusicCommandOptions } from '@lib/structures/MusicCommand';
+import { MusicCommand } from '@lib/structures/MusicCommand';
 import { GuildMessage } from '@lib/types/Discord';
 import { LanguageKeys } from '@lib/types/namespaces/LanguageKeys';
 import { ApplyOptions } from '@skyra/decorators';
 import { requireUserInVoiceChannel } from '@utils/Music/Decorators';
 
-@ApplyOptions<MusicCommandOptions>({
+@ApplyOptions<MusicCommand.Options>({
 	aliases: ['p'],
 	description: (language) => language.get(LanguageKeys.Commands.Music.PlayDescription),
 	extendedHelp: (language) => language.get(LanguageKeys.Commands.Music.PlayExtended),

--- a/src/commands/Music/playing.ts
+++ b/src/commands/Music/playing.ts
@@ -1,4 +1,4 @@
-import { MusicCommand, MusicCommandOptions } from '@lib/structures/MusicCommand';
+import { MusicCommand } from '@lib/structures/MusicCommand';
 import { GuildMessage } from '@lib/types/Discord';
 import { LanguageKeys } from '@lib/types/namespaces/LanguageKeys';
 import { TrackInfo } from '@skyra/audio';
@@ -7,7 +7,7 @@ import { requireMusicPlaying } from '@utils/Music/Decorators';
 import { IMAGE_EXTENSION, showSeconds } from '@utils/util';
 import { MessageEmbed } from 'discord.js';
 
-@ApplyOptions<MusicCommandOptions>({
+@ApplyOptions<MusicCommand.Options>({
 	aliases: ['np', 'nowplaying'],
 	description: (language) => language.get(LanguageKeys.Commands.Music.PlayingDescription),
 	requiredPermissions: ['EMBED_LINKS']

--- a/src/commands/Music/promote.ts
+++ b/src/commands/Music/promote.ts
@@ -1,4 +1,4 @@
-import { MusicCommand, MusicCommandOptions } from '@lib/structures/MusicCommand';
+import { MusicCommand } from '@lib/structures/MusicCommand';
 import { GuildMessage } from '@lib/types/Discord';
 import { LanguageKeys } from '@lib/types/namespaces/LanguageKeys';
 import { ApplyOptions } from '@skyra/decorators';
@@ -10,7 +10,7 @@ import {
 	requireUserInVoiceChannel
 } from '@utils/Music/Decorators';
 
-@ApplyOptions<MusicCommandOptions>({
+@ApplyOptions<MusicCommand.Options>({
 	description: (language) => language.get(LanguageKeys.Commands.Music.PromoteDescription),
 	extendedHelp: (language) => language.get(LanguageKeys.Commands.Music.PromoteExtended),
 	usage: '<number:integer>'

--- a/src/commands/Music/queue-clear.ts
+++ b/src/commands/Music/queue-clear.ts
@@ -1,10 +1,10 @@
-import { MusicCommand, MusicCommandOptions } from '@lib/structures/MusicCommand';
+import { MusicCommand } from '@lib/structures/MusicCommand';
 import { GuildMessage } from '@lib/types/Discord';
 import { LanguageKeys } from '@lib/types/namespaces/LanguageKeys';
 import { ApplyOptions } from '@skyra/decorators';
 import { requireDj, requireQueueNotEmpty } from '@utils/Music/Decorators';
 
-@ApplyOptions<MusicCommandOptions>({
+@ApplyOptions<MusicCommand.Options>({
 	aliases: ['qc', 'clear'],
 	description: (language) => language.get(LanguageKeys.Commands.Music.ClearDescription)
 })

--- a/src/commands/Music/queue.ts
+++ b/src/commands/Music/queue.ts
@@ -1,6 +1,6 @@
 import { Queue } from '@lib/audio';
 import { DbSet } from '@lib/structures/DbSet';
-import { MusicCommand, MusicCommandOptions } from '@lib/structures/MusicCommand';
+import { MusicCommand } from '@lib/structures/MusicCommand';
 import { UserRichDisplay } from '@lib/structures/UserRichDisplay';
 import { GuildMessage } from '@lib/types/Discord';
 import { LanguageKeys } from '@lib/types/namespaces/LanguageKeys';
@@ -12,7 +12,7 @@ import { requireQueueNotEmpty } from '@utils/Music/Decorators';
 import { pickRandom, showSeconds } from '@utils/util';
 import { MessageEmbed } from 'discord.js';
 
-@ApplyOptions<MusicCommandOptions>({
+@ApplyOptions<MusicCommand.Options>({
 	aliases: ['q', 'playing-time', 'pt'],
 	description: (language) => language.get(LanguageKeys.Commands.Music.QueueDescription),
 	requiredPermissions: ['ADD_REACTIONS', 'MANAGE_MESSAGES', 'EMBED_LINKS', 'READ_MESSAGE_HISTORY']

--- a/src/commands/Music/queue.ts
+++ b/src/commands/Music/queue.ts
@@ -37,7 +37,7 @@ export default class extends MusicCommand {
 		const tracks = await this.getTrackInformation(audio);
 
 		if (current) {
-			const track = await audio.player.node.decode(current.entry.track);
+			const track = current.entry.info;
 			const nowPlayingDescription = [
 				track.isStream ? message.language.get(LanguageKeys.Commands.Music.QueueNowplayingLiveStream) : showSeconds(track.length),
 				message.language.get(LanguageKeys.Commands.Music.QueueNowplaying, {

--- a/src/commands/Music/remove.ts
+++ b/src/commands/Music/remove.ts
@@ -1,11 +1,11 @@
-import { MusicCommand, MusicCommandOptions } from '@lib/structures/MusicCommand';
+import { MusicCommand } from '@lib/structures/MusicCommand';
 import { GuildMessage } from '@lib/types/Discord';
 import { Events } from '@lib/types/Enums';
 import { LanguageKeys } from '@lib/types/namespaces/LanguageKeys';
 import { ApplyOptions } from '@skyra/decorators';
 import { requireQueueNotEmpty } from '@utils/Music/Decorators';
 
-@ApplyOptions<MusicCommandOptions>({
+@ApplyOptions<MusicCommand.Options>({
 	description: (language) => language.get(LanguageKeys.Commands.Music.RemoveDescription),
 	usage: '<number:integer>'
 })

--- a/src/commands/Music/repeat.ts
+++ b/src/commands/Music/repeat.ts
@@ -1,11 +1,11 @@
-import { MusicCommand, MusicCommandOptions } from '@lib/structures/MusicCommand';
+import { MusicCommand } from '@lib/structures/MusicCommand';
 import { GuildMessage } from '@lib/types/Discord';
 import { Events } from '@lib/types/Enums';
 import { LanguageKeys } from '@lib/types/namespaces/LanguageKeys';
 import { ApplyOptions } from '@skyra/decorators';
 import { requireMusicPlaying, requireSameVoiceChannel, requireSkyraInVoiceChannel, requireUserInVoiceChannel } from '@utils/Music/Decorators';
 
-@ApplyOptions<MusicCommandOptions>({
+@ApplyOptions<MusicCommand.Options>({
 	aliases: ['replay'],
 	description: (language) => language.get(LanguageKeys.Commands.Music.RepeatDescription)
 })

--- a/src/commands/Music/resume.ts
+++ b/src/commands/Music/resume.ts
@@ -1,11 +1,11 @@
-import { MusicCommand, MusicCommandOptions } from '@lib/structures/MusicCommand';
+import { MusicCommand } from '@lib/structures/MusicCommand';
 import { GuildMessage } from '@lib/types/Discord';
 import { Events } from '@lib/types/Enums';
 import { LanguageKeys } from '@lib/types/namespaces/LanguageKeys';
 import { ApplyOptions } from '@skyra/decorators';
 import { requireMusicPaused, requireSameVoiceChannel, requireSkyraInVoiceChannel, requireUserInVoiceChannel } from '@utils/Music/Decorators';
 
-@ApplyOptions<MusicCommandOptions>({
+@ApplyOptions<MusicCommand.Options>({
 	description: (language) => language.get(LanguageKeys.Commands.Music.ResumeDescription)
 })
 export default class extends MusicCommand {

--- a/src/commands/Music/seek.ts
+++ b/src/commands/Music/seek.ts
@@ -1,11 +1,11 @@
-import { MusicCommand, MusicCommandOptions } from '@lib/structures/MusicCommand';
+import { MusicCommand } from '@lib/structures/MusicCommand';
 import { GuildMessage } from '@lib/types/Discord';
 import { Events } from '@lib/types/Enums';
 import { LanguageKeys } from '@lib/types/namespaces/LanguageKeys';
 import { ApplyOptions } from '@skyra/decorators';
 import { requireDj, requireMusicPlaying } from '@utils/Music/Decorators';
 
-@ApplyOptions<MusicCommandOptions>({
+@ApplyOptions<MusicCommand.Options>({
 	description: (language) => language.get(LanguageKeys.Commands.Music.SeekDescription),
 	usage: '<position:timespan>'
 })

--- a/src/commands/Music/shuffle.ts
+++ b/src/commands/Music/shuffle.ts
@@ -1,10 +1,10 @@
-import { MusicCommand, MusicCommandOptions } from '@lib/structures/MusicCommand';
+import { MusicCommand } from '@lib/structures/MusicCommand';
 import { GuildMessage } from '@lib/types/Discord';
 import { LanguageKeys } from '@lib/types/namespaces/LanguageKeys';
 import { ApplyOptions } from '@skyra/decorators';
 import { requireDj, requireQueueNotEmpty } from '@utils/Music/Decorators';
 
-@ApplyOptions<MusicCommandOptions>({
+@ApplyOptions<MusicCommand.Options>({
 	description: (language) => language.get(LanguageKeys.Commands.Music.ShuffleDescription)
 })
 export default class extends MusicCommand {

--- a/src/commands/Music/skip.ts
+++ b/src/commands/Music/skip.ts
@@ -1,5 +1,5 @@
 import { Queue } from '@lib/audio';
-import { MusicCommand, MusicCommandOptions } from '@lib/structures/MusicCommand';
+import { MusicCommand } from '@lib/structures/MusicCommand';
 import { GuildMessage } from '@lib/types/Discord';
 import { Events } from '@lib/types/Enums';
 import { LanguageKeys } from '@lib/types/namespaces/LanguageKeys';
@@ -7,7 +7,7 @@ import { ApplyOptions } from '@skyra/decorators';
 import { requireSongPresent } from '@utils/Music/Decorators';
 import { VoiceChannel } from 'discord.js';
 
-@ApplyOptions<MusicCommandOptions>({
+@ApplyOptions<MusicCommand.Options>({
 	description: (language) => language.get(LanguageKeys.Commands.Music.SkipDescription),
 	usage: '[force]'
 })

--- a/src/commands/Music/volume.ts
+++ b/src/commands/Music/volume.ts
@@ -1,11 +1,11 @@
-import { MusicCommand, MusicCommandOptions } from '@lib/structures/MusicCommand';
+import { MusicCommand } from '@lib/structures/MusicCommand';
 import { GuildMessage } from '@lib/types';
 import { Events } from '@lib/types/Enums';
 import { LanguageKeys } from '@lib/types/namespaces/LanguageKeys';
 import { ApplyOptions } from '@skyra/decorators';
 import { requireMusicPlaying, requireSameVoiceChannel, requireSkyraInVoiceChannel, requireUserInVoiceChannel } from '@utils/Music/Decorators';
 
-@ApplyOptions<MusicCommandOptions>({
+@ApplyOptions<MusicCommand.Options>({
 	aliases: ['vol'],
 	description: (language) => language.get(LanguageKeys.Commands.Music.VolumeDescription),
 	usage: '[volume:number]'

--- a/src/events/music/musicQueueSync.ts
+++ b/src/events/music/musicQueueSync.ts
@@ -6,7 +6,7 @@ export default class extends AudioEvent {
 	public run(queue: Queue) {
 		return this.broadcastMessageForGuild(queue.guildID, async () => ({
 			action: OutgoingWebsocketAction.MusicSync,
-			data: { tracks: await queue.decodedTracks() }
+			data: { status: await queue.nowPlaying(), tracks: await queue.decodedTracks() }
 		}));
 	}
 }

--- a/src/events/music/musicSongPlayNotify.ts
+++ b/src/events/music/musicSongPlayNotify.ts
@@ -1,14 +1,13 @@
-import { QueueEntry } from '@lib/audio';
+import { NowPlayingEntry } from '@lib/audio';
 import { AudioEvent } from '@lib/structures/AudioEvent';
 import { MessageAcknowledgeable } from '@lib/types';
 import { LanguageKeys } from '@lib/types/namespaces/LanguageKeys';
 
 export default class extends AudioEvent {
-	public async run(channel: MessageAcknowledgeable, entry: QueueEntry) {
-		const [title, requester] = await Promise.all([
-			channel.guild.audio.player.node.decode(entry.track).then((data) => data.title),
-			this.client.users.fetch(entry.author).then((data) => data.username)
-		]);
+	public async run(channel: MessageAcknowledgeable, entry: NowPlayingEntry) {
+		const requester = await this.client.users.fetch(entry.author).then((data) => data.username);
+		const { title } = entry.info;
+
 		await channel.sendLocale(LanguageKeys.Commands.Music.PlayNext, [{ title, requester }], {
 			allowedMentions: { users: [], roles: [] }
 		});

--- a/src/lib/audio/Queue.ts
+++ b/src/lib/audio/Queue.ts
@@ -334,6 +334,7 @@ export class Queue {
 	 */
 	public async moveTracks(from: number, to: number): Promise<void> {
 		await this.store.redis.lmove(this.keys.next, -from - 1, -to - 1); // work from the end of the list, since it's reversed
+		this.client.emit(Events.MusicQueueSync, this);
 	}
 
 	/**
@@ -341,6 +342,7 @@ export class Queue {
 	 */
 	public async shuffleTracks(): Promise<void> {
 		await this.store.redis.lshuffle(this.keys.next, Date.now());
+		this.client.emit(Events.MusicQueueSync, this);
 	}
 
 	/**

--- a/src/lib/audio/Queue.ts
+++ b/src/lib/audio/Queue.ts
@@ -361,6 +361,7 @@ export class Queue {
 	 */
 	public async clearTracks(): Promise<void> {
 		await this.store.redis.del(this.keys.next);
+		this.client.emit(Events.MusicQueueSync, this);
 	}
 
 	/**

--- a/src/lib/structures/MusicCommand.ts
+++ b/src/lib/structures/MusicCommand.ts
@@ -3,7 +3,7 @@ import { CommandStore } from 'klasa';
 import { SkyraCommand, SkyraCommandOptions } from './SkyraCommand';
 
 export abstract class MusicCommand extends SkyraCommand {
-	protected constructor(store: CommandStore, file: string[], directory: string, options: MusicCommandOptions = {}) {
+	protected constructor(store: CommandStore, file: string[], directory: string, options: MusicCommand.Options = {}) {
 		super(store, file, directory, { ...options, runIn: ['text'] });
 	}
 
@@ -13,7 +13,10 @@ export abstract class MusicCommand extends SkyraCommand {
 	}
 }
 
-/**
- * The music command options
- */
-export type MusicCommandOptions = SkyraCommandOptions;
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace MusicCommand {
+	/**
+	 * The music command options
+	 */
+	export type Options = SkyraCommandOptions;
+}

--- a/src/lib/util/Models/ApiTransform.ts
+++ b/src/lib/util/Models/ApiTransform.ts
@@ -1,4 +1,5 @@
-import {
+import type { TrackInfo } from '@skyra/audio';
+import type {
 	Channel,
 	DMChannel,
 	Guild,
@@ -298,3 +299,13 @@ export interface FlattenedMember {
 }
 
 // #endregion Member
+
+// #region Music
+
+export interface PublicFlattenedMusic {
+	guildData: PublicFlattenedGuild;
+	currentlyPlaying?: TrackInfo;
+	queueLength: number;
+}
+
+// #endregion Music

--- a/src/lib/websocket/types.d.ts
+++ b/src/lib/websocket/types.d.ts
@@ -13,26 +13,16 @@ export const enum IncomingWebsocketAction {
 }
 
 export const enum OutgoingWebsocketAction {
-	MusicAdd = 'MUSIC_ADD',
 	MusicConnect = 'MUSIC_CONNECT',
 	MusicFinish = 'MUSIC_FINISH',
 	MusicLeave = 'MUSIC_LEAVE',
-	MusicPromoteQueue = 'MUSIC_PROMOTE_QUEUE',
 	MusicPrune = 'MUSIC_PRUNE',
-	MusicRemove = 'MUSIC_REMOVE',
 	MusicReplayUpdate = 'MUSIC_REPLAY_UPDATE',
-	MusicShuffleQueue = 'MUSIC_SHUFFLE_QUEUE',
-	MusicSongFinish = 'MUSIC_SONG_FINISH',
 	MusicSongPause = 'MUSIC_SONG_PAUSE',
-	MusicSongPlay = 'MUSIC_SONG_PLAY',
-	MusicSongReplay = 'MUSIC_SONG_REPLAY',
 	MusicSongResume = 'MUSIC_SONG_RESUME',
 	MusicSongSeekUpdate = 'MUSIC_SONG_SEEK_UPDATE',
-	MusicSongSkip = 'MUSIC_SONG_SKIP',
 	MusicSongVolumeUpdate = 'MUSIC_SONG_VOLUME_UPDATE',
-	MusicSwitch = 'MUSIC_SWITCH',
 	MusicSync = 'MUSIC_SYNC',
-	MusicVoiceChannelJoin = 'MUSIC_VOICE_CHANNEL_JOIN',
 	MusicVoiceChannelLeave = 'MUSIC_VOICE_CHANNEL_LEAVE',
 	MusicWebsocketDisconnect = 'MUSIC_WEBSOCKET_DISCONNECT'
 }

--- a/src/lib/websocket/types.d.ts
+++ b/src/lib/websocket/types.d.ts
@@ -23,6 +23,7 @@ export const enum OutgoingWebsocketAction {
 	MusicSongSeekUpdate = 'MUSIC_SONG_SEEK_UPDATE',
 	MusicSongVolumeUpdate = 'MUSIC_SONG_VOLUME_UPDATE',
 	MusicSync = 'MUSIC_SYNC',
+	MusicVoiceChannelJoin = 'MUSIC_VOICE_CHANNEL_JOIN',
 	MusicVoiceChannelLeave = 'MUSIC_VOICE_CHANNEL_LEAVE',
 	MusicWebsocketDisconnect = 'MUSIC_WEBSOCKET_DISCONNECT'
 }

--- a/src/routes/music/publicMusicData.ts
+++ b/src/routes/music/publicMusicData.ts
@@ -1,0 +1,34 @@
+import { ApiRequest } from '@lib/structures/api/ApiRequest';
+import { ApiResponse } from '@lib/structures/api/ApiResponse';
+import { ApplyOptions } from '@skyra/decorators';
+import { flattenGuild, PublicFlattenedMusic } from '@utils/Models/ApiTransform';
+import { ratelimit } from '@utils/util';
+import { Route, RouteOptions } from 'klasa-dashboard-hooks';
+
+@ApplyOptions<RouteOptions>({ route: 'music/:guild/publicData' })
+export default class extends Route {
+	@ratelimit(2, 5000)
+	public async get(request: ApiRequest, response: ApiResponse) {
+		const guildID = request.params.guild;
+
+		const guild = this.client.guilds.cache.get(guildID);
+		if (!guild) return response.error(400);
+
+		const flattenedGuild = flattenGuild(guild);
+		const { audio } = guild;
+		const tracks = await audio.decodedTracks();
+		const nowPlaying = await audio.nowPlaying();
+
+		return response.json<PublicFlattenedMusic>({
+			guildData: {
+				description: flattenedGuild.description,
+				icon: flattenedGuild.icon,
+				id: flattenedGuild.id,
+				name: flattenedGuild.name,
+				vanityURLCode: flattenedGuild.vanityURLCode
+			},
+			currentlyPlaying: nowPlaying?.entry.info,
+			queueLength: tracks.length
+		});
+	}
+}


### PR DESCRIPTION
- refactor(dehoist): use proper options interface
- fix: emit sync on moveTracks and shuffleTracks
- refactor: remove unused server actions from enum
- fix: emit status on musicQueueSync
- refactor: use namespace for options
- feat(kdh): create publicData endpoint for music
- fix: music send track info with now-playing data
- fix: emit sync on queue clear
