### PR TITLE
refactor(moderation): make timespan argument stricter

### DIFF
--- a/typescript/src/lib/moderation/structures/SetUpModerationCommand.ts
+++ b/typescript/src/lib/moderation/structures/SetUpModerationCommand.ts
@@ -46,7 +46,7 @@ export abstract class SetUpModerationCommand extends ModerationCommand {
 			await message.guild.security.actions.restrictionSetup(message, this.setUpKey);
 			await message.send(t(LanguageKeys.Commands.Moderation.Success));
 		} else {
-			await message.send(t(LanguageKeys.Commands.Management.CommandHandlerAborted));
+			this.error(LanguageKeys.Commands.Management.CommandHandlerAborted);
 		}
 
 		return undefined;


### PR DESCRIPTION
So if somebody sets a duration that's too big, e.g. `6y` (6 years, being the limit 5y), the action doesn't silently become permanent.

![image](https://user-images.githubusercontent.com/24852502/115888878-b3294800-a453-11eb-9243-a809f9e1f98e.png)

Also fixed all restriction commands (as well as mute) running the command's logic even when no role was set up.