### PR TITLE
feat(command-error): handle Internal Server Error messages

### DIFF
--- a/src/events/commands/commandError.ts
+++ b/src/events/commands/commandError.ts
@@ -21,8 +21,8 @@ export class UserEvent extends Event<Events.CommandError> {
 		if (error instanceof UserError) return this.userError(message, args.t, error);
 
 		const { client } = this.context;
-		// If the error was an AbortError, tell the user to re-try:
-		if (error.name === 'AbortError') {
+		// If the error was an AbortError or an Internal Server Error, tell the user to re-try:
+		if (error.name === 'AbortError' || error.message === 'Internal Server Error') {
 			client.logger.warn(`${this.getWarnError(message)} (${message.author.id}) | ${error.constructor.name}`);
 			return message.alert(args.t(LanguageKeys.System.DiscordAbortError));
 		}


### PR DESCRIPTION
Fixes this error:

```typescript
Response: Internal Server Error
    at RequestHandler.execute (/home/archid/workspace/skyra/node_modules/discord.js/src/rest/RequestHandler.js:161:15)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:94:5)
    at RequestHandler.push (/home/archid/workspace/skyra/node_modules/discord.js/src/rest/RequestHandler.js:39:14)
    at CoreEvent.run (/home/archid/workspace/skyra/node_modules/@sapphire/framework/src/events/command-handler/CoreCommandAccepted.ts:15:19)
    at CoreEvent._run (/home/archid/workspace/skyra/node_modules/@sapphire/framework/src/lib/structures/Event.ts:87:4)
```