### PR TITLE
feat: add support for multipliers in `dice`

### DIFF
--- a/src/commands/Fun/dice.ts
+++ b/src/commands/Fun/dice.ts
@@ -18,6 +18,7 @@ export class UserCommand extends SkyraCommand {
 	 *  - 4d6
 	 *  - d20
 	 *  - 2d8+2
+	 *  - 1d10*10
 	 */
 	private readonly kDice20RegExp = /^(\d+)?\s*d\s*(\d+)\s*(.*?)$/;
 
@@ -27,46 +28,60 @@ export class UserCommand extends SkyraCommand {
 	 *  - +20
 	 *  - -50
 	 *  - + 70
+	 *  - *10
 	 */
-	private readonly kDice20TrailRegExp = /([+-])\s*(\d+)/g;
+	private readonly kDice20TrailRegExp = /([+-x*])\s*(\d+)/g;
 
 	public async run(message: Message, args: SkyraCommand.Args) {
 		const amountOrDice = await args.pick('integer', { minimum: 1, maximum: 1024 }).catch(() => args.rest('string'));
-		const content = args.t(LanguageKeys.Commands.Fun.DiceOutput, { result: await this.roll(amountOrDice) });
+		const content = args.t(LanguageKeys.Commands.Fun.DiceOutput, { result: this.roll(amountOrDice) });
 		return send(message, content);
 	}
 
-	private async roll(pattern: string | number) {
-		let amount: number;
-		let dice: number;
-		let modifier = 0;
+	private roll(pattern: string | number) {
 		if (typeof pattern === 'number') {
 			if (!isNumber(pattern) || pattern < 3) this.error(LanguageKeys.Serializers.InvalidInt, { name: 'dice' });
-			amount = 1;
-			dice = pattern;
-		} else {
-			const results = this.kDice20RegExp.exec(pattern);
-			if (results === null) this.error(LanguageKeys.Commands.Fun.DiceRollsError);
-			amount = typeof results[1] === 'undefined' ? 1 : Number(results[1]);
-			dice = Number(results[2]);
-
-			if (amount < 1 || amount > 1024) this.error(LanguageKeys.Commands.Fun.DiceRollsError);
-			if (dice < 3 || dice > 1024) this.error(LanguageKeys.Commands.Fun.DiceSidesError);
-
-			if (results[3].length > 0) {
-				let modifierResults: RegExpExecArray | null = null;
-				while ((modifierResults = this.kDice20TrailRegExp.exec(results[3]))) {
-					if (modifierResults[1] === '+') {
-						modifier += Number(modifierResults[2]);
-					} else {
-						modifier -= Number(modifierResults[2]);
-					}
-				}
-			}
+			return this.generateNumber(1, pattern);
 		}
 
-		const maximum = amount * dice;
-		const minimum = amount;
-		return Math.floor(Math.random() * (maximum - minimum + 1) + minimum + modifier);
+		const results = this.kDice20RegExp.exec(pattern);
+		if (results === null) this.error(LanguageKeys.Commands.Fun.DiceRollsError);
+
+		const amount = typeof results[1] === 'undefined' ? 1 : Number(results[1]);
+		if (amount < 1 || amount > 1024) this.error(LanguageKeys.Commands.Fun.DiceRollsError);
+
+		const dice = Number(results[2]);
+		if (dice < 3 || dice > 1024) this.error(LanguageKeys.Commands.Fun.DiceSidesError);
+
+		let result = this.generateNumber(amount, amount * dice);
+		if (results[3].length > 0) result = this.processModifiers(result, results[3]);
+
+		return result;
+	}
+
+	private generateNumber(minimum: number, maximum: number) {
+		return Math.floor(Math.random() * (maximum - minimum + 1) + minimum);
+	}
+
+	private processModifiers(output: number, modifiers: string) {
+		let modifierResults: RegExpExecArray | null = null;
+		while ((modifierResults = this.kDice20TrailRegExp.exec(modifiers))) {
+			output = this.processModifier(output, modifierResults);
+		}
+
+		return output;
+	}
+
+	private processModifier(output: number, modifierResults: RegExpExecArray) {
+		const value = Number(modifierResults[2]);
+		switch (modifierResults[1] as '+' | '-' | '*' | 'x') {
+			case '+':
+				return output + value;
+			case '-':
+				return output - value;
+			case 'x':
+			case '*':
+				return output * value;
+		}
 	}
 }

--- a/src/languages/en-US/commands/fun.json
+++ b/src/languages/en-US/commands/fun.json
@@ -55,9 +55,12 @@
 		],
 		"extendedHelp": "The mechanics of this command are easy. You have a dice, then you roll it __x__ times, but the dice can also be configured to have __y__ sides. By default, this command rolls a dice with 6 sides once. However, you can change the amount of rolls for the dice, and this command will \"roll\" (get a random number between 1 and the amount of sides). For example, rolling a dice with 6 sides 3 times will leave a random sequence of three random numbers between 1 and 6, for example: 3, 1, 6; And this command will return 10 as output.",
 		"examples": [
+			"6",
 			"370d24",
 			"100d6",
-			"6"
+			"2d6+4",
+			"1d10*10",
+			"6d10+2*10"
 		]
 	},
 	"escaperopeDescription": "Use the escape rope from Pokemon.",


### PR DESCRIPTION
This allows us to represent a dice with a tens digit (`00`, `10`, `20`, `30`, `40`, `50`, `60`, `70`, `80`, `90`) separately from it's pair dice (with numbers between `0` and `9`) that's used to represent a number between 1 (`00` + `1`) and 100 (`00` + `0`), as shown below:

![image](https://user-images.githubusercontent.com/24852502/134788650-761a6a98-3482-4faf-bc75-9da988392b2b.png)

Also refactored the code a little, reduced `roll`'s complexity and removed useless `async`.
