### PR TITLE
fix(tags): format and send errors from parser to the user

### DIFF
--- a/src/languages/en-US/commands/tags.json
+++ b/src/languages/en-US/commands/tags.json
@@ -50,5 +50,22 @@
 	"permissionlevel": "You must be a staff member, moderator, or admin, to be able to manage tags.",
 	"removed": "Successfully removed the tag **{{name}}**.",
 	"renamed": "Successfully renamed the tag **{{previous}}** to **{{name}}**.",
-	"reset": "All tags have been successfully removed from this server."
+	"reset": "All tags have been successfully removed from this server.",
+	"parseMismatchingNamedArgumentTypeValidation": "{{REDCROSS}} Mismatching named argument types, expected `{{expected.type}}` but received `{{received.type}}`.",
+	"parseParserEmptyStringTag": "{{REDCROSS}} Content tags must have at least one character.",
+	"parseParserMissingToken": "{{REDCROSS}} A token was expected for the last tag, but none was given.",
+	"parseParserPickMissingOptions": "{{REDCROSS}} Pick tags require at least one option to be given.",
+	"parseParserRandomDuplicatedOptions": "{{REDCROSS}} Random tags cannot have duplicated options.",
+	"parseParserRandomMissingOptions": "{{REDCROSS}} Random tags must have at least two items.",
+	"parseParserUnexpectedToken": "{{REDCROSS}} I expected {{expected}}, however, I received a token {{received}}.",
+	"parsePickInvalidOption": "{{REDCROSS}} The key `{{option}}` is not a valid option.",
+	"parseSentenceMissingArgument": "{{REDCROSS}} An argument must be specified for this argument.",
+	"parseTokenColon": "Colon (\":\")",
+	"parseTokenEquals": "Equals (\"=\")",
+	"parseTokenLiteral": "Literal (Any Word)",
+	"parseTokenPipe": "Pipe (\"|\")",
+	"parseTokenSpace": "Space (\" \")",
+	"parseTokenTagEnd": "Tag End (\"}\")",
+	"parseTokenTagStart": "Tag Start (\"{\")",
+	"parseTransformerInvalidFormatter": "{{REDCROSS}} The key `{{formatter}}` does not correspond with a valid formatter."
 }

--- a/src/lib/i18n/languageKeys/keys/commands/Tags.ts
+++ b/src/lib/i18n/languageKeys/keys/commands/Tags.ts
@@ -1,5 +1,6 @@
 import type { LanguageHelpDisplayOptions } from '#lib/i18n/LanguageHelp';
 import { FT, T } from '#lib/types';
+import type { Pick, Tag, Transformer } from '@skyra/tags';
 
 export const TagAdded = FT<{ name: string; content: string }, string>('commands/tags:added');
 export const TagDescription = T<string>('commands/tags:description');
@@ -14,3 +15,24 @@ export const TagPermissionLevel = T<string>('commands/tags:permissionlevel');
 export const TagRemoved = FT<{ name: string }, string>('commands/tags:removed');
 export const TagRenamed = FT<{ name: string; previous: string }, string>('commands/tags:renamed');
 export const TagReset = T<string>('commands/tags:reset');
+export const ParseMismatchingNamedArgumentTypeValidation = FT<{ expected: Tag; received: Tag }, string>(
+	'commands/tags:parseMismatchingNamedArgumentTypeValidation'
+);
+export const ParseParserEmptyStringTag = T<string>('commands/tags:parseParserEmptyStringTag');
+export const ParseParserMissingToken = T<string>('commands/tags:parseParserMissingToken');
+export const ParseParserPickMissingOptions = T<string>('commands/tags:parseParserPickMissingOptions');
+export const ParseParserRandomDuplicatedOptions = T<string>('commands/tags:parseParserRandomDuplicatedOptions');
+export const ParseParserRandomMissingOptions = T<string>('commands/tags:parseParserRandomMissingOptions');
+export const ParseParserUnexpectedToken = FT<{ expected: string; received: string }, string>('commands/tags:parseParserUnexpectedToken');
+export const ParsePickInvalidOption = FT<{ pick: Pick; option: string }, string>('commands/tags:parsePickInvalidOption');
+export const ParseSentenceMissingArgument = T<string>('commands/tags:parseSentenceMissingArgument');
+export const ParseTransformerInvalidFormatter = FT<{ transformer: Transformer; formatter: string }, string>(
+	'commands/tags:parseTransformerInvalidFormatter'
+);
+export const ParseTokenSpace = T<string>('commands/tags:parseTokenSpace');
+export const ParseTokenTagStart = T<string>('commands/tags:parseTokenTagStart');
+export const ParseTokenTagEnd = T<string>('commands/tags:parseTokenTagEnd');
+export const ParseTokenEquals = T<string>('commands/tags:parseTokenEquals');
+export const ParseTokenColon = T<string>('commands/tags:parseTokenColon');
+export const ParseTokenPipe = T<string>('commands/tags:parseTokenPipe');
+export const ParseTokenLiteral = T<string>('commands/tags:parseTokenLiteral');


### PR DESCRIPTION
Fixes this kind of error:

```typescript
ParserRandomMissingOptionsError: Random tags must have at least two items.
    at Parser.parseRandom (/home/archid/workspace/skyra/node_modules/@skyra/tags/src/lib/parser/Parser.ts:195:10)
    at Parser.parseTag (/home/archid/workspace/skyra/node_modules/@skyra/tags/src/lib/parser/Parser.ts:111:20)
    at Parser.parse (/home/archid/workspace/skyra/node_modules/@skyra/tags/src/lib/parser/Parser.ts:34:22)
    at Object.parseAndValidate (/home/archid/workspace/skyra/src/lib/customCommands/util.ts:30:23)
    at UserCommand.createTag (/home/archid/workspace/skyra/src/commands/Tags/tag.ts:145:13)
    at /home/archid/workspace/skyra/src/commands/Tags/tag.ts:87:68
    at Map.write (/home/archid/workspace/skyra/src/lib/database/settings/base/SettingsCollection.ts:185:26)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:94:5)
    at UserCommand.edit (/home/archid/workspace/skyra/src/commands/Tags/tag.ts:83:3)
```

And many others.