### PR TITLE
fix(prune): resolved user error when extra arguments are passed

### DIFF
--- a/src/commands/Moderation/prune.ts
+++ b/src/commands/Moderation/prune.ts
@@ -44,7 +44,12 @@ const enum Filter {
 export class UserCommand extends SkyraCommand {
 	public async run(message: GuildMessage, args: SkyraCommand.Args) {
 		const limit = await args.pick('integer', { minimum: 1, maximum: 100 });
-		const rawFilter = args.finished ? null : await args.pick(UserCommand.filter).catch(() => args.pick('user'));
+		const rawFilter = args.finished
+			? null
+			: await args
+					.pick(UserCommand.filter)
+					.catch(() => args.pick('user'))
+					.catch(() => null);
 		const rawPosition = args.finished ? null : await args.pick(UserCommand.position);
 		const targetMessage = args.finished && rawPosition === null ? message : await args.pick('message');
 


### PR DESCRIPTION
Before this patch, the command use:
```
s!prune 3 after 822639122254266399
```

Would throw an error saying it cannot resolve `after` to a user.

After this patch, this command now works as intended.