### PR TITLE
fix(kitty): check for valid image URLs

### DIFF
--- a/typescript/src/commands/Animal/kitty.ts
+++ b/typescript/src/commands/Animal/kitty.ts
@@ -1,6 +1,6 @@
 import { LanguageKeys } from '#lib/i18n/languageKeys';
 import { SkyraCommand } from '#lib/structures';
-import { fetch, wrap } from '#utils/util';
+import { fetch, getImageUrl, wrap } from '#utils/util';
 import { ApplyOptions } from '@sapphire/decorators';
 import { Message, MessageEmbed } from 'discord.js';
 
@@ -18,7 +18,7 @@ export class UserCommand extends SkyraCommand {
 		return message.send(
 			new MessageEmbed()
 				.setColor(await this.context.db.fetchColor(message))
-				.setImage(result.success ? result.value.file : 'https://wallpapercave.com/wp/wp3021105.jpg')
+				.setImage((result.success && getImageUrl(result.value.file)) || 'https://wallpapercave.com/wp/wp3021105.jpg')
 				.setTimestamp()
 		);
 	}


### PR DESCRIPTION
Fixes this error:

```
DiscordAPIError: Invalid Form Body
embed.image.url: Not a well formed URL.
    at RequestHandler.execute (/home/archid/workspace/skyra/node_modules/discord.js/src/rest/RequestHandler.js:154:13)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:94:5)
    at RequestHandler.message [as push] (/home/archid/workspace/skyra/node_modules/discord.js/src/rest/RequestHandler.js:39:14)
    at SkyraMessage.send (/home/archid/workspace/skyra/node_modules/@skyra/editable-commands/src/index.ts:109:9)
    at CoreEvent.run (/home/archid/workspace/skyra/node_modules/@sapphire/framework/src/events/command-handler/CoreCommandAccepted.ts:15:19)
    at CoreEvent._run (/home/archid/workspace/skyra/node_modules/@sapphire/framework/src/lib/structures/Event.ts:87:4)
```
