### PR TITLE
fix think command.

### DIFF
--- a/typescript/src/languages/en-US/commands/fun.json
+++ b/typescript/src/languages/en-US/commands/fun.json
@@ -204,7 +204,7 @@
 			"Mark"
 		]
 	},
-	"thinkMessage": "Think, {{user}}!",
+	"thinkMessage": "Think, {{user}}, think!",
 	"wakandaDescription": "Helpful descriptions? We don't do that here",
 	"wakandaExtended": {
 		"extendedHelp": "Creates an image macro using the [We Don't Do That Here Meme](https://knowyourmeme.com/memes/we-dont-do-that-here) using the given user."


### PR DESCRIPTION
This reverts @YorkAARGH's change and fixes the think command to use the correct (as per the meme) text.

While accurate to the show, the meme uses "Think {x}, think!" - and brings it to consistency with other meme based commands (using the meme as point of reference rather then the origin of the meme)