### PR TITLE
fix(star): resolved id of null error

### DIFF
--- a/typescript/src/lib/database/entities/StarboardEntity.ts
+++ b/typescript/src/lib/database/entities/StarboardEntity.ts
@@ -170,7 +170,7 @@ export class StarboardEntity extends BaseEntity {
 	 */
 	public remove() {
 		this.enabled = false;
-		this.#manager.delete(this.#message.id);
+		this.#manager.delete(this.messageID);
 		return super.remove();
 	}
 


### PR DESCRIPTION
Resolves this error:

```
TypeError: Cannot read property 'id' of null
    at StarboardEntity.remove (/***/typescript/src/lib/database/entities/StarboardEntity.ts:174:38)
    at UserCommand.handleRandom (/***/typescript/src/commands/Starboard/star.ts:147:24)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:94:5)
    at CoreEvent.run (/***/node_modules/@sapphire/framework/src/events/command-handler/CoreCommandAccepted.ts:15:19)
    at CoreEvent._run (/***/node_modules/@sapphire/framework/src/lib/structures/Event.ts:87:4)
```
