### PR TITLE
fix(moderation): handle payloads correctly

### DIFF
--- a/src/events/moderation/messages/guildUserMessageAttachmentsHandler.ts
+++ b/src/events/moderation/messages/guildUserMessageAttachmentsHandler.ts
@@ -21,7 +21,7 @@ import type { TFunction } from 'i18next';
 	}
 })
 export class UserModerationMessageEvent extends ModerationMessageEvent {
-	protected preProcess(message: GuildMessage) {
+	protected preProcess(message: GuildMessage): 1 | null {
 		const attachments = message.attachments.size;
 		return attachments > 0 ? 1 : null;
 	}

--- a/src/events/moderation/messages/guildUserMessageCapitalsHandler.ts
+++ b/src/events/moderation/messages/guildUserMessageCapitalsHandler.ts
@@ -24,7 +24,7 @@ import type { TFunction } from 'i18next';
 	}
 })
 export class UserModerationMessageEvent extends ModerationMessageEvent {
-	protected async preProcess(message: GuildMessage) {
+	protected async preProcess(message: GuildMessage): Promise<1 | null> {
 		if (message.content.length === 0) return null;
 
 		const [minimumCapitals, maximumCapitals] = await message.guild.readSettings([

--- a/src/events/moderation/messages/guildUserMessageInvitesHandler.ts
+++ b/src/events/moderation/messages/guildUserMessageInvitesHandler.ts
@@ -28,7 +28,7 @@ const enum CodeType {
 export class UserModerationMessageEvent extends ModerationMessageEvent {
 	private readonly kInviteRegExp = /(?<source>discord\.(?:gg|io|me|plus|link)|invite\.(?:gg|ink)|discord(?:app)?\.com\/invite)\/(?<code>[\w-]{2,})/gi;
 
-	protected async preProcess(message: GuildMessage) {
+	protected async preProcess(message: GuildMessage): Promise<string[] | null> {
 		if (message.content.length === 0) return null;
 
 		let value: RegExpExecArray | null = null;

--- a/src/events/moderation/messages/guildUserMessageLinksHandler.ts
+++ b/src/events/moderation/messages/guildUserMessageLinksHandler.ts
@@ -25,7 +25,7 @@ export class UserModerationMessageEvent extends ModerationMessageEvent {
 	private readonly kRegExp = urlRegex({ requireProtocol: true, tlds: true });
 	private readonly kAllowedDomains = /^(?:\w+\.)?(?:discordapp.com|discord.gg|discord.com)$/i;
 
-	protected async preProcess(message: GuildMessage) {
+	protected async preProcess(message: GuildMessage): Promise<1 | null> {
 		if (message.content.length === 0) return null;
 
 		let match: RegExpExecArray | null = null;

--- a/src/events/moderation/messages/guildUserMessageMessagesHandler.ts
+++ b/src/events/moderation/messages/guildUserMessageMessagesHandler.ts
@@ -24,7 +24,7 @@ import type { TFunction } from 'i18next';
 export class UserModerationMessageEvent extends ModerationMessageEvent {
 	private readonly kChannels = new WeakMap<TextChannel, string[]>();
 
-	protected async preProcess(message: GuildMessage) {
+	protected async preProcess(message: GuildMessage): Promise<1 | null> {
 		// Retrieve the threshold
 		const [threshold, queueSize] = await message.guild.readSettings([
 			GuildSettings.Selfmod.Messages.Maximum,

--- a/src/events/moderation/messages/guildUserMessageNewLinesHandler.ts
+++ b/src/events/moderation/messages/guildUserMessageNewLinesHandler.ts
@@ -24,7 +24,7 @@ const NEW_LINE = '\n';
 	}
 })
 export class UserModerationMessageEvent extends ModerationMessageEvent {
-	protected async preProcess(message: GuildMessage) {
+	protected async preProcess(message: GuildMessage): Promise<1 | null> {
 		const threshold = await message.guild.readSettings(GuildSettings.Selfmod.NewLines.Maximum);
 		if (threshold === 0) return null;
 


### PR DESCRIPTION
`ModerationMessageEvent#preProcess` is very lax and allows for any output besides numbers.

#1748 introduced a regression where the word handler's return type would be changed to something else, but always a non-null payload in case a RegExp existed.

During the tests, I tested every case in the worker via eval and stuff, everything worked just fine.

Except the monitor... there was no integration testing, and I tested with filtered words only, it didn't occur to me to test on non-filtered ones, and it didn't trigger on us (Alphy was running for quite some time) because the testing server was dead silent, and the ones active were moderators+, which aren't affected.

For preventive measures, I strict-typed the returns of all moderation filters, so in case something changes, TypeScript will complain.

This issue was so silly, it makes me want to go to a corner and cry for a day.

I will try to add integration testing for moderation monitors later, mocking the components and making them go through a very high flow of messages, as the server spawned 6 workers in 25 seconds, which should not have happened.

I am deeply sorry for this regression. 😭
