### PR TITLE
fix(info): remove what and details

### DIFF
--- a/src/commands/General/Chat Bot Info/info.ts
+++ b/src/commands/General/Chat Bot Info/info.ts
@@ -4,7 +4,7 @@ import { ApplyOptions } from '@sapphire/decorators';
 import type { Message } from 'discord.js';
 
 @ApplyOptions<SkyraCommand.Options>({
-	aliases: ['details', 'what'],
+	aliases: ['bot-info'],
 	cooldown: 5,
 	description: LanguageKeys.Commands.General.InfoDescription,
 	extendedHelp: LanguageKeys.Commands.General.InfoExtended,


### PR DESCRIPTION
Those would trigger when doing `Skyra what ...`, and `details` didn't feel like a good alias
