### PR TITLE
refactor: remove `streamToBuffer`

### DIFF
--- a/src/commands/Misc/triggered.ts
+++ b/src/commands/Misc/triggered.ts
@@ -1,6 +1,5 @@
 import { LanguageKeys } from '#lib/i18n/languageKeys';
 import { SkyraCommand } from '#lib/structures';
-import { streamToBuffer } from '#utils/common';
 import { assetsFolder } from '#utils/constants';
 import { fetchAvatar } from '#utils/util';
 import { ApplyOptions } from '@sapphire/decorators';
@@ -9,6 +8,7 @@ import { GifEncoder } from '@skyra/gifenc';
 import { Canvas, Image, resolveImage, rgba } from 'canvas-constructor/skia';
 import type { Message, User } from 'discord.js';
 import { join } from 'path';
+import { buffer } from 'stream/consumers';
 
 const COORDINATES: readonly [number, number][] = [
 	[-25, -25],
@@ -54,7 +54,7 @@ export class UserCommand extends SkyraCommand {
 
 		encoder.finish();
 
-		return streamToBuffer(stream);
+		return buffer(stream);
 	}
 
 	public async onLoad() {

--- a/src/lib/types/shims/stream/consumers.d.ts
+++ b/src/lib/types/shims/stream/consumers.d.ts
@@ -1,0 +1,6 @@
+// TODO: Remove when @types/node ships those (alongside 3 more methods):
+
+declare module 'stream/consumers' {
+	export function buffer(stream: NodeJS.ReadableStream): Buffer;
+	export function text(stream: NodeJS.ReadableStream): string;
+}

--- a/src/lib/util/common/promises.ts
+++ b/src/lib/util/common/promises.ts
@@ -16,16 +16,6 @@ export function floatPromise(promise: Awaited<unknown>) {
 	if (isThenable(promise)) promise.catch((error: Error) => container.logger.fatal(error));
 }
 
-/**
- * Read a stream and resolve to a buffer.
- * @param stream The readable stream to read
- */
-export async function streamToBuffer(stream: NodeJS.ReadableStream): Promise<Buffer> {
-	const data: Buffer[] = [];
-	for await (const buffer of stream) data.push(buffer as Buffer);
-	return Buffer.concat(data);
-}
-
 export interface ReferredPromise<T> {
 	promise: Promise<T>;
 	resolve(value?: T): void;

--- a/tests/lib/util/common/promises.test.ts
+++ b/tests/lib/util/common/promises.test.ts
@@ -1,18 +1,20 @@
-import { streamToBuffer } from '#utils/common';
-import { resolveImage } from 'canvas-constructor/skia';
-import { createReadStream } from 'fs';
-import { resolve } from 'path';
+import { safeWrapPromise } from '#utils/common';
+import { err, ok } from '@sapphire/framework';
 
 describe('util common iterators', () => {
-	describe('streamToBuffer', () => {
-		test('GIVEN path to file THEN converts to Buffer', async () => {
-			const filePath = resolve(__dirname, '..', '..', '..', 'mocks', 'image.png');
-			const readStream = createReadStream(filePath);
-			const buffer = await streamToBuffer(readStream);
-			const image = await resolveImage(buffer);
+	describe('safeWrapPromise', () => {
+		test('GIVEN passing promise THEN resolves with result', async () => {
+			const value = 'Hello there';
+			const result = safeWrapPromise(Promise.resolve(value));
 
-			expect(image.width).toBe(32);
-			expect(image.height).toBe(32);
+			await expect(result).resolves.toStrictEqual(ok(value));
+		});
+
+		test('GIVEN failing promise THEN resolves with result', async () => {
+			const error = new Error('Hello there');
+			const result = safeWrapPromise(Promise.reject(error));
+
+			await expect(result).resolves.toStrictEqual(err(error));
 		});
 	});
 });


### PR DESCRIPTION
**This requires Node.js v16.7.0**

There's also an experimental warning that's emitted... but not on our side, as shown below:

```js
ExperimentalWarning: buffer.Blob is an experimental feature. This feature could change at any time
    at emitExperimentalWarning (node:internal/util:210:11)
    at new Blob (node:internal/blob:142:5)
    at blob (node:stream/consumers:33:10)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at arrayBuffer (node:stream/consumers:41:15)
    at Object.buffer (node:stream/consumers:50:22)
```

- [Node.js documentation](https://nodejs.org/dist/latest-v16.x/docs/api/webstreams.html#webstreams_utility_consumers)
- `@types/node` is not updated for this release yet, so we're augmenting the types until it's updated - I added a TODO for this.
