### PR TITLE
fix(resu): handle maximum range and improve error message

### DIFF
--- a/src/commands/Suggestions/resolvesuggestion.ts
+++ b/src/commands/Suggestions/resolvesuggestion.ts
@@ -19,6 +19,9 @@ const enum SuggestionsColors {
 type Actions = 'accept' | 'a' | 'deny' | 'd' | 'consider' | 'c';
 const kActions: readonly Actions[] = ['accept', 'a', 'deny', 'd', 'consider', 'c'];
 
+const minimum = 1;
+const maximum = 2_147_483_647; // Maximum value for int32
+
 @ApplyOptions<SkyraCommand.Options>({
 	aliases: ['resu'],
 	cooldown: 10,
@@ -116,8 +119,13 @@ export class UserCommand extends SkyraCommand {
 
 		// Validate the suggestion number
 		const id = Number(parameter);
-		if (!Number.isInteger(id) || id < 1) {
-			return Args.error({ argument, parameter, identifier: LanguageKeys.Commands.Suggestions.ResolveSuggestionInvalidID });
+		if (!Number.isInteger(id) || id < minimum || id > maximum) {
+			return Args.error({
+				argument,
+				parameter,
+				identifier: LanguageKeys.Commands.Suggestions.ResolveSuggestionInvalidID,
+				context: { minimum, maximum }
+			});
 		}
 
 		// Retrieve the suggestion data

--- a/src/languages/en-US/commands/suggestion.json
+++ b/src/languages/en-US/commands/suggestion.json
@@ -48,7 +48,7 @@
 		],
 		"reminder": "Suggestions also can be configured to DM the author regarding the status of their suggestion, with the `suggestions.on-action.dm` setting.\nFurthermore, in case you wish to preserve anonymity, you can hide your name using the `suggestions.on-action` setting, which can be overridden with the `--hide-author` and `--show-author` flags."
 	},
-	"resolveSuggestionInvalidId": "{{REDCROSS}} That's not a valid suggestion ID!",
+	"resolveSuggestionInvalidId": "I am sorry, but I was not able to resolve `{{parameter}}` to a valid suggestion ID! They are integers between {{minimum, number}} and {{maximum, number}} inclusive.",
 	"resolveSuggestionInvalidAction": "I am sorry, but I was not able to resolve `{{parameter}}` into a valid action.\n**Hint**: The possible values are: {{possibles, orList}}.",
 	"resolveSuggestionMessageNotFound": "{{REDCROSS}} I was not able to retrieve the suggestion as its message has been deleted.",
 	"resolveSuggestionIdNotFound": "{{REDCROSS}} Couldn't find a suggestion with that ID",


### PR DESCRIPTION
Fixes this error:

```typescript
QueryFailedError: value "824294071341547500" is out of range for type integer
    at new QueryFailedError (/home/archid/workspace/skyra/src/error/QueryFailedError.ts:9:9)
    at Query.callback (/home/archid/workspace/skyra/src/driver/postgres/PostgresQueryRunner.ts:195:30)
    at Query.handleError (/home/archid/workspace/skyra/node_modules/pg/lib/query.js:128:19)
    at Client._handleErrorMessage (/home/archid/workspace/skyra/node_modules/pg/lib/client.js:335:17)
    at Connection.emit (node:events:378:20)
    at Connection.EventEmitter.emit (node:domain:470:12)
    at /home/archid/workspace/skyra/node_modules/pg/lib/connection.js:115:12
    at Parser.parse (/home/archid/workspace/skyra/node_modules/pg-protocol/src/parser.ts:102:9)
    at Socket.<anonymous> (/home/archid/workspace/skyra/node_modules/pg-protocol/src/index.ts:7:48)
    at Socket.emit (node:events:378:20)
```