### PR TITLE
feat(prune): make options flags

### DIFF
--- a/typescript/src/commands/Moderation/prune.ts
+++ b/typescript/src/commands/Moderation/prune.ts
@@ -115,7 +115,7 @@ export class UserCommand extends SkyraCommand {
 		else if (args.getFlags(...imageFlags)) fns.push((mes: GuildMessage) => mes.attachments.some((at) => !isNullish(getImageUrl(at.url))));
 		if (args.getFlags(...authorFlags)) fns.push((mes: GuildMessage) => mes.author.id === args.message.author.id);
 		if (args.getFlags(...botsFlags)) fns.push((mes: GuildMessage) => mes.author.bot);
-		if (args.getFlags(...humansFlags)) fns.push((mes: GuildMessage) => mes.author.id === args.message.author.id);
+		if (args.getFlags(...humansFlags)) fns.push((mes: GuildMessage) => !mes.author.bot);
 		if (args.getFlags(...invitesFlags)) fns.push((mes: GuildMessage) => UserCommand.kInviteRegExp.test(mes.content));
 		if (args.getFlags(...linksFlags)) fns.push((mes: GuildMessage) => UserCommand.kLinkRegExp.test(mes.content));
 		if (args.getFlags(...youFlags)) fns.push((mes: GuildMessage) => mes.author.id === process.env.CLIENT_ID);

--- a/typescript/src/languages/en-US/commands/moderation.json
+++ b/typescript/src/languages/en-US/commands/moderation.json
@@ -423,8 +423,10 @@
 	"pruneDescription": "Prunes a certain amount of messages w/o filter.",
 	"pruneExtended": {
 		"usages": [
-			"Amount files/me/bots/humans/invites/links/skyra/User?",
-			"Amount files/me/bots/humans/invites/links/skyra/User? after/before Message",
+			"Amount Flags User",
+			"Amount Flags after/before Message",
+			"Amount User",
+			"Amount User after/before Message",
 			"Amount --silent"
 		],
 		"extendedHelp": "This command deletes the given amount of messages given a filter within the last 100 messages sent in the channel the command has been run.\nOptionally, you can add `--silent` to tell Skyra not to send a response message.",
@@ -434,35 +436,39 @@
 				"The amount of messages to delete."
 			],
 			[
-				"Filter: files",
+				"--f/file/files",
 				"Deletes messages with attachments."
 			],
 			[
-				"Filter: me",
+				"--a/author",
 				"Deletes your messages."
 			],
 			[
-				"Filter: bots",
+				"--b/bot/bots",
 				"Deletes messages sent by bots."
 			],
 			[
-				"Filter: humans",
+				"--h/human/humans",
 				"Deletes messages sent by users."
 			],
 			[
-				"Filter: invites",
+				"--i/invite/invites",
 				"Deletes messages that contain invite links."
 			],
 			[
-				"Filter: links",
+				"--l/link/links",
 				"Deletes messages that contain any link."
 			],
 			[
-				"Filter: skyra",
+				"--y/you",
 				"Deletes my messages."
 			],
 			[
-				"Filter: User",
+				"--p/pin/pins",
+				"Deletes pinned messages, unless specified, no other filter deletes pins."
+			],
+			[
+				"User",
 				"Deletes messages sent by the specified user."
 			],
 			[
@@ -474,15 +480,15 @@
 				"Deletes messages sent before the specified message."
 			],
 			[
-				"--silent",
-				"Whether or not a response message should be sent."
+				"--s/silent",
+				"Whether or not a response message should be sent, this will also delete your command message if there were less than 100 messages filtered."
 			]
 		],
 		"examples": [
-			"50 me",
+			"50 --a",
 			"75 @kyra",
-			"20 bots",
-			"60 humans before 629992398700675082",
+			"20 --bots",
+			"60 --humans --files before 629992398700675082",
 			"100 --silent"
 		],
 		"reminder": "Due to a Discord limitation, bots cannot delete messages older than 14 days."

--- a/typescript/src/languages/en-US/commands/moderation.json
+++ b/typescript/src/languages/en-US/commands/moderation.json
@@ -464,6 +464,14 @@
 				"Deletes my messages."
 			],
 			[
+				"--age=Duration",
+				"Deletes any message newer than Duration."
+			],
+			[
+				"--include/contain=Word",
+				"Deletes messages that contain Word."
+			],
+			[
 				"--p/pin/pins",
 				"Deletes pinned messages, unless specified, no other filter deletes pins."
 			],
@@ -489,6 +497,7 @@
 			"75 @kyra",
 			"20 --bots",
 			"60 --humans --files before 629992398700675082",
+			"30 --age=5m --contain=lol",
 			"100 --silent"
 		],
 		"reminder": "Due to a Discord limitation, bots cannot delete messages older than 14 days."

--- a/typescript/src/lib/util/comparators.ts
+++ b/typescript/src/lib/util/comparators.ts
@@ -72,3 +72,17 @@ export function bidirectionalReplace<T>(regex: RegExp, content: string, options:
 	if (previous < content.length) results.push(options.outMatch(content.slice(previous), previous, content.length));
 	return results;
 }
+
+export type BooleanFn<T extends readonly unknown[], R extends boolean = boolean> = (...args: T) => R;
+
+export function andMix<T extends readonly unknown[], R extends boolean>(fns: readonly BooleanFn<T, R>[]): BooleanFn<T, R> {
+	if (fns.length === 0) throw new Error('You must input at least one function.');
+	return (...args) => {
+		let ret!: R;
+		for (const fn of fns) {
+			if (!(ret = fn(...args))) break;
+		}
+
+		return ret;
+	};
+}

--- a/typescript/unit-tests/tests/lib/comparators.test.ts
+++ b/typescript/unit-tests/tests/lib/comparators.test.ts
@@ -1,4 +1,4 @@
-import { hasAtLeastOneKeyInMap, isNullishOrEmpty, isNullishOrZero } from '#utils/comparators';
+import { andMix, hasAtLeastOneKeyInMap, isNullishOrEmpty, isNullishOrZero } from '#utils/comparators';
 
 describe('comparators', () => {
 	describe('isNullishOrZero', () => {
@@ -71,6 +71,55 @@ describe('comparators', () => {
 					['world', 'baz']
 				)
 			).toEqual(false);
+		});
+	});
+
+	describe('andMix', () => {
+		test('GIVEN two callbacks AND passing value THEN passes test', () => {
+			const a = jest.fn((v: number) => v > 0);
+			const b = jest.fn((v: number) => v < 1);
+
+			const mix = andMix([a, b]);
+			expect(a.mock.calls.length).toBe(0);
+			expect(b.mock.calls.length).toBe(0);
+
+			expect(mix(0.5)).toBe(true);
+			expect(a.mock.calls.length).toBe(1);
+			expect(a.mock.results[0].value).toBe(true);
+
+			expect(b.mock.calls.length).toBe(1);
+			expect(b.mock.results[0].value).toBe(true);
+		});
+
+		test('GIVEN two callbacks AND a value failing the second THEN fails test', () => {
+			const a = jest.fn((v: number) => v > 0);
+			const b = jest.fn((v: number) => v < 1);
+
+			const mix = andMix([a, b]);
+			expect(a.mock.calls.length).toBe(0);
+			expect(b.mock.calls.length).toBe(0);
+
+			expect(mix(1.5)).toBe(false);
+			expect(a.mock.calls.length).toBe(1);
+			expect(a.mock.results[0].value).toBe(true);
+
+			expect(b.mock.calls.length).toBe(1);
+			expect(b.mock.results[0].value).toBe(false);
+		});
+
+		test('GIVEN two callbacks AND a value failing the first THEN fails test and short-circuits the second', () => {
+			const a = jest.fn((v: number) => v > 0);
+			const b = jest.fn((v: number) => v < 1);
+
+			const mix = andMix([a, b]);
+			expect(a.mock.calls.length).toBe(0);
+			expect(b.mock.calls.length).toBe(0);
+
+			expect(mix(-1)).toBe(false);
+			expect(a.mock.calls.length).toBe(1);
+			expect(a.mock.results[0].value).toBe(false);
+
+			expect(b.mock.calls.length).toBe(0);
 		});
 	});
 });


### PR DESCRIPTION
- refactor(prune): rewrite filter argument to be flags
- refactor(prune): add support for specifying multiple filters
- fix(prune): do not prune pinned messages unless specified otherwise

### TODO

- [x] Add unit tests for `andMix`.
- [x] Add `--image` flag in `prune`.
- [x] Add `--age=Duration` option in `prune`.
- [x] Add `--contains=Word` option in `prune`.
- [x] Test the `prune` command.

### Testing options:

https://user-images.githubusercontent.com/24852502/116857104-8bc53e80-abfc-11eb-9a61-9d05ac1dabf3.mp4

### Testing pins:

https://user-images.githubusercontent.com/24852502/116857327-e363aa00-abfc-11eb-9123-e4587f77f06f.mp4

> Gotta say, it's pretty nice.