### PR TITLE
feat(custom-commands): add empty formatter

### DIFF
--- a/src/commands/Tags/tag.ts
+++ b/src/commands/Tags/tag.ts
@@ -126,8 +126,8 @@ export class UserCommand extends SkyraCommand {
 		while (!result.done) result = iterator.next(await parseParameter(args, result.value.type as InvalidTypeError.Type));
 
 		return tag.embed
-			? message.send(new MessageEmbed().setDescription(result.value).setColor(tag.color))
-			: message.send(result.value, { allowedMentions: { users: [], roles: [] } });
+			? message.send(new MessageEmbed().setDescription(result.value.trim()).setColor(tag.color))
+			: message.send(result.value.trim(), { allowedMentions: { users: [], roles: [] } });
 	}
 
 	public async source(message: GuildMessage, args: SkyraCommand.Args) {

--- a/src/lib/customCommands/setup.ts
+++ b/src/lib/customCommands/setup.ts
@@ -1,6 +1,7 @@
 import { Transformer } from '@skyra/tags';
 
 Transformer.formatters
+	.set('empty', () => '')
 	.set('mockcase', (value) =>
 		value
 			.split(' ')


### PR DESCRIPTION
This is useful for defining arguments at the start of a tag (to specify their order) but not show them, for example:
`{target:user | empty}{money:integer | empty}{money:integer} dollar(s) was sent from {author} to {target:user}`