### PR TITLE
fix(mrr): reduce the amount of entries per page from 20 to 15

### DIFF
--- a/src/commands/Management/Configuration/manageReactionRoles.ts
+++ b/src/commands/Management/Configuration/manageReactionRoles.ts
@@ -113,7 +113,7 @@ export class UserCommand extends SkyraCommand {
 
 		const display = new UserPaginatedMessage({ template: new MessageEmbed().setColor(await this.context.db.fetchColor(message)) });
 
-		for (const bulk of chunk(reactionRoles, 20)) {
+		for (const bulk of chunk(reactionRoles, 15)) {
 			const serialized = bulk.map((value) => this.format(value, message.guild)).join('\n');
 			display.addPageEmbed((template) => template.setDescription(serialized));
 		}


### PR DESCRIPTION
Fixes this error:

```typescript
DiscordAPIError: Invalid Form Body
embed.description: Must be 2048 or fewer in length.
    at RequestHandler.execute (/home/archid/workspace/skyra/node_modules/discord.js/src/rest/RequestHandler.js:154:13)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:94:5)
    at RequestHandler.response [as push] (/home/archid/workspace/skyra/node_modules/discord.js/src/rest/RequestHandler.js:39:14)
    at UserPaginatedMessage.setUpMessage (/home/archid/workspace/skyra/node_modules/@sapphire/discord.js-utilities/src/lib/PaginatedMessage.ts:232:12)
    at UserPaginatedMessage.run (/home/archid/workspace/skyra/node_modules/@sapphire/discord.js-utilities/src/lib/PaginatedMessage.ts:188:3)
    at UserPaginatedMessage.start (/home/archid/workspace/skyra/src/lib/structures/UserPaginatedMessage.ts:24:19)
    at UserCommand.show (/home/archid/workspace/skyra/src/commands/Management/Configuration/manageReactionRoles.ts:121:3)
    at CoreEvent.run (/home/archid/workspace/skyra/node_modules/@sapphire/framework/src/events/command-handler/CoreCommandAccepted.ts:15:19)
    at CoreEvent._run (/home/archid/workspace/skyra/node_modules/@sapphire/framework/src/lib/structures/Event.ts:87:4)
```