### PR TITLE
refactor: unguard owner-only commands, leave important ones

### DIFF
--- a/typescript/src/commands/General/Chat Bot Info/info.ts
+++ b/typescript/src/commands/General/Chat Bot Info/info.ts
@@ -7,8 +7,7 @@ import type { Message } from 'discord.js';
 	aliases: ['bot-info'],
 	cooldown: 5,
 	description: LanguageKeys.Commands.General.InfoDescription,
-	extendedHelp: LanguageKeys.Commands.General.InfoExtended,
-	guarded: true
+	extendedHelp: LanguageKeys.Commands.General.InfoExtended
 })
 export class UserCommand extends SkyraCommand {
 	public async run(message: Message, args: SkyraCommand.Args) {

--- a/typescript/src/commands/General/Chat Bot Info/ping.ts
+++ b/typescript/src/commands/General/Chat Bot Info/ping.ts
@@ -7,8 +7,7 @@ import type { Message } from 'discord.js';
 	aliases: ['pong'],
 	cooldown: 5,
 	description: LanguageKeys.Commands.General.PingDescription,
-	extendedHelp: LanguageKeys.Commands.General.PingExtended,
-	guarded: true
+	extendedHelp: LanguageKeys.Commands.General.PingExtended
 })
 export class UserCommand extends SkyraCommand {
 	public async run(message: Message, args: SkyraCommand.Args) {

--- a/typescript/src/commands/System/Admin/disable.ts
+++ b/typescript/src/commands/System/Admin/disable.ts
@@ -7,7 +7,6 @@ import type { Message } from 'discord.js';
 @ApplyOptions<SkyraCommand.Options>({
 	description: LanguageKeys.Commands.System.DisableDescription,
 	extendedHelp: LanguageKeys.Commands.System.DisableExtended,
-	guarded: true,
 	permissionLevel: PermissionLevels.BotOwner
 })
 export class UserCommand extends SkyraCommand {

--- a/typescript/src/commands/System/Admin/dm.ts
+++ b/typescript/src/commands/System/Admin/dm.ts
@@ -7,7 +7,6 @@ import type { Message, MessageOptions } from 'discord.js';
 @ApplyOptions<SkyraCommand.Options>({
 	description: LanguageKeys.Commands.System.DmDescription,
 	extendedHelp: LanguageKeys.Commands.System.DmExtended,
-	guarded: true,
 	permissionLevel: PermissionLevels.BotOwner
 })
 export class UserCommand extends SkyraCommand {

--- a/typescript/src/commands/System/Admin/enable.ts
+++ b/typescript/src/commands/System/Admin/enable.ts
@@ -7,7 +7,6 @@ import type { Message } from 'discord.js';
 @ApplyOptions<SkyraCommand.Options>({
 	description: LanguageKeys.Commands.System.EnableDescription,
 	extendedHelp: LanguageKeys.Commands.System.EnableExtended,
-	guarded: true,
 	permissionLevel: PermissionLevels.BotOwner
 })
 export class UserCommand extends SkyraCommand {

--- a/typescript/src/commands/System/Admin/eval.ts
+++ b/typescript/src/commands/System/Admin/eval.ts
@@ -16,7 +16,6 @@ import { inspect } from 'util';
 	aliases: ['ev'],
 	description: LanguageKeys.Commands.System.EvalDescription,
 	extendedHelp: LanguageKeys.Commands.System.EvalExtended,
-	guarded: true,
 	permissionLevel: PermissionLevels.BotOwner,
 	quotes: [],
 	strategyOptions: {

--- a/typescript/src/commands/System/Admin/exec.ts
+++ b/typescript/src/commands/System/Admin/exec.ts
@@ -11,7 +11,6 @@ import { Message, MessageAttachment } from 'discord.js';
 	aliases: ['execute'],
 	description: LanguageKeys.Commands.System.ExecDescription,
 	extendedHelp: LanguageKeys.Commands.System.ExecExtended,
-	guarded: true,
 	permissionLevel: PermissionLevels.BotOwner,
 	strategyOptions: { options: ['timeout'] }
 })

--- a/typescript/src/commands/System/Admin/heapsnapshot.ts
+++ b/typescript/src/commands/System/Admin/heapsnapshot.ts
@@ -33,7 +33,6 @@ import { writeHeapSnapshot } from 'v8';
 @ApplyOptions<SkyraCommand.Options>({
 	description: LanguageKeys.Commands.Admin.HeapSnapshotDescription,
 	extendedHelp: LanguageKeys.Commands.Admin.HeapSnapshotExtended,
-	guarded: true,
 	permissionLevel: PermissionLevels.BotOwner
 })
 export class UserCommand extends SkyraCommand {

--- a/typescript/src/commands/System/Admin/reboot.ts
+++ b/typescript/src/commands/System/Admin/reboot.ts
@@ -8,7 +8,6 @@ import type { Message } from 'discord.js';
 @ApplyOptions<SkyraCommand.Options>({
 	description: LanguageKeys.Commands.System.RebootDescription,
 	extendedHelp: LanguageKeys.Commands.System.RebootExtended,
-	guarded: true,
 	permissionLevel: PermissionLevels.BotOwner
 })
 export class UserCommand extends SkyraCommand {

--- a/typescript/src/commands/System/Admin/reload.ts
+++ b/typescript/src/commands/System/Admin/reload.ts
@@ -11,7 +11,6 @@ import i18next, { TFunction } from 'i18next';
 	aliases: ['r'],
 	description: LanguageKeys.Commands.System.ReloadDescription,
 	extendedHelp: LanguageKeys.Commands.System.ReloadExtended,
-	guarded: true,
 	permissionLevel: PermissionLevels.BotOwner
 })
 export class UserCommand extends SkyraCommand {

--- a/typescript/src/commands/System/Admin/update.ts
+++ b/typescript/src/commands/System/Admin/update.ts
@@ -13,7 +13,6 @@ import type { Message } from 'discord.js';
 	aliases: ['pull'],
 	description: LanguageKeys.Commands.Admin.UpdateDescription,
 	extendedHelp: LanguageKeys.Commands.Admin.UpdateExtended,
-	guarded: true,
 	strategyOptions: { flags: ['clean'] },
 	permissionLevel: PermissionLevels.BotOwner
 })

--- a/typescript/src/commands/System/echo.ts
+++ b/typescript/src/commands/System/echo.ts
@@ -9,7 +9,6 @@ import type { MessageOptions } from 'discord.js';
 	aliases: ['talk'],
 	description: LanguageKeys.Commands.System.EchoDescription,
 	extendedHelp: LanguageKeys.Commands.System.EchoExtended,
-	guarded: true,
 	permissionLevel: PermissionLevels.BotOwner,
 	runIn: ['text', 'news']
 })


### PR DESCRIPTION
Guarded commands are now `conf`, `help`, `invite`, `donate`, and `support`.
