### PR TITLE
fix(guild-member-update): check view audit logs permission

### DIFF
--- a/src/events/guilds/members/rawGuildMemberUpdate.ts
+++ b/src/events/guilds/members/rawGuildMemberUpdate.ts
@@ -10,13 +10,20 @@ import {
 	RESTGetAPIAuditLogQuery,
 	RESTGetAPIAuditLogResult
 } from 'discord-api-types/v6';
-import type { Guild } from 'discord.js';
+import { Guild, Permissions } from 'discord.js';
 
 @ApplyOptions<EventOptions>({ event: GatewayDispatchEvents.GuildMemberUpdate, emitter: 'ws' })
 export class UserEvent extends Event {
+	private readonly requiredPermissions = new Permissions(Permissions.FLAGS.VIEW_AUDIT_LOG);
+
 	public run(data: GatewayGuildMemberUpdateDispatch['d']) {
 		const guild = this.context.client.guilds.cache.get(data.guild_id);
+
+		// If the guild does not exist for some reason, skip:
 		if (typeof guild === 'undefined') return;
+
+		// If the bot doesn't have the required permissions, skip:
+		if (!guild.me!.permissions.has(this.requiredPermissions)) return;
 
 		floatPromise(this.handleRoleSets(guild, data));
 	}


### PR DESCRIPTION
Fixes this error:

```typescript
DiscordAPIError: Missing Permissions
    at RequestHandler.execute (/home/archid/workspace/skyra/node_modules/discord.js/src/rest/RequestHandler.
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:94:5)
    at RequestHandler.push (/home/archid/workspace/skyra/node_modules/discord.js/src/rest/RequestHandler.
    at UserEvent.handleRoleSets (/home/archid/workspace/skyra/src/events/guilds/members/rawGuildMemberUpdate.
  method: 'get',
  path: '/guilds/------------------/audit-logs?limit=10&action_type=25',
  code: 50013,
  httpStatus: 403
}
```
