### PR TITLE
feat(command-error): ignore DM reply-after-block errors

### DIFF
--- a/typescript/src/events/commands/commandError.ts
+++ b/typescript/src/events/commands/commandError.ts
@@ -33,7 +33,7 @@ export class UserEvent extends Event<Events.CommandError> {
 
 		// Extract useful information about the DiscordAPIError
 		if (error instanceof DiscordAPIError || error instanceof HTTPError) {
-			if (ignoredCodes.includes(error.code)) return;
+			if (this.isSilencedError(args, error)) return;
 			client.emit(Events.Error, error);
 		} else {
 			client.logger.warn(`${this.getWarnError(message)} (${message.author.id}) | ${error.constructor.name}`);
@@ -52,6 +52,26 @@ export class UserEvent extends Event<Events.CommandError> {
 		}
 
 		return undefined;
+	}
+
+	private isSilencedError(args: Args, error: DiscordAPIError | HTTPError) {
+		return (
+			// If it's an unknown channel or an unknown message, ignore:
+			ignoredCodes.includes(error.code) ||
+			// If it's a DM message reply after a block, ignore:
+			this.isDirectMessageReplyAfterBlock(args, error)
+		);
+	}
+
+	private isDirectMessageReplyAfterBlock(args: Args, error: DiscordAPIError | HTTPError) {
+		// When sending a message to a user who has blocked the bot, Discord replies with 50007 "Cannot send messages to this user":
+		if (error.code !== RESTJSONErrorCodes.CannotSendMessagesToThisUser) return false;
+
+		// If it's not a Direct Message, return false:
+		if (args.message.guild !== null) return false;
+
+		// If the query was made to the message's channel, then it was a DM response:
+		return error.path === `/channels/${args.message.channel.id}/messages`;
 	}
 
 	private generateUnexpectedErrorMessage(args: Args, error: Error) {


### PR DESCRIPTION
If somebody spams the ping command in DMs to the point Skyra gets ratelimited,
and then blocks Skyra, there's no point on reporting the error - there's nothing
we can do about it.
