### PR TITLE
fix: disable `country` command for until we can find an API replacement

### DIFF
--- a/src/commands/Tools/Websearch/country.ts
+++ b/src/commands/Tools/Websearch/country.ts
@@ -1,6 +1,7 @@
 import { LanguageKeys } from '#lib/i18n/languageKeys';
 import { PaginatedMessageCommand, SkyraPaginatedMessage } from '#lib/structures';
 import type { GuildMessage } from '#lib/types';
+import { PermissionLevels } from '#lib/types/Enums';
 import { formatNumber } from '#utils/functions';
 import { sendLoadingMessage } from '#utils/util';
 import { ApplyOptions } from '@sapphire/decorators';
@@ -14,7 +15,11 @@ const mapCurrency = (currency: CurrencyData) => `${currency.name} (${currency.sy
 
 @ApplyOptions<PaginatedMessageCommand.Options>({
 	description: LanguageKeys.Commands.Tools.CountryDescription,
-	detailedDescription: LanguageKeys.Commands.Tools.CountryExtended
+	detailedDescription: LanguageKeys.Commands.Tools.CountryExtended,
+	enabled: false,
+	hidden: true,
+	guarded: true,
+	permissionLevel: PermissionLevels.BotOwner
 })
 export class UserPaginatedMessageCommand extends PaginatedMessageCommand {
 	public async run(message: GuildMessage, args: PaginatedMessageCommand.Args) {

--- a/src/commands/Tools/Websearch/country.ts
+++ b/src/commands/Tools/Websearch/country.ts
@@ -16,10 +16,7 @@ const mapCurrency = (currency: CurrencyData) => `${currency.name} (${currency.sy
 @ApplyOptions<PaginatedMessageCommand.Options>({
 	description: LanguageKeys.Commands.Tools.CountryDescription,
 	detailedDescription: LanguageKeys.Commands.Tools.CountryExtended,
-	enabled: false,
-	hidden: true,
-	guarded: true,
-	permissionLevel: PermissionLevels.BotOwner
+	enabled: false
 })
 export class UserPaginatedMessageCommand extends PaginatedMessageCommand {
 	public async run(message: GuildMessage, args: PaginatedMessageCommand.Args) {

--- a/src/commands/Tools/Websearch/country.ts
+++ b/src/commands/Tools/Websearch/country.ts
@@ -1,7 +1,6 @@
 import { LanguageKeys } from '#lib/i18n/languageKeys';
 import { PaginatedMessageCommand, SkyraPaginatedMessage } from '#lib/structures';
 import type { GuildMessage } from '#lib/types';
-import { PermissionLevels } from '#lib/types/Enums';
 import { formatNumber } from '#utils/functions';
 import { sendLoadingMessage } from '#utils/util';
 import { ApplyOptions } from '@sapphire/decorators';


### PR DESCRIPTION
At least until we can replace it. This way we don't have to disable it on every reboot.