### PR TITLE
chore: remove `:dependencyDashboard` preset

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["config:base", ":dependencyDashboard"],
+	"extends": ["config:base"],
 	"npm": {
 		"rangeStrategy": "bump"
 	},


### PR DESCRIPTION
## Changes:

- Remove `:dependencyDashboard` preset

## Context:

The `config:base` preset now defaults to always show the Dependency Dashboard, so you no longer need to opt-in explicitly by using the `:dependencyDashboard` preset. 😉 

Relevant quote from the `v26.0.0` release notes of Renovate:

> add dependencyDashboard to config:base (`13532ec`)

https://github.com/renovatebot/renovate/releases/tag/26.0.0