### PR TITLE
chore: add base for all .NET projects

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -87,6 +87,12 @@ jobs:
         with:
           name: coverage
           path: coverage/
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '5.0.103'
+      - name: Run dotnet tests
+        run: dotnet test services/Skyra.Tests
 
   Building:
     name: Compile source code
@@ -114,6 +120,12 @@ jobs:
           popd
       - name: Build Code
         run: yarn build
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '5.0.103'
+      - name: Build Services
+        run: dotnet build services
 
   Upload_Coverage_Report:
     name: Upload coverage report to coveralls

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,5 @@ gh
 wiki/
 
 # Ignore dotnet build outputs
-
 obj/
 bin/

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,8 @@ gh
 
 # Ignore the "wiki" folder so we can checkout the wiki inside the same folder
 wiki/
+
+# Ignore dotnet build outputs
+
+obj/
+bin/

--- a/services/Directory.Build.props
+++ b/services/Directory.Build.props
@@ -7,11 +7,6 @@
 
     <!-- We add InternalsVisibleTo to every project, making sure Skyra.Tests can see internals (to test) APART from Skyra.Tests itself. -->
 
-    <ItemGroup>
-        <MyProjectReferences Include="**\*.*proj" />
-        <MyProjectReferences Remove="Skyra.Tests.csproj"/>
-    </ItemGroup>
-
     <ItemGroup Condition="'$(MSBuildProjectName)' != 'Skyra.Tests.csproj'">
         <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
             <_Parameter1>Skyra.Tests</_Parameter1>

--- a/services/Directory.Build.props
+++ b/services/Directory.Build.props
@@ -1,0 +1,20 @@
+<Project>
+    <PropertyGroup>
+        <Deterministic>true</Deterministic>
+        <Features>strict</Features>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <!-- We add InternalsVisibleTo to every project, making sure Skyra.Tests can see internals (to test) APART from Skyra.Tests itself. -->
+
+    <ItemGroup>
+        <MyProjectReferences Include="**\*.*proj" />
+        <MyProjectReferences Remove="Skyra.Tests.csproj"/>
+    </ItemGroup>
+
+    <ItemGroup Condition="'$(MSBuildProjectName)' != 'Skyra.Tests.csproj'">
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+            <_Parameter1>Skyra.Tests</_Parameter1>
+        </AssemblyAttribute>
+    </ItemGroup>
+</Project>

--- a/services/Skyra.Tests/Skyra.Tests.csproj
+++ b/services/Skyra.Tests/Skyra.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net5.0</TargetFramework>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="NUnit" Version="3.12.0"/>
+        <PackageReference Include="NUnit3TestAdapter" Version="3.16.1"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0"/>
+    </ItemGroup>
+
+</Project>

--- a/services/Skyra.Tests/UnitTest1.cs
+++ b/services/Skyra.Tests/UnitTest1.cs
@@ -1,0 +1,18 @@
+using NUnit.Framework;
+
+namespace Skyra.Tests
+{
+	public class Tests
+	{
+		[SetUp]
+		public void Setup()
+		{
+		}
+
+		[Test]
+		public void Test1()
+		{
+			Assert.Pass();
+		}
+	}
+}

--- a/services/Skyra.sln
+++ b/services/Skyra.sln
@@ -1,0 +1,16 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Skyra.Tests", "Skyra.Tests\Skyra.Tests.csproj", "{0AE01293-2D6A-49B3-8E6F-7A2627565631}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0AE01293-2D6A-49B3-8E6F-7A2627565631}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0AE01293-2D6A-49B3-8E6F-7A2627565631}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0AE01293-2D6A-49B3-8E6F-7A2627565631}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0AE01293-2D6A-49B3-8E6F-7A2627565631}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/services/Skyra.sln.DotSettings
+++ b/services/Skyra.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Skyra/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
This PR will add the base solution and required extras for all .NET services going forward.
It also closes #1567 (while that PR is still needed, I'll reopen a PR later to add that stuff back in, instead based off this).
This should have been done from the start as this gives us a proper base to start new services from, instead of being lumped in (and therefore requiring other service PRs to wait for) #1567.