### PR TITLE
fix: fixed hastebin outputs by switching to self-hosted version

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -48,6 +48,22 @@ services:
     ports:
       - '8287:8287'
     command: redis-server --port 8287 --requirepass redis
+  hasteserver:
+    container_name: hasteserver
+    image: skyrabot/haste-server
+    restart: always
+    depends_on:
+      - redis
+    ports:
+      - '8290:8290'
+    environment:
+      PORT: 8290
+      STORAGE_TYPE: redis
+      STORAGE_HOST: host.docker.internal
+      STORAGE_PORT: 8287
+      STORAGE_PASSWORD: redis
+      STORAGE_DB: 2
+      STORAGE_EXPIRE_SECONDS: 21600
 
 volumes:
   postgres-data:

--- a/src/commands/System/Admin/exec.ts
+++ b/src/commands/System/Admin/exec.ts
@@ -34,9 +34,9 @@ export default class extends SkyraCommand {
 	}
 
 	private async getHaste(result: string) {
-		const { key } = (await fetch('https://hasteb.in/documents', { method: FetchMethods.Post, body: result }, FetchResultTypes.JSON)) as {
+		const { key } = (await fetch(`https://hastebin.skyra.pw/documents`, { method: FetchMethods.Post, body: result }, FetchResultTypes.JSON)) as {
 			key: string;
 		};
-		return `https://hasteb.in/${key}.js`;
+		return `https://hastebin.skyra.pw/${key}.js`;
 	}
 }

--- a/src/lib/util/Parsers/ExceededLength.ts
+++ b/src/lib/util/Parsers/ExceededLength.ts
@@ -112,8 +112,12 @@ async function getTypeOutput<ED extends ExtraDataPartial>(message: Message, opti
 }
 
 async function getHaste(result: string, language = 'js') {
-	const { key } = await fetch<{ key: string }>('https://hasteb.in/documents', { method: FetchMethods.Post, body: result }, FetchResultTypes.JSON);
-	return `https://hasteb.in/${key}.${language}`;
+	const { key } = await fetch<{ key: string }>(
+		`https://hastebin.skyra.pw/documents`,
+		{ method: FetchMethods.Post, body: result },
+		FetchResultTypes.JSON
+	);
+	return `https://hastebin.skyra.pw/${key}.${language}`;
 }
 
 type HandleMessageData<ED extends ExtraDataPartial> = {


### PR DESCRIPTION
|  **⚠️ This Pull Request needs hastebin.skyra.pw to be added as CNAME in CloudFlare before it can be tested** |
| --- |

[hasteb.in](hasteb.in) has been down for a while
[hastebin.com](hastebin.com) POST endpoint is broken

So screw it all, lets self host it. Image has already been published to dockerhub (source code is at https://github.com/skyra-project/docker-images/tree/main/haste-server)