### PR TITLE
feat(utils): added message formatter

### DIFF
--- a/src/.env.test
+++ b/src/.env.test
@@ -1,0 +1,1 @@
+OVERRIDE_ROOT_PATH='src'

--- a/src/commands/Tools/content.ts
+++ b/src/commands/Tools/content.ts
@@ -1,9 +1,8 @@
 import { LanguageKeys } from '#lib/i18n/languageKeys';
 import { SkyraCommand } from '#lib/structures';
 import { GuildMessage } from '#lib/types';
-import { ZeroWidthSpace } from '#utils/constants';
 import { escapeCodeBlock } from '#utils/External/escapeMarkdown';
-import { formatMessage } from '#utils/formatters';
+import { formatAttachment, formatMessage } from '#utils/formatters';
 import { handleMessage } from '#utils/Parsers/ExceededLength';
 import { getAllContent, getContent } from '#utils/util';
 import { ApplyOptions } from '@sapphire/decorators';
@@ -26,13 +25,11 @@ export class UserCommand extends SkyraCommand {
 		const target = await args.pick('message', { channel });
 
 		// Parse the message content:
-		const attachments = target.attachments.size ? target.attachments.map((att) => `📁 <${att.url}>`).join('\n') : '';
 		const content = escapeCodeBlock(this.getContent(args, target as GuildMessage));
 
 		const sendAs = args.getOption('output', 'output-to');
 		return handleMessage(message, {
 			sendAs,
-			attachments,
 			content,
 			targetId: target.id,
 			hastebinUnavailable: false,
@@ -42,12 +39,18 @@ export class UserCommand extends SkyraCommand {
 	}
 
 	private getContent(args: SkyraCommand.Args, message: GuildMessage) {
-		if (args.getFlags(...allPlain)) return this.ensure(getAllContent(message));
-		if (args.getFlags(...allFormat)) return this.ensure(formatMessage(args.t, message));
-		return this.ensure(getContent(message));
+		if (args.getFlags(...allPlain)) return this.join(getAllContent(message), this.getAttachments(message));
+		if (args.getFlags(...allFormat)) return formatMessage(args.t, message);
+		return this.join(getContent(message) ?? '', this.getAttachments(message));
 	}
 
-	private ensure(content: string | null) {
-		return content === null || content.length === 0 ? ZeroWidthSpace : content;
+	private getAttachments(message: GuildMessage) {
+		return message.attachments.map(formatAttachment).join('\n');
+	}
+
+	private join(content: string, attachments: string) {
+		if (content.length === 0) return attachments;
+		if (attachments.length === 0) return content;
+		return `${content}\n\n${attachments}`;
 	}
 }

--- a/src/commands/Tools/content.ts
+++ b/src/commands/Tools/content.ts
@@ -1,15 +1,20 @@
 import { LanguageKeys } from '#lib/i18n/languageKeys';
 import { SkyraCommand } from '#lib/structures';
+import { GuildMessage } from '#lib/types';
 import { ZeroWidthSpace } from '#utils/constants';
 import { escapeCodeBlock } from '#utils/External/escapeMarkdown';
+import { formatMessage } from '#utils/formatters';
 import { handleMessage } from '#utils/Parsers/ExceededLength';
-import { getContent } from '#utils/util';
+import { getAllContent, getContent } from '#utils/util';
 import { ApplyOptions } from '@sapphire/decorators';
 import type { Message } from 'discord.js';
 
+const allPlain = ['all', 'all-plain', 'all-plain-text'];
+const allFormat = ['format', 'formatted', 'all-format', 'all-formatted'];
+
 @ApplyOptions<SkyraCommand.Options>({
 	aliases: ['source', 'msg-source', 'message-source'],
-	strategyOptions: { flags: ['output', 'output-to'], options: ['log'] },
+	strategyOptions: { options: ['output', 'output-to'], flags: [...allPlain, ...allFormat] },
 	cooldown: 15,
 	description: LanguageKeys.Commands.Tools.ContentDescription,
 	extendedHelp: LanguageKeys.Commands.Tools.ContentExtended
@@ -22,9 +27,9 @@ export class UserCommand extends SkyraCommand {
 
 		// Parse the message content:
 		const attachments = target.attachments.size ? target.attachments.map((att) => `📁 <${att.url}>`).join('\n') : '';
-		const content = escapeCodeBlock(getContent(target) || ZeroWidthSpace);
+		const content = escapeCodeBlock(this.getContent(args, target as GuildMessage));
 
-		const sendAs = args.getOption('output', 'output-to') ?? (args.getFlags('log') ? 'log' : null);
+		const sendAs = args.getOption('output', 'output-to');
 		return handleMessage(message, {
 			sendAs,
 			attachments,
@@ -34,5 +39,15 @@ export class UserCommand extends SkyraCommand {
 			url: null,
 			canLogToConsole: false
 		});
+	}
+
+	private getContent(args: SkyraCommand.Args, message: GuildMessage) {
+		if (args.getFlags(...allPlain)) return this.ensure(getAllContent(message));
+		if (args.getFlags(...allFormat)) return this.ensure(formatMessage(args.t, message));
+		return this.ensure(getContent(message));
+	}
+
+	private ensure(content: string | null) {
+		return content === null || content.length === 0 ? ZeroWidthSpace : content;
 	}
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -88,6 +88,9 @@ function parseRegExpPrefix(): RegExp | undefined {
 	return CLIENT_REGEX_PREFIX ? new RegExp(CLIENT_REGEX_PREFIX, 'i') : undefined;
 }
 
+export const PROJECT_ROOT = join(rootFolder, process.env.OVERRIDE_ROOT_PATH ?? 'dist');
+export const LANGUAGE_ROOT = join(PROJECT_ROOT, 'languages');
+
 export const CLIENT_OPTIONS: ClientOptions = {
 	audio: parseAudio(),
 	ws: {
@@ -125,6 +128,7 @@ export const CLIENT_OPTIONS: ClientOptions = {
 	i18n: {
 		defaultMissingKey: 'default',
 		defaultNS: 'globals',
+		defaultLanguageDirectory: LANGUAGE_ROOT,
 		i18next: (_: string[], languages: string[]) => ({
 			supportedLngs: languages,
 			preload: languages,

--- a/src/languages/en-US/commands/tools.json
+++ b/src/languages/en-US/commands/tools.json
@@ -60,17 +60,26 @@
 	"contentExtended": {
 		"usages": [
 			"Message",
-			"Channel Message"
+			"Channel Message",
+			"Channel Message --all/--format"
 		],
 		"extendedHelp": "Raw content will help you better copy-paste message content as you will not have to reproduce all the formatting.",
 		"explainedUsage": [
 			[
-				"channel",
+				"Channel",
 				"The channel in which the message is to get the content from. Defaults to the current channel"
 			],
 			[
-				"message",
+				"Message",
 				"ID of the message to get the content from."
+			],
+			[
+				"--all",
+				"Gets all content including embeds and formats them separated by lines."
+			],
+			[
+				"--format",
+				"Gets all content including embeds and formats them in a more readable format."
 			]
 		],
 		"examples": [

--- a/src/lib/util/Parsers/ExceededLength.ts
+++ b/src/lib/util/Parsers/ExceededLength.ts
@@ -65,12 +65,7 @@ export async function handleMessage<ED extends ExtraDataPartial>(
 			}
 
 			if (options.content) {
-				return message.send(
-					`${options.content}${
-						options.content && options.attachments ? `\n\n\n=============\n${options.attachments}` : options.attachments
-					}`,
-					{ code: 'md' }
-				);
+				return message.send(options.content, { code: 'md' });
 			}
 
 			if (options.success) {
@@ -125,7 +120,6 @@ export interface EvalExtraData extends QueryExtraData {
 export interface ContentExtraData {
 	content: string;
 	targetId: string;
-	attachments: string;
 }
 
 export interface QueryExtraData {

--- a/src/lib/util/formatters.ts
+++ b/src/lib/util/formatters.ts
@@ -1,0 +1,115 @@
+import { LanguageKeys } from '#lib/i18n/languageKeys';
+import type { GuildMessage } from '#lib/types';
+import type { EmbedField, Guild, MessageAttachment, MessageEmbed, MessageEmbedFooter, MessageEmbedImage, User } from 'discord.js';
+import type { TFunction } from 'i18next';
+import { cleanMentions } from './util';
+
+export function formatMessage(t: TFunction, message: GuildMessage): string {
+	const header = formatHeader(t, message);
+	const content = formatContents(message);
+	return `${header}\n${content}`;
+}
+
+function formatHeader(t: TFunction, message: GuildMessage): string {
+	return `${formatTimestamp(t, message.createdTimestamp)} ${message.system ? 'SYSTEM' : formatAuthor(message.author)}`;
+}
+
+function formatTimestamp(t: TFunction, timestamp: number): string {
+	return `[${t(LanguageKeys.Globals.DateTimeValue, { value: timestamp })}]`;
+}
+
+function formatAuthor(author: User): string {
+	return `${author.tag}${author.bot ? ' [BOT]' : ''}`;
+}
+
+function formatContents(message: GuildMessage): string {
+	const output: string[] = [];
+	if (message.content.length > 0) output.push(formatContent(message.guild, message.content));
+	if (message.embeds.length > 0) output.push(message.embeds.map((embed) => formatEmbed(message.guild, embed)).join('\n'));
+	if (message.attachments.size > 0) output.push(message.attachments.map((attachment) => formatAttachment(attachment)).join('\n'));
+	return output.join('\n');
+}
+
+function formatContent(guild: Guild, content: string): string {
+	return cleanMentions(guild, content)
+		.split('\n')
+		.map((line) => `> ${line}`)
+		.join('\n');
+}
+
+function formatAttachment(attachment: MessageAttachment): string {
+	return `📂 [${attachment.name}: ${attachment.url}]`;
+}
+
+function formatEmbed(guild: Guild, embed: MessageEmbed): string {
+	switch (embed.type) {
+		case 'video':
+			return formatEmbedVideo(embed);
+		case 'image':
+			return formatEmbedImage(embed);
+		default:
+			return formatEmbedRich(guild, embed);
+	}
+}
+
+function formatEmbedVideo(embed: MessageEmbed): string {
+	return `📹 [${embed.url}]${embed.provider ? ` From ${embed.provider.name}.` : ''}`;
+}
+
+function formatEmbedImage(embed: MessageEmbed): string {
+	return `🖼️ [${embed.url}]${embed.provider ? ` From ${embed.provider.name}.` : ''}`;
+}
+
+function formatEmbedRich(guild: Guild, embed: MessageEmbed): string {
+	if (embed.provider === null) {
+		const output: string[] = [];
+		if (embed.title) output.push(formatEmbedRichTitle(embed.title));
+		if (embed.author) output.push(formatEmbedRichAuthor(embed.author));
+		if (embed.url) output.push(formatEmbedRichUrl(embed.url));
+		if (embed.description) output.push(formatEmbedRichDescription(guild, embed.description));
+		if (embed.fields.length > 0) output.push(embed.fields.map((field) => formatEmbedRichField(guild, field)).join('\n'));
+		if (embed.image) output.push(formatEmbedRichImage(embed.image));
+		if (embed.footer) output.push(formatEmbedRichFooter(embed.footer));
+		return output.join('\n');
+	}
+
+	return formatEmbedRichProvider(embed);
+}
+
+function formatEmbedRichTitle(title: string): string {
+	return `># ${title}`;
+}
+
+function formatEmbedRichUrl(url: string): string {
+	return `> 📎 ${url}`;
+}
+
+function formatEmbedRichAuthor(author: Exclude<MessageEmbed['author'], null>): string {
+	return `> 👤 ${author.name || '-'}${author.iconURL ? ` [${author.iconURL}]` : ''}${author.url ? ` <${author.url}>` : ''}`;
+}
+
+function formatEmbedRichDescription(guild: Guild, description: string): string {
+	return cleanMentions(guild, description)
+		.split('\n')
+		.map((line) => `> > ${line}`)
+		.join('\n');
+}
+
+function formatEmbedRichField(guild: Guild, field: EmbedField): string {
+	return `> #> ${field.name}\n${cleanMentions(guild, field.value)
+		.split('\n')
+		.map((line) => `>  > ${line}`)
+		.join('\n')}`;
+}
+
+function formatEmbedRichImage(image: MessageEmbedImage): string {
+	return `>🖼️ [${image.url}]`;
+}
+
+function formatEmbedRichFooter(footer: MessageEmbedFooter): string {
+	return `>_ ${footer.iconURL ? `[🖼️ ${footer.iconURL}]${footer.text ? ' - ' : ''}` : ''}${footer.text ?? ''}`;
+}
+
+function formatEmbedRichProvider(embed: MessageEmbed): string {
+	return `🔖 [${embed.url}]${embed.provider ? ` From ${embed.provider.name}.` : ''}`;
+}

--- a/src/lib/util/formatters.ts
+++ b/src/lib/util/formatters.ts
@@ -37,7 +37,7 @@ function formatContent(guild: Guild, content: string): string {
 		.join('\n');
 }
 
-function formatAttachment(attachment: MessageAttachment): string {
+export function formatAttachment(attachment: MessageAttachment): string {
 	return `📂 [${attachment.name}: ${attachment.url}]`;
 }
 
@@ -53,11 +53,11 @@ function formatEmbed(guild: Guild, embed: MessageEmbed): string {
 }
 
 function formatEmbedVideo(embed: MessageEmbed): string {
-	return `📹 [${embed.url}]${embed.provider ? ` From ${embed.provider.name}.` : ''}`;
+	return `📹 [${embed.url}]${embed.provider ? ` (${embed.provider.name}).` : ''}`;
 }
 
 function formatEmbedImage(embed: MessageEmbed): string {
-	return `🖼️ [${embed.url}]${embed.provider ? ` From ${embed.provider.name}.` : ''}`;
+	return `🖼️ [${embed.url}]${embed.provider ? ` (${embed.provider.name}).` : ''}`;
 }
 
 function formatEmbedRich(guild: Guild, embed: MessageEmbed): string {
@@ -85,7 +85,7 @@ function formatEmbedRichUrl(url: string): string {
 }
 
 function formatEmbedRichAuthor(author: Exclude<MessageEmbed['author'], null>): string {
-	return `> 👤 ${author.name || '-'}${author.iconURL ? ` [${author.iconURL}]` : ''}${author.url ? ` <${author.url}>` : ''}`;
+	return `> 👤 ${author.iconURL ? `[${author.iconURL}] ` : ''}${author.name || '-'}${author.url ? ` <${author.url}>` : ''}`;
 }
 
 function formatEmbedRichDescription(guild: Guild, description: string): string {
@@ -107,9 +107,9 @@ function formatEmbedRichImage(image: MessageEmbedImage): string {
 }
 
 function formatEmbedRichFooter(footer: MessageEmbedFooter): string {
-	return `>_ ${footer.iconURL ? `[🖼️ ${footer.iconURL}]${footer.text ? ' - ' : ''}` : ''}${footer.text ?? ''}`;
+	return `>_ ${footer.iconURL ? `[${footer.iconURL}]${footer.text ? ' - ' : ''}` : ''}${footer.text ?? ''}`;
 }
 
 function formatEmbedRichProvider(embed: MessageEmbed): string {
-	return `🔖 [${embed.url}]${embed.provider ? ` From ${embed.provider.name}.` : ''}`;
+	return `🔖 [${embed.url}]${embed.provider ? ` (${embed.provider.name}).` : ''}`;
 }

--- a/src/lib/util/util.ts
+++ b/src/lib/util/util.ts
@@ -354,7 +354,7 @@ export function getAllContent(message: Message): string {
 		if (embed.author?.name) output.push(embed.author.name);
 		if (embed.title) output.push(embed.title);
 		if (embed.description) output.push(embed.description);
-		for (const field of embed.fields) output.push(`${field.name} ${field.value}`);
+		for (const field of embed.fields) output.push(`${field.name}\n${field.value}`);
 		if (embed.footer?.text) output.push(embed.footer.text);
 	}
 

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -1,4 +1,4 @@
-import '#root/config';
+import '#lib/setup';
 import { client } from '#mocks/MockInstances';
 import { TimerManager } from '@sapphire/time-utilities';
 

--- a/tests/lib/formatters.test.ts
+++ b/tests/lib/formatters.test.ts
@@ -160,6 +160,17 @@ describe('formatters', () => {
 			);
 		});
 
+		test('GIVEN embed with image only THEN returns embed with image only', () => {
+			const message = createMessage({ embeds: [{ image: { url: 'https://skyra.pw/avatars/skyra.png' } }] });
+
+			expect(formatMessage(t(), message)).toBe(
+				join(
+					'[3/26/21, 10:29:51 PM] Skyra#7023 [BOT]', //
+					'>🖼️ [https://skyra.pw/avatars/skyra.png]'
+				)
+			);
+		});
+
 		test('GIVEN embed footer with text only THEN returns embed footer with text only', () => {
 			const message = createMessage({ embeds: [{ footer: { text: 'Your Footer!' } }] });
 

--- a/tests/lib/formatters.test.ts
+++ b/tests/lib/formatters.test.ts
@@ -1,7 +1,7 @@
 import { GuildMessage } from '#lib/types';
 import { client, textChannel } from '#mocks/MockInstances';
 import { formatMessage } from '#utils/formatters';
-import { APIMessage } from 'discord-api-types/v6';
+import { APIMessage, EmbedType } from 'discord-api-types/v6';
 import { Message } from 'discord.js';
 
 describe('formatters', () => {
@@ -85,6 +85,41 @@ describe('formatters', () => {
 				join(
 					'[3/26/21, 10:29:51 PM] Skyra#7023 [BOT]', //
 					'># Your Title Goes Here'
+				)
+			);
+		});
+
+		test('GIVEN embed author only THEN returns embed author only', () => {
+			const message = createMessage({
+				embeds: [{ author: { name: 'Skyra', icon_url: 'https://skyra.pw/avatars/skyra.png', url: 'https://skyra.pw' } }]
+			});
+
+			expect(formatMessage(t(), message)).toBe(
+				join(
+					'[3/26/21, 10:29:51 PM] Skyra#7023 [BOT]', //
+					'> 👤 [https://skyra.pw/avatars/skyra.png] Skyra <https://skyra.pw>'
+				)
+			);
+		});
+
+		test('GIVEN embed author with name only THEN returns embed author with name only', () => {
+			const message = createMessage({ embeds: [{ author: { name: 'Skyra' } }] });
+
+			expect(formatMessage(t(), message)).toBe(
+				join(
+					'[3/26/21, 10:29:51 PM] Skyra#7023 [BOT]', //
+					'> 👤 Skyra'
+				)
+			);
+		});
+
+		test('GIVEN embed author with iconURL only THEN returns embed author with iconURL only', () => {
+			const message = createMessage({ embeds: [{ author: { icon_url: 'https://skyra.pw/avatars/skyra.png' } }] });
+
+			expect(formatMessage(t(), message)).toBe(
+				join(
+					'[3/26/21, 10:29:51 PM] Skyra#7023 [BOT]', //
+					'> 👤 [https://skyra.pw/avatars/skyra.png] -'
 				)
 			);
 		});
@@ -188,7 +223,7 @@ describe('formatters', () => {
 			expect(formatMessage(t(), message)).toBe(
 				join(
 					'[3/26/21, 10:29:51 PM] Skyra#7023 [BOT]', //
-					'>_ [🖼️ https://skyra.pw/avatars/skyra.png]'
+					'>_ [https://skyra.pw/avatars/skyra.png]'
 				)
 			);
 		});
@@ -199,7 +234,74 @@ describe('formatters', () => {
 			expect(formatMessage(t(), message)).toBe(
 				join(
 					'[3/26/21, 10:29:51 PM] Skyra#7023 [BOT]', //
-					'>_ [🖼️ https://skyra.pw/avatars/skyra.png] - Yes, that is me!'
+					'>_ [https://skyra.pw/avatars/skyra.png] - Yes, that is me!'
+				)
+			);
+		});
+
+		test('GIVEN image embed THEN returns image embed', () => {
+			const message = createMessage({
+				embeds: [
+					{
+						type: EmbedType.Image,
+						url: 'https://media.discordapp.net/attachments/758186338217492503/825157377090912296/birdflip2.gif',
+						thumbnail: {
+							url: 'https://media.discordapp.net/attachments/758186338217492503/825157377090912296/birdflip2.gif',
+							proxy_url:
+								'https://images-ext-2.discordapp.net/external/nFHEK4-YMyLCGsv4MbtTgwxCudyi3Q6jezLx4cLdfOc/https/media.discordapp.net/attachments/758186338217492503/825157377090912296/birdflip2.gif',
+							width: 494,
+							height: 368
+						}
+					}
+				]
+			});
+
+			expect(formatMessage(t(), message)).toBe(
+				join(
+					'[3/26/21, 10:29:51 PM] Skyra#7023 [BOT]', //
+					'🖼️ [https://media.discordapp.net/attachments/758186338217492503/825157377090912296/birdflip2.gif]'
+				)
+			);
+		});
+
+		test('GIVEN video embed THEN returns video embed', () => {
+			const message = createMessage({
+				embeds: [
+					{
+						type: EmbedType.Video,
+						url: 'https://www.youtube.com/watch?v=5dqixBi8TPU',
+						title: "LADY'S ONLY feat. Marpril - Throwback",
+						description:
+							"ハッとした時の冷却。\n\n【Throwback】\n\nVocal ：Marpril \n立花鈴\nhttps://twitter.com/Rin04ple\n谷田透佳\nhttps://twitter.com/Touka03mar\n\nMusic：LADY'S ONLY\nhttps://twitter.com/LADY50NLY\n\nLyric：uyuni\nhttps://twitter.com/uyn_yn\n\nChoreographer：ALEXANDER KAWAMOTO(アレックス) \nhttps://www.instagram.com/alex_kwmt/ \n\nMovie：ノノル ／ ヲタきち\nThrowback ロゴデザイン　チョロみ\nhttps://twitter.com/nonolu41...",
+						color: 16711680,
+						author: {
+							name: 'Marpril Channel',
+							url: 'https://www.youtube.com/channel/UCWhv732tk4DAQ7X32qHKrfA'
+						},
+						provider: {
+							name: 'YouTube',
+							url: 'https://www.youtube.com'
+						},
+						thumbnail: {
+							url: 'https://i.ytimg.com/vi/5dqixBi8TPU/maxresdefault.jpg',
+							proxy_url:
+								'https://images-ext-1.discordapp.net/external/gk1nrmD5dvvSyYrFm1tMGNOm6f80Ps1hyX8zf9bYImw/https/i.ytimg.com/vi/5dqixBi8TPU/maxresdefault.jpg',
+							width: 1280,
+							height: 720
+						},
+						video: {
+							url: 'https://www.youtube.com/embed/5dqixBi8TPU',
+							width: 1280,
+							height: 720
+						}
+					}
+				]
+			});
+
+			expect(formatMessage(t(), message)).toBe(
+				join(
+					'[3/26/21, 10:29:51 PM] Skyra#7023 [BOT]', //
+					'📹 [https://www.youtube.com/watch?v=5dqixBi8TPU] (YouTube).'
 				)
 			);
 		});

--- a/tests/lib/formatters.test.ts
+++ b/tests/lib/formatters.test.ts
@@ -1,0 +1,196 @@
+import { GuildMessage } from '#lib/types';
+import { client, textChannel } from '#mocks/MockInstances';
+import { formatMessage } from '#utils/formatters';
+import { APIMessage } from 'discord-api-types/v6';
+import { Message } from 'discord.js';
+
+describe('formatters', () => {
+	describe('formatMessage', () => {
+		beforeAll(() => client.i18n.init());
+
+		function createMessage(data: Partial<APIMessage> = {}): GuildMessage {
+			const messageData: APIMessage = {
+				id: '825134485813067796',
+				type: 0,
+				content: '',
+				channel_id: '331027040306331648',
+				author: {
+					id: '266624760782258186',
+					username: 'Skyra',
+					avatar: '51227d2976cc66b9c1add6b911eda5e9',
+					discriminator: '7023',
+					public_flags: 65536,
+					bot: true
+				},
+				attachments: [],
+				embeds: [],
+				mentions: [],
+				mention_roles: [],
+				pinned: false,
+				mention_everyone: false,
+				tts: false,
+				timestamp: '2021-03-26T22:29:51.675000+00:00',
+				edited_timestamp: '2021-03-26T22:29:56.581000+00:00',
+				flags: 0
+			};
+
+			return new Message(client, { ...messageData, ...data }, textChannel) as GuildMessage;
+		}
+
+		function t() {
+			return client.i18n.fetchT('en-US');
+		}
+
+		function join(...parts: string[]) {
+			return parts.join('\n');
+		}
+
+		test('GIVEN empty message THEN returns header only', () => {
+			const message = createMessage();
+
+			expect(formatMessage(t(), message)).toBe(
+				join(
+					'[3/26/21, 10:29:51 PM] Skyra#7023 [BOT]', //
+					''
+				)
+			);
+		});
+
+		test('GIVEN content only THEN returns content only', () => {
+			const message = createMessage({ content: 'Hello World' });
+
+			expect(formatMessage(t(), message)).toBe(
+				join(
+					'[3/26/21, 10:29:51 PM] Skyra#7023 [BOT]', //
+					'> Hello World'
+				)
+			);
+		});
+
+		test('GIVEN content only with block quotes THEN returns content only with nested block quotes', () => {
+			const message = createMessage({ content: '> Block Quotes!' });
+
+			expect(formatMessage(t(), message)).toBe(
+				join(
+					'[3/26/21, 10:29:51 PM] Skyra#7023 [BOT]', //
+					'> > Block Quotes!'
+				)
+			);
+		});
+
+		test('GIVEN embed title only THEN returns embed title only', () => {
+			const message = createMessage({ embeds: [{ title: 'Your Title Goes Here' }] });
+
+			expect(formatMessage(t(), message)).toBe(
+				join(
+					'[3/26/21, 10:29:51 PM] Skyra#7023 [BOT]', //
+					'># Your Title Goes Here'
+				)
+			);
+		});
+
+		test('GIVEN embed description only THEN returns embed description only', () => {
+			const message = createMessage({ embeds: [{ description: 'Hello!' }] });
+
+			expect(formatMessage(t(), message)).toBe(
+				join(
+					'[3/26/21, 10:29:51 PM] Skyra#7023 [BOT]', //
+					'> > Hello!'
+				)
+			);
+		});
+
+		test('GIVEN embed with one field only THEN returns embed with one field only', () => {
+			const message = createMessage({ embeds: [{ fields: [{ name: 'Hello', value: 'World!' }] }] });
+
+			expect(formatMessage(t(), message)).toBe(
+				join(
+					'[3/26/21, 10:29:51 PM] Skyra#7023 [BOT]', //
+					'> #> Hello',
+					'>  > World!'
+				)
+			);
+		});
+
+		test('GIVEN embed with two fields THEN returns embed with two fields', () => {
+			const message = createMessage({
+				embeds: [
+					{
+						fields: [
+							{ name: 'Hello', value: 'World!' },
+							{ name: 'Foo', value: 'Bar' }
+						]
+					}
+				]
+			});
+
+			expect(formatMessage(t(), message)).toBe(
+				join(
+					'[3/26/21, 10:29:51 PM] Skyra#7023 [BOT]', //
+					'> #> Hello',
+					'>  > World!',
+					'> #> Foo',
+					'>  > Bar'
+				)
+			);
+		});
+
+		test('GIVEN embed with description and two fields THEN returns embed with description and two fields', () => {
+			const message = createMessage({
+				embeds: [
+					{
+						description: 'This is a description!',
+						fields: [
+							{ name: 'Hello', value: 'World!' },
+							{ name: 'Foo', value: 'Bar' }
+						]
+					}
+				]
+			});
+
+			expect(formatMessage(t(), message)).toBe(
+				join(
+					'[3/26/21, 10:29:51 PM] Skyra#7023 [BOT]', //
+					'> > This is a description!',
+					'> #> Hello',
+					'>  > World!',
+					'> #> Foo',
+					'>  > Bar'
+				)
+			);
+		});
+
+		test('GIVEN embed footer with text only THEN returns embed footer with text only', () => {
+			const message = createMessage({ embeds: [{ footer: { text: 'Your Footer!' } }] });
+
+			expect(formatMessage(t(), message)).toBe(
+				join(
+					'[3/26/21, 10:29:51 PM] Skyra#7023 [BOT]', //
+					'>_ Your Footer!'
+				)
+			);
+		});
+
+		test('GIVEN embed footer with icon only THEN returns embed footer with icon only', () => {
+			const message = createMessage({ embeds: [{ footer: { icon_url: 'https://skyra.pw/avatars/skyra.png', text: '' } }] });
+
+			expect(formatMessage(t(), message)).toBe(
+				join(
+					'[3/26/21, 10:29:51 PM] Skyra#7023 [BOT]', //
+					'>_ [🖼️ https://skyra.pw/avatars/skyra.png]'
+				)
+			);
+		});
+
+		test('GIVEN embed footer with icon and text THEN returns embed footer with icon and text', () => {
+			const message = createMessage({ embeds: [{ footer: { icon_url: 'https://skyra.pw/avatars/skyra.png', text: 'Yes, that is me!' } }] });
+
+			expect(formatMessage(t(), message)).toBe(
+				join(
+					'[3/26/21, 10:29:51 PM] Skyra#7023 [BOT]', //
+					'>_ [🖼️ https://skyra.pw/avatars/skyra.png] - Yes, that is me!'
+				)
+			);
+		});
+	});
+});

--- a/tests/lib/util.test.ts
+++ b/tests/lib/util.test.ts
@@ -512,7 +512,7 @@ describe('Utils', () => {
 					content: '',
 					embeds: [new MessageEmbed().addField('Name', 'Value')]
 				} as unknown) as Message)
-			).toEqual('Name Value');
+			).toEqual('Name\nValue');
 		});
 
 		test('GIVEN no detectable content THEN returns null', () => {

--- a/tests/mocks/MockInstances.ts
+++ b/tests/mocks/MockInstances.ts
@@ -1,9 +1,86 @@
 import { LanguageKeys } from '#lib/i18n/languageKeys';
 import { SkyraCommand } from '#lib/structures';
+import { CLIENT_OPTIONS } from '#root/config';
 import { SapphireClient } from '@sapphire/framework';
+import { APIChannel, APIGuild, ChannelType, GuildFeature } from 'discord-api-types/v6';
+import { Guild, TextChannel } from 'discord.js';
 import { resolve } from 'path';
 
-export const client = new SapphireClient();
+export const client = new SapphireClient(CLIENT_OPTIONS);
+
+export const guildData: APIGuild = {
+	id: '254360814063058944',
+	name: 'Skyra Lounge',
+	icon: 'a_933397e7006838cf97fe70e47605b274',
+	description: null,
+	splash: null,
+	discovery_splash: null,
+	features: [
+		GuildFeature.NEWS,
+		GuildFeature.ANIMATED_ICON,
+		GuildFeature.COMMERCE,
+		GuildFeature.WELCOME_SCREEN_ENABLED,
+		GuildFeature.INVITE_SPLASH,
+		GuildFeature.COMMUNITY
+	],
+	emojis: [],
+	banner: null,
+	owner_id: '242043489611808769',
+	application_id: null,
+	region: 'eu-central',
+	afk_channel_id: null,
+	afk_timeout: 60,
+	system_channel_id: '254360814063058944',
+	widget_enabled: true,
+	widget_channel_id: '409663610780909569',
+	verification_level: 2,
+	roles: [
+		{
+			id: '254360814063058944',
+			name: '@​everyone',
+			color: 0,
+			hoist: false,
+			position: 0,
+			permissions: 104189505,
+			permissions_new: '104189505',
+			managed: false,
+			mentionable: false
+		}
+	],
+	default_message_notifications: 1,
+	mfa_level: 1,
+	explicit_content_filter: 2,
+	max_presences: null,
+	max_members: 100000,
+	max_video_channel_users: 25,
+	vanity_url_code: null,
+	premium_tier: 1,
+	premium_subscription_count: 3,
+	system_channel_flags: 0,
+	preferred_locale: 'en-US',
+	rules_channel_id: '409663610780909569',
+	public_updates_channel_id: '700806874294911067',
+	embed_enabled: true,
+	embed_channel_id: '409663610780909569'
+};
+export const guild = new Guild(client, guildData);
+
+export const textChannelData: APIChannel = {
+	type: ChannelType.GUILD_TEXT,
+	id: '331027040306331648',
+	name: 'staff-testing',
+	position: 19,
+	parent_id: '355963113696133130',
+	permission_overwrites: [],
+	topic: null,
+	last_message_id: '825133477896388670',
+	rate_limit_per_user: 0,
+	last_pin_timestamp: '2021-01-17T08:17:36.935Z',
+	guild_id: '254360814063058944',
+	nsfw: false
+};
+export const textChannel = new TextChannel(guild, textChannelData);
+
 export const commands = client.stores.get('commands');
 
 function addCommand(command: SkyraCommand) {


### PR DESCRIPTION
- feat(content): Adds `--all` for getting all content from a string.
- feat(content): Adds `--formatted` for getting all content from a string and formatting it.
- fix(prune-logs): Resolved bug making rich embeds show as `[null]`.

Fixes #1350.

In a side note, we can finally test stuff that uses i18n!