### PR TITLE
fix(settings): reset all if reload fails

### DIFF
--- a/src/lib/database/entities/GuildEntity.ts
+++ b/src/lib/database/entities/GuildEntity.ts
@@ -9,12 +9,13 @@ import { arrayStrictEquals } from '@sapphire/utilities';
 import { Sentence } from '@skyra/tags';
 import type { TFunction } from 'i18next';
 import { AfterInsert, AfterLoad, AfterRemove, AfterUpdate, BaseEntity, Column, Entity, PrimaryColumn } from 'typeorm';
+import type { IBaseEntity } from '../settings/base/IBaseEntity';
 import { AdderManager } from '../settings/structures/AdderManager';
 import { PermissionNodeManager } from '../settings/structures/PermissionNodeManager';
 import { kBigIntTransformer, kTagsTransformer } from '../utils/Transformers';
 
 @Entity('guilds', { schema: 'public' })
-export class GuildEntity extends BaseEntity {
+export class GuildEntity extends BaseEntity implements IBaseEntity {
 	@PrimaryColumn('varchar', { name: 'id', length: 19 })
 	public id!: string;
 
@@ -779,6 +780,15 @@ export class GuildEntity extends BaseEntity {
 	 */
 	public toJSON(): AnyObject {
 		return Object.fromEntries(configurableKeys.map((v) => [v.property, this[v.property] ?? v.default]));
+	}
+
+	public resetAll(): this {
+		for (const value of configurableKeys.values()) {
+			Reflect.set(this, value.property, value.default);
+		}
+
+		this.entityRemove();
+		return this;
 	}
 
 	@AfterLoad()

--- a/src/lib/database/settings/base/IBaseEntity.ts
+++ b/src/lib/database/settings/base/IBaseEntity.ts
@@ -1,0 +1,5 @@
+import type { BaseEntity } from 'typeorm';
+
+export interface IBaseEntity extends BaseEntity {
+	resetAll(): void;
+}

--- a/src/lib/database/settings/index.ts
+++ b/src/lib/database/settings/index.ts
@@ -1,3 +1,4 @@
+export * from './base/IBaseEntity';
 export * from './base/IBaseManager';
 export * from './base/SettingsCollection';
 export * from './ConfigurableKey';


### PR DESCRIPTION
This fixes one of the most annoying errors present in production:

```typescript
EntityNotFound: Could not find any entity of type "GuildEntity" matching: "254360814063058944"
    at new EntityNotFoundError (D:\r\archid\skyra\node_modules\typeorm\error\EntityNotFoundError.js:11:28)
    at D:\r\archid\skyra\node_modules\typeorm\entity-manager\EntityManager.js:555:51
    at processTicksAndRejections (node:internal/process/task_queues:94:5)
```

When setting a key for first time in the server, and the validation fails, `BaseEntity#reload()` would throw, resulting on the entity to be corrupted unless manually removed or until restart.
