### PR TITLE
fix: make disabled commands work again

### DIFF
--- a/src/monitors/commandHandler.ts
+++ b/src/monitors/commandHandler.ts
@@ -14,9 +14,10 @@ export default class extends Monitor {
 	}
 
 	public async run(message: KlasaMessage) {
-		await message.parseCommand();
 		if (message.guild && message.guild.me === null) await message.guild.members.fetch(CLIENT_ID);
 		if (!message.channel.postable) return undefined;
+
+		await message.parseCommand();
 		if (!message.commandText && message.prefix === this.client.mentionPrefix) return this.sendPrefixReminder(message);
 		if (!message.commandText) return undefined;
 		if (!message.command) return this.client.emit('commandUnknown', message, message.commandText, message.prefix, message.prefixLength);


### PR DESCRIPTION
Also fixes an old bug, if a command is disabled in a channel, Skyra does not reply, but if the command happened to be globally disabled, this behaviour would override the default one, which is not expected.

This PR also reduces code duplication!

![image](https://user-images.githubusercontent.com/24852502/99513790-492fe280-298b-11eb-9018-69e1a16d29c8.png)
