### PR TITLE
refactor(gstart): make the argument parser stricter

### DIFF
--- a/typescript/src/languages/en-US/arguments.json
+++ b/typescript/src/languages/en-US/arguments.json
@@ -82,6 +82,8 @@
 	"voiceChannel": "I could not resolve `{{parameter}}` to a voice channel, please make sure you typed its name or ID correctly!",
 	"wager": "I am sorry, but {{parameter}} {{SHINY}} is an invalid amount to bet. You can bet one of {{possibles, orList}}",
 	"winners": "I could not resolve `{{parameter}}` to a valid winner amount!\n**Hint**: the following format is supported: `Nw`, being `N` any integer, e.g. `3w` or `12w`.",
+	"tooFewWinners": "The parameter `{{parameter}}` resolved to a number that is too low, it must be at least 1!",
+	"tooManyWinners": "The parameter `{{parameter}}` resolved to a number that is too high, it must be at maximum 20!",
 	"unavailable": "Whoops! It seems I couldn't find a parser for a parameter, please contact my developers about it!",
 	"missing": "You need to write another parameter!\n\n> **Tip**: You can do `{{commandContext.commandPrefix}}help {{command.name}}` to find out how to use this command."
 }

--- a/typescript/src/lib/i18n/languageKeys/keys/Arguments.ts
+++ b/typescript/src/lib/i18n/languageKeys/keys/Arguments.ts
@@ -58,5 +58,7 @@ export const User = FT<{ parameter: string }, string>('arguments:user');
 export const VoiceChannel = FT<{ parameter: string }, string>('arguments:voiceChannel');
 export const Wager = FT<{ parameter: number; possibles: readonly string[] }, string>('arguments:wager');
 export const Winners = FT<{ parameter: string }, string>('arguments:winners');
+export const TooFewWinners = FT<{ parameter: string }>('arguments:tooFewWinners');
+export const TooManyWinners = FT<{ parameter: string }>('arguments:tooManyWinners');
 export const Unavailable = T<string>('arguments:unavailable');
 export const Missing = T<string>('arguments:missing');


### PR DESCRIPTION
Fixes this database error:

```
QueryFailedError: invalid input syntax for type integer: "NaN"
    at new QueryFailedError (/home/archid/workspace/skyra/src/error/QueryFailedError.ts:9:9)
    at Query.callback (/home/archid/workspace/skyra/src/driver/postgres/PostgresQueryRunner.ts:195:30)
    at Query.handleError (/home/archid/workspace/skyra/node_modules/pg/lib/query.js:128:19)
    at Client._handleErrorMessage (/home/archid/workspace/skyra/node_modules/pg/lib/client.js:335:17)
    at Connection.emit (node:events:369:20)
    at Connection.emit (node:domain:470:12)
    at /home/archid/workspace/skyra/node_modules/pg/lib/connection.js:115:12
    at Parser.parse (/home/archid/workspace/skyra/node_modules/pg-protocol/src/parser.ts:102:9)
    at Socket.<anonymous> (/home/archid/workspace/skyra/node_modules/pg-protocol/src/index.ts:7:48)
    at Socket.emit (node:events:369:20)
```
