### PR TITLE
refactor(i18n): rename guild to server

### DIFF
--- a/src/languages/en-US/commands/management.json
+++ b/src/languages/en-US/commands/management.json
@@ -27,7 +27,7 @@
 	"triggersRemove": "Successfully removed this trigger.",
 	"triggersAddTaken": "There is already a trigger with this input.",
 	"triggersAdd": "Successfully added the trigger.",
-	"triggersListEmpty": "The trigger list for this guild is empty.",
+	"triggersListEmpty": "The trigger list for this server is empty.",
 	"guildInfoTitles": {
 		"CHANNELS": "Channels",
 		"MEMBERS": "Members",
@@ -92,7 +92,7 @@
 	"stickyRolesShowSingle": "Sticky Role(s) for **{{user}}**: {{roles, andList}}.",
 	"createMuteDescription": "Prepare the mute system.",
 	"createMuteExtended": {
-		"extendedHelp": "This command prepares the mute system by creating a role called `muted`, and configuring it to the guild settings. This command also modifies all channels (where possible) permissions and disables the permission **{{SEND_MESSAGES, permissions}}** in text channels and **{{CONNECT, permissions}}** in voice channels for said role."
+		"extendedHelp": "This command prepares the mute system by creating a role called `muted`, and configuring it to the server settings. This command also modifies all channels (where possible) permissions and disables the permission **{{SEND_MESSAGES, permissions}}** in text channels and **{{CONNECT, permissions}}** in voice channels for said role."
 	},
 	"nickDescription": "Change Skyra's nickname for this server.",
 	"nickExtended": {
@@ -152,7 +152,7 @@
 		],
 		"reminder": "The server owner cannot have any actions, nor the `everyone` role can have allowed commands."
 	},
-	"triggersDescription": "Set custom triggers for your guild!.",
+	"triggersDescription": "Set custom triggers for your server.",
 	"triggersExtended": {
 		"usages": [
 			"add alias Input Command",
@@ -161,7 +161,7 @@
 			"show",
 			""
 		],
-		"extendedHelp": "This command allows administrators to go further with the personalization of Skyra in the guild!.\nA trigger is a piece that can active other functions.\nFor example, the aliases are triggers that get executed when the command does not exist in bot, triggering the unknown command event.\nWhen this happens, the alias system executes and tries to find an entry that matches with the input.",
+		"extendedHelp": "This command allows administrators to go further with the personalization of Skyra in the server.\nA trigger is a piece that can active other functions.\nFor example, the aliases are triggers that get executed when the command does not exist in bot, triggering the unknown command event.\nWhen this happens, the alias system executes and tries to find an entry that matches with the input.",
 		"explainedUsage": [
 			[
 				"add alias",
@@ -189,7 +189,7 @@
 			""
 		]
 	},
-	"managecommandautodeleteDescription": "Manage per-channel autodelete timer.",
+	"managecommandautodeleteDescription": "Manage per-channel auto-delete timer.",
 	"managecommandautodeleteExtended": {
 		"usages": [
 			"add TextChannel Seconds",
@@ -198,15 +198,15 @@
 			"show",
 			""
 		],
-		"extendedHelp": "This command manages this guild's per-channel command autodelete timer, it serves well to leave a channel clean from commands.",
+		"extendedHelp": "This command manages this server's per-channel command auto-delete timer, it serves well to leave a channel clean from commands.",
 		"explainedUsage": [
 			[
 				"add",
-				"Add an autodelete timer for the specified channel."
+				"Add an auto-delete timer for the specified channel."
 			],
 			[
 				"remove",
-				"Remove the autotimer from the specified channel."
+				"Remove the auto-timer from the specified channel."
 			],
 			[
 				"reset",
@@ -228,7 +228,7 @@
 	"manageCommandChannelDescription": "Manage per-channel blocked command list.",
 	"manageCommandChannelExtended": {
 		"usages": ["add TextChannel Command", "remove TextChannel Command", "reset TextChannel", "show TextChannel"],
-		"extendedHelp": "This command manages this guild's per-channel blocked command list, it serves well to disable certain commands you do not want to be used in certain channels (to disable a command globally, use the `disabledCommands` settings key to disable in all channels.",
+		"extendedHelp": "This command manages this server's per-channel blocked command list, it serves well to disable certain commands you do not want to be used in certain channels (to disable a command globally, use the `disabledCommands` settings key to disable in all channels.",
 		"explainedUsage": [
 			["show [channel]", "Show the list of commands blocked in the specified channel."],
 			["add [channel] <command>", "Add a command to the specified channel's list of blocked commands."],
@@ -350,7 +350,7 @@
 				"A TextChannel. You can either put the name of the channel, tag it, or type in \"here\" to select the channel the message was sent."
 			]
 		],
-		"reminder": "Due to Discord limitations, Skyra cannot know who deleted a message. The only way to know is by fetching audit logs, requiring the permission **{{VIEW_AUDIT_LOG, permissions}}** which access is limited in the majority of guilds and the amount of times I can fetch them in a period of time.",
+		"reminder": "Due to Discord limitations, Skyra cannot know who deleted a message. The only way to know is by fetching audit logs, requiring the permission **{{VIEW_AUDIT_LOG, permissions}}** which access is limited in the majority of servers and the amount of times I can fetch them in a period of time.",
 		"examples": [
 			"#message-logs",
 			"here"
@@ -409,9 +409,9 @@
 			"⭐"
 		]
 	},
-	"guildInfoDescription": "Check the information of the guild!.",
+	"guildInfoDescription": "Check the information of the server.",
 	"guildInfoExtended": {
-		"extendedHelp": "The serverinfo command displays information for the guild the message got sent.\nIt shows the amount of channels, with the count for each category, the amount of members (given from the API), the owner with their user id, the amount of roles, region, creation date, verification level... between others."
+		"extendedHelp": "The serverinfo command displays information for the server the message got sent.\nIt shows the amount of channels, with the count for each category, the amount of members (given from the API), the owner with their user id, the amount of roles, region, creation date, verification level... between others."
 	},
 	"roleInfoDescription": "Check the information for a role.",
 	"roleInfoExtended": {
@@ -464,7 +464,7 @@
 		],
 		"reminder": "The member's roles will not be modified by this command, you need to add or remove them."
 	},
-	"attachmentsModeDescription": "Manage this guild's flags for the attachments filter.",
+	"attachmentsModeDescription": "Manage this server's flags for the attachments filter.",
 	"attachmentsModeExtended": {
 		"usages": [
 			"on/e/enable",
@@ -528,7 +528,7 @@
 			"threshold-duration 30s"
 		]
 	},
-	"capitalsModeDescription": "Manage this guild's flags for the caps filter.",
+	"capitalsModeDescription": "Manage this server's flags for the caps filter.",
 	"capitalsModeExtended": {
 		"usages": [
 			"on/e/enable",
@@ -592,10 +592,10 @@
 			"threshold-duration 30s"
 		]
 	},
-	"filterDescription": "Manage this guild's list of blocked words.",
+	"filterDescription": "Manage this server's list of blocked words.",
 	"filterExtended": {
 		"usages": ["add Word", "remove Word", "reset", "show", ""],
-		"extendedHelp": "The filter command manages the list of blocked words for this guild and must have a filter mode set up (see: `Skyra, help filterMode`).\n\nSkyra's word filter can find matches even with special characters or spaces between the letters of a blocked word, as well as duplicated characters for enhanced filtering.",
+		"extendedHelp": "The filter command manages the list of blocked words for this server and must have a filter mode set up (see: `Skyra, help filterMode`).\n\nSkyra's word filter can find matches even with special characters or spaces between the letters of a blocked word, as well as duplicated characters for enhanced filtering.",
 		"examples": ["add darn", "remove darn", "reset", "show", ""]
 	},
 	"filterModeDescription": "Manage this server's word filter modes.",

--- a/src/languages/en-US/commands/misc.json
+++ b/src/languages/en-US/commands/misc.json
@@ -286,7 +286,7 @@
 			"User",
 			""
 		],
-		"extendedHelp": "This commands generates a ship name between two users and creates more love in the world.\nUsers are optional, you can provide none, just one or both users. For any non-provided users I will pick a random guild member.",
+		"extendedHelp": "This commands generates a ship name between two users and creates more love in the world.\nUsers are optional, you can provide none, just one or both users. For any non-provided users I will pick a random server member.",
 		"explainedUsage": [
 			[
 				"User",

--- a/src/languages/en-US/commands/moderation.json
+++ b/src/languages/en-US/commands/moderation.json
@@ -90,7 +90,7 @@
 	"moderationDmDescriptionWithReason": "**❯ Server**: {{guild}}\n**❯ Type**: {{title}}\n**❯ Reason**: {{reason}}",
 	"moderationDmDescriptionWithDuration": "**❯ Server**: {{guild}}\n**❯ Type**: {{title}}\n**❯ Duration**: {{duration, duration}}\n**❯ Reason**: None specified",
 	"moderationDmDescriptionWithReasonWithDuration": "**❯ Server**: {{guild}}\n**❯ Type**: {{title}}\n**❯ Duration**: {{duration, duration}}\n**❯ Reason**: {{reason}}",
-	"historyDescription": "Display the count of moderation cases from this guild or from a user.",
+	"historyDescription": "Display the count of moderation cases from this server or from a user.",
 	"historyExtended": {
 		"usages": [
 			"",
@@ -127,7 +127,7 @@
 	"historyFooterKicks_plural": "kicks",
 	"historyFooterBans": "ban",
 	"historyFooterBans_plural": "bans",
-	"moderationsDescription": "List all running moderation logs from this guild.",
+	"moderationsDescription": "List all running moderation logs from this server.",
 	"moderationsExtended": {
 		"usages": [
 			"",
@@ -156,25 +156,25 @@
 	"moderationsEmpty": "There are no active moderations that will expire at some future date or time. If you want to see all moderations in this server use: `{{prefix}}history`.",
 	"moderationsAmount": "There is 1 entry.",
 	"moderationsAmount_plural": "There are {{count}} entries.",
-	"mutesDescription": "List all mutes from this guild or from a user.",
+	"mutesDescription": "List all mutes from this server or from a user.",
 	"mutesExtended": {
 		"usages": [
 			"",
 			"User"
 		],
-		"extendedHelp": "This command shows either all mutes filed in this guild, or all mutes filed in this guild for a specific user.\nThis command uses a reaction-based menu and requires the permission **{{MANAGE_MESSAGES, permissions}}** to execute correctly.",
+		"extendedHelp": "This command shows either all mutes filed in this server, or all mutes filed in this server for a specific user.\nThis command uses a reaction-based menu and requires the permission **{{MANAGE_MESSAGES, permissions}}** to execute correctly.",
 		"examples": [
 			"",
 			"@Pete"
 		]
 	},
-	"warningsDescription": "List all warnings from this guild or from a user.",
+	"warningsDescription": "List all warnings from this server or from a user.",
 	"warningsExtended": {
 		"usages": [
 			"",
 			"User"
 		],
-		"extendedHelp": "This command shows either all warnings filed in this guild, or all warnings filed in this guild for a specific user.\nThis command uses a reaction-based menu and requires the permission **{{MANAGE_MESSAGES, permissions}}** to execute correctly.",
+		"extendedHelp": "This command shows either all warnings filed in this server, or all warnings filed in this server for a specific user.\nThis command uses a reaction-based menu and requires the permission **{{MANAGE_MESSAGES, permissions}}** to execute correctly.",
 		"examples": [
 			"",
 			"@Pete"
@@ -220,7 +220,7 @@
 				"The amount of days of messages to prune. Should be a number between a minimum of 0 and maximum of 7."
 			]
 		],
-		"extendedHelp": "This command requires **{{BAN_MEMBERS, permissions}}**, and only members with lower role hierarchy position can be banned by me.\nNo, the guild's owner cannot be banned.\nThis action can be optionally timed to create a temporary ban.",
+		"extendedHelp": "This command requires **{{BAN_MEMBERS, permissions}}**, and only members with lower role hierarchy position can be banned by me.\nNo, the server's owner cannot be banned.\nThis action can be optionally timed to create a temporary ban.",
 		"examples": [
 			"@Pete",
 			"@Pete Spamming all channels.",
@@ -239,7 +239,7 @@
 			"User1 User2 User3...User10",
 			"User Reason"
 		],
-		"extendedHelp": "This command requires **{{KICK_MEMBERS, permissions}}**, and only members with lower role hierarchy position can be kicked by me. No, the guild's owner cannot be kicked.",
+		"extendedHelp": "This command requires **{{KICK_MEMBERS, permissions}}**, and only members with lower role hierarchy position can be kicked by me. No, the server's owner cannot be kicked.",
 		"explainedUsage": [
 			[
 				"User/User1/User2",
@@ -313,7 +313,7 @@
 				"The reason for the mute. This will also show in the server's audit logs."
 			]
 		],
-		"extendedHelp": "This command requires **{{MANAGE_ROLES, permissions}}**, and only members with lower role hierarchy position can be managed by me.\nNo, the guild's owner cannot be muted.\nThis action can be optionally timed to create a temporary mute. This action saves a member's roles temporarily and will be granted to the user after the unmute.\nThe muted role is **sticky**, if the user tries to remove it by rejoining the guild, it will be added back.",
+		"extendedHelp": "This command requires **{{MANAGE_ROLES, permissions}}**, and only members with lower role hierarchy position can be managed by me.\nNo, the server's owner cannot be muted.\nThis action can be optionally timed to create a temporary mute. This action saves a member's roles temporarily and will be granted to the user after the unmute.\nThe muted role is **sticky**, if the user tries to remove it by rejoining the server, it will be added back.",
 		"examples": [
 			"@Alphonse",
 			"@Alphonse Spamming all channels",
@@ -347,7 +347,7 @@
 				"The reason for this nickname change. This will also show in the server's audit logs."
 			]
 		],
-		"extendedHelp": "This command requires **{{MANAGE_NICKNAMES, permissions}}**, and only members with lower role hierarchy position can be managed by me.\nNo, the guild's owner nickname cannot be changed.",
+		"extendedHelp": "This command requires **{{MANAGE_NICKNAMES, permissions}}**, and only members with lower role hierarchy position can be managed by me.\nNo, the server's owner nickname cannot be changed.",
 		"examples": [
 			"@Pete peeehteeerrr",
 			"@ꓑ𝗲੮ẻ Pete Unmentionable name"
@@ -381,7 +381,7 @@
 				"The reason for adding this role. This will also show in the server's audit logs."
 			]
 		],
-		"extendedHelp": "This command requires **{{MANAGE_ROLES, permissions}}**, and only members with lower role hierarchy position can be managed by me.\nNo, the guild's owner roles cannot be changed.",
+		"extendedHelp": "This command requires **{{MANAGE_ROLES, permissions}}**, and only members with lower role hierarchy position can be managed by me.\nNo, the server's owner roles cannot be changed.",
 		"examples": [
 			"@John member",
 			"@John member Make John a member"
@@ -414,7 +414,7 @@
 				"The reason for removing this role. This will also show in the server's audit logs."
 			]
 		],
-		"extendedHelp": "This command requires **{{MANAGE_ROLES, permissions}}**, and only members with lower role hierarchy position can be managed by me.\nNo, the guild's owner roles cannot be changed.",
+		"extendedHelp": "This command requires **{{MANAGE_ROLES, permissions}}**, and only members with lower role hierarchy position can be managed by me.\nNo, the server's owner roles cannot be changed.",
 		"examples": [
 			"@Paula member",
 			"@Paula member Remove member permissions from Paula"
@@ -570,7 +570,7 @@
 				"The reason for adding this restriction. This will also show in the server's audit logs."
 			]
 		],
-		"extendedHelp": "This command requires **{{MANAGE_ROLES, permissions}}**, and only members with lower role hierarchy position can be managed by me.\nNo, the guild's owner cannot be restricted.\nThis action can be optionally timed to create a temporary restriction.\nThe restricted role is **sticky**, if the user tries to remove it by rejoining the guild, it will be added back.",
+		"extendedHelp": "This command requires **{{MANAGE_ROLES, permissions}}**, and only members with lower role hierarchy position can be managed by me.\nNo, the server's owner cannot be restricted.\nThis action can be optionally timed to create a temporary restriction.\nThe restricted role is **sticky**, if the user tries to remove it by rejoining the server, it will be added back.",
 		"examples": [
 			"@Pete",
 			"@Pete Sending weird images",
@@ -599,7 +599,7 @@
 				"The reason for adding this restriction. This will also show in the server's audit logs."
 			]
 		],
-		"extendedHelp": "This command requires **{{MANAGE_ROLES, permissions}}**, and only members with lower role hierarchy position can be managed by me.\nNo, the guild's owner cannot be restricted.\nThis action can be optionally timed to create a temporary restriction.\nThe restricted role is **sticky**, if the user tries to remove it by rejoining the guild, it will be added back.",
+		"extendedHelp": "This command requires **{{MANAGE_ROLES, permissions}}**, and only members with lower role hierarchy position can be managed by me.\nNo, the server's owner cannot be restricted.\nThis action can be optionally timed to create a temporary restriction.\nThe restricted role is **sticky**, if the user tries to remove it by rejoining the server, it will be added back.",
 		"examples": [
 			"@Pete",
 			"@Pete Sending weird links",
@@ -629,7 +629,7 @@
 				"The reason for adding this restriction. This will also show in the server's audit logs."
 			]
 		],
-		"extendedHelp": "This command requires **{{MANAGE_ROLES, permissions}}**, and only members with lower role hierarchy position can be managed by me.\nNo, the guild's owner cannot be restricted.\nThis action can be optionally timed to create a temporary restriction.\nThe restricted role is **sticky**, if the user tries to remove it by rejoining the guild, it will be added back.",
+		"extendedHelp": "This command requires **{{MANAGE_ROLES, permissions}}**, and only members with lower role hierarchy position can be managed by me.\nNo, the server's owner cannot be restricted.\nThis action can be optionally timed to create a temporary restriction.\nThe restricted role is **sticky**, if the user tries to remove it by rejoining the server, it will be added back.",
 		"examples": [
 			"@Pete",
 			"@Pete Spamming external emojis",
@@ -659,7 +659,7 @@
 				"The reason for adding this restriction. This will also show in the server's audit logs."
 			]
 		],
-		"extendedHelp": "This command requires **{{MANAGE_ROLES, permissions}}**, and only members with lower role hierarchy position can be managed by me.\nNo, the guild's owner cannot be restricted.\nThis action can be optionally timed to create a temporary restriction.\nThe restricted role is **sticky**, if the user tries to remove it by rejoining the guild, it will be added back.",
+		"extendedHelp": "This command requires **{{MANAGE_ROLES, permissions}}**, and only members with lower role hierarchy position can be managed by me.\nNo, the server's owner cannot be restricted.\nThis action can be optionally timed to create a temporary restriction.\nThe restricted role is **sticky**, if the user tries to remove it by rejoining the server, it will be added back.",
 		"examples": [
 			"@Pete",
 			"@Pete Spamming reactions",
@@ -688,7 +688,7 @@
 				"The reason for adding this restriction. This will also show in the server's audit logs."
 			]
 		],
-		"extendedHelp": "This command requires **{{MANAGE_ROLES, permissions}}**, and only members with lower role hierarchy position can be managed by me.\nNo, the guild's owner cannot be restricted.\nThis action can be optionally timed to create a temporary restriction.\nThe restricted role is **sticky**, if the user tries to remove it by rejoining the guild, it will be added back.",
+		"extendedHelp": "This command requires **{{MANAGE_ROLES, permissions}}**, and only members with lower role hierarchy position can be managed by me.\nNo, the server's owner cannot be restricted.\nThis action can be optionally timed to create a temporary restriction.\nThe restricted role is **sticky**, if the user tries to remove it by rejoining the server, it will be added back.",
 		"examples": [
 			"@Pete",
 			"@Pete Earraping in general voice channels",
@@ -712,7 +712,7 @@
 				"The reason for the softban. This will also show in the server's audit logs."
 			]
 		],
-		"extendedHelp": "This command requires **{{BAN_MEMBERS, permissions}}**, and only members with lower role hierarchy position can be banned by me.\nNo, the guild's owner cannot be banned.\nThe ban feature from Discord has a feature that allows the moderator to remove all messages from all channels that have been sent in the last 'x' days, being a number between 0 (no days) and 7.\nThe user gets unbanned right after the ban, so it is like a kick, but that can prune many many messages.",
+		"extendedHelp": "This command requires **{{BAN_MEMBERS, permissions}}**, and only members with lower role hierarchy position can be banned by me.\nNo, the server's owner cannot be banned.\nThe ban feature from Discord has a feature that allows the moderator to remove all messages from all channels that have been sent in the last 'x' days, being a number between 0 (no days) and 7.\nThe user gets unbanned right after the ban, so it is like a kick, but that can prune many many messages.",
 		"examples": [
 			"@Pete",
 			"@Pete Spamming all channels",
@@ -723,7 +723,7 @@
 	"toggleModerationDmExtended": {
 		"extendedHelp": "This command allows you to toggle moderation DMs. By default, they are on, meaning that any moderation action (automatic or manual) will DM you, but you can disable them with this command."
 	},
-	"unbanDescription": "Unban somebody from this guild!.",
+	"unbanDescription": "Unban somebody from this server.",
 	"unbanExtended": {
 		"usages": [
 			"User",
@@ -740,7 +740,7 @@
 				"The reason for the ban removal. This will also show in the server's audit logs."
 			]
 		],
-		"extendedHelp": "This command requires **{{BAN_MEMBERS, permissions}}**. It literally gets somebody from the rubbish bin, cleans them up, and allows the pass to this guild's gates.",
+		"extendedHelp": "This command requires **{{BAN_MEMBERS, permissions}}**. It literally gets somebody from the rubbish bin, cleans them up, and allows the pass to this server's gates.",
 		"examples": [
 			"@Pete",
 			"@Pete Turns out he was not the one who spammed all channels 🤷"
@@ -923,7 +923,7 @@
 				"The reason for adding this voice mute. This will also show in the server's audit logs."
 			]
 		],
-		"extendedHelp": "This command requires **{{MUTE_MEMBERS, permissions}}**, and only members with lower role hierarchy position can be silenced by me.\nNo, the guild's owner cannot be silenced.\nThis action can be optionally timed to create a temporary voice mute.",
+		"extendedHelp": "This command requires **{{MUTE_MEMBERS, permissions}}**, and only members with lower role hierarchy position can be silenced by me.\nNo, the server's owner cannot be silenced.\nThis action can be optionally timed to create a temporary voice mute.",
 		"examples": [
 			"@Pete",
 			"@Pete Singing too loud",
@@ -971,7 +971,7 @@
 				"The reason for removing the voice mute. This will also show in the server's audit logs."
 			]
 		],
-		"extendedHelp": "This command requires **{{MUTE_MEMBERS, permissions}}**, and only members with lower role hierarchy position can be un-silenced by me.\nNo, the guild's owner cannot be un-silenced.",
+		"extendedHelp": "This command requires **{{MUTE_MEMBERS, permissions}}**, and only members with lower role hierarchy position can be un-silenced by me.\nNo, the server's owner cannot be un-silenced.",
 		"examples": [
 			"@Pete",
 			"@Pete Appealed his times signing hear rape."

--- a/src/languages/en-US/commands/social.json
+++ b/src/languages/en-US/commands/social.json
@@ -104,7 +104,7 @@
 	"reputations": "The user {{user}} has a total of {{points}}.",
 	"scoreboardPosition": "Your placing position is: {{position}}",
 	"setColor": "Color changed to {{color}}",
-	"socialDescription": "Configure this guild's member points.",
+	"socialDescription": "Configure this server's member points.",
 	"socialExtended": {
 		"usages": [
 			"add User Integer",
@@ -179,7 +179,7 @@
 	"toggleDarkModeExtended": {
 		"extendedHelp": "This command lets you toggle the template used to generate your profile."
 	},
-	"autoRoleDescription": "List or configure the autoroles for a guild.",
+	"autoRoleDescription": "List or configure the level roles for a server.",
 	"autoRoleExtended": {
 		"usages": [
 			"add Role Integer",
@@ -190,7 +190,7 @@
 			"show",
 			""
 		],
-		"extendedHelp": "Autoroles are roles that are available for everyone, and automatically given when they reach a configured amount of (local) points, an administrator must configure them through a setting command.\nNote that if the role name has spaces in the name you need to put `'quotes'` around the name!",
+		"extendedHelp": "Level roles are roles that are available for everyone, and automatically given when they reach a configured amount of (local) points, an administrator must configure them through a setting command.\nNote that if the role name has spaces in the name you need to put `'quotes'` around the name!",
 		"explainedUsage": [
 			[
 				"add",
@@ -260,7 +260,7 @@
 				"The page number to jump to. Defaults to 1."
 			]
 		],
-		"reminder": "\"Local\" leaderboards refer to the guild's top list. \"Global\" refers to all scores from all guilds."
+		"reminder": "`local` leaderboards refer to the server's top list. `global` refers to all scores from all servers."
 	},
 	"leaderboardListifyPage": "Page {{page}} / {{pageCount}} | {{results, number}} Total",
 	"levelDescription": "Check your global level.",
@@ -309,11 +309,11 @@
 			"User",
 			""
 		],
-		"extendedHelp": "How much until next auto role? How many points do I have in this guild?",
+		"extendedHelp": "How much until next auto role? How many points do I have in this server?",
 		"explainedUsage": [
 			[
 				"user",
-				"(Optional) The user's profile to show. Defaults to the message's author!."
+				"(Optional) The user's profile to show. Defaults to the message's author."
 			]
 		]
 	},

--- a/src/languages/en-US/commands/system.json
+++ b/src/languages/en-US/commands/system.json
@@ -83,7 +83,7 @@
 		"serverUsage": "Server Usage"
 	},
 	"statsFields": {
-		"stats": "• **Users**: {{stats.users, number}}\n• **Guilds**: {{stats.guilds, number}}\n• **Channels**: {{stats.channels, number}}\n• **Discord.js**: {{stats.version}}\n• **Node.js**: {{stats.nodeJs}}",
+		"stats": "• **Users**: {{stats.users, number}}\n• **Servers**: {{stats.guilds, number}}\n• **Channels**: {{stats.channels, number}}\n• **Discord.js**: {{stats.version}}\n• **Node.js**: {{stats.nodeJs}}",
 		"uptime": "• **Host**: {{uptime.host, duration}}\n• **Total**: {{uptime.total, duration}}\n• **Client**: {{uptime.client, duration}}",
 		"serverUsage": "• **CPU Load**: {{usage.cpuLoad}}\n• **Heap**: {{usage.ramUsed, number}}MB (Total: {{usage.ramTotal, number}}MB)"
 	},

--- a/src/languages/en-US/commands/tags.json
+++ b/src/languages/en-US/commands/tags.json
@@ -1,6 +1,6 @@
 {
 	"added": "Successfully added a new tag: **{{name}}** with a content of:\n{{content}}",
-	"description": "Manage this guilds' tags.",
+	"description": "Manage this server's tags.",
 	"edited": "Successfully edited the tag **{{name}}** with a content of:\n{{content}}",
 	"exists": "The tag '{{tag}}' already exists.",
 	"extended": {

--- a/src/languages/en-US/moderationActions.json
+++ b/src/languages/en-US/moderationActions.json
@@ -25,7 +25,7 @@
 	"setNicknameSet": "[Action] Set Nickname | Reason: {{reason}}",
 	"setupMuteExists": "**Aborting mute role creation**: There is already one that exists.",
 	"setupRestrictionExists": "**Aborting restriction role creation**: There is already one that exists.",
-	"setupTooManyRoles": "**Aborting role creation**: There are 250 roles in this guild, you need to delete one role.",
+	"setupTooManyRoles": "**Aborting role creation**: There are 250 roles in this server, you need to delete one role.",
 	"sharedRoleSetupAsk": "{{LOADING}} Can I modify {{channels}} channel to apply the role {{role}} the following permission: {{permissions}}?",
 	"sharedRoleSetupNoMessage": "You did not input a message on time, cancelling the set up!",
 	"sharedRoleSetupExisting": "I could not find a configured role. Do you want to configure an existing one?",

--- a/src/languages/en-US/permissions.json
+++ b/src/languages/en-US/permissions.json
@@ -29,5 +29,5 @@
 	"MOVE_MEMBERS": "Move Members",
 	"USE_VAD": "Use Voice Activity",
 	"PRIORITY_SPEAKER": "Priority Speaker",
-	"VIEW_GUILD_INSIGHTS": "View Guild Insights"
+	"VIEW_GUILD_INSIGHTS": "View Server Insights"
 }

--- a/src/languages/en-US/preconditions.json
+++ b/src/languages/en-US/preconditions.json
@@ -21,6 +21,6 @@
 	"musicPaused": "{{REDCROSS}} The queue's playing and the session is still up 'till the night ends!",
 	"musicQueueEmpty": "{{REDCROSS}} The queue's empty! The session will start as soon as we have some songs queued.",
 	"musicUserVoiceChannel": "{{REDCROSS}} Hey, I need you to join a voice channel before I can run this command!",
-	"disabledGuild": "This command has been disabled by an admin in this guild!",
+	"disabledGuild": "This command has been disabled by an admin in this server!",
 	"permissionNodes": "{{REDCROSS}} You do not have permission to use this command!"
 }

--- a/src/languages/en-US/serializers.json
+++ b/src/languages/en-US/serializers.json
@@ -14,7 +14,7 @@
 	"invalidCommand": "{{name}} must be a command name.",
 	"invalidEmoji": "{{name}} must be a valid emoji.",
 	"invalidFloat": "{{name}} must be a valid number.",
-	"invalidGuild": "{{name}} must be a valid guild ID.",
+	"invalidGuild": "{{name}} must be a valid server ID.",
 	"invalidInt": "{{name}} must be an integer.",
 	"invalidInvite": "{{name}} must be a valid invite code.",
 	"invalidRole": "{{name}} must be a role mention or role id.",

--- a/src/languages/en-US/system.json
+++ b/src/languages/en-US/system.json
@@ -36,7 +36,7 @@
 	"parseError": "{{REDCROSS}} I failed to process the data I was given, sorry~!",
 	"pokedexExternalResource": "External Resources",
 	"poweredByWeebSh": "Powered by weeb.sh",
-	"prefixReminder": "The prefix in this guild is set to: `{{prefix}}`",
+	"prefixReminder": "The prefix in this server is set to: `{{prefix}}`",
 	"queryFail": "I am sorry, but the application could not resolve your request. Are you sure you wrote the name correctly?",
 	"textPromptAbortOptions": [
 		"abort",


### PR DESCRIPTION
The reasoning behind this is because we are using `guild` and `server` for the same context, this PR changes all references of `guild` to `server` in en-US, as it is the term used in Discord's UI, which users are familiar with.

I also fixed some typos and fixed some punctuation errors (`!.`, `?.`) which were remnants from an earlier refactor.
