### PR TITLE
fix(readme): partial rewrite of dependencies list

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ The developer team does not support the idea of other self-hosted instances of S
 
 In addition, Skyra was built with a dependence on many services which need consistent maintenance and oversight in order to function and behave properly. These include, but are not limited to,
 
--    [`Lavalink`] as music module, this means you need to host your own instance of Lavalink (a Java application)
+-    [`Lavalink`] as music module, this requires hosting a personal instance of Lavalink (a Java application)
 -    [`Redis`] for the music queue, and as a cache for [`Saelem`]
--    [`InfluxDB`] for keeping anonymous metrics of how she is being used
--    [`PostgreSQL`] as database.
--    Other external APIs, each requiring their own individual API keys
+-    [`InfluxDB`] in order to keep anonymous metrics on bot usage
+-    [`PostgreSQL`] as database
+-    Other external APIs, each requiring their own individual API keys.
 
 With this in mind, it is also worth noting that Skyra will in no way be capable of running on services such as [Glitch] or [Heroku]. A dedicated VPS (Virtual Private Server) is required in order to maintain the proper production environment.
 


### PR DESCRIPTION
The list of dependencies still wasn't really in line with the rest of the changes from #1652 ; that's an oversight on my part sorry.

- Removed "you" usage for lavalink line (and equivalent sentence restructure)
- Removed personification for InfluxDB line
- Corrected period placement to the end of the list

Depending on your choice of grammar a comma could be also added to the end of each list item. For now I haven't added them, though this can evidently be changed based on maintainer preferences.