### PR TITLE
fix: incorrect example in `gstart`

### DIFF
--- a/src/languages/en-US/commands/giveaway.json
+++ b/src/languages/en-US/commands/giveaway.json
@@ -34,7 +34,7 @@
 		"examples": [
 			"6h A hug from Skyra.",
 			"60m 5w A mysterious Steam game",
-			"1d Free Discord Nitro! --winners=2w"
+			"1d Free Discord Nitro! --winners=2"
 		]
 	},
 	"giveawayRerollDescription": "Re-roll the winners from a giveaway.",

--- a/src/languages/es-ES/commands/giveaway.json
+++ b/src/languages/es-ES/commands/giveaway.json
@@ -34,7 +34,7 @@
 		"examples": [
 			"6h Un abrazo de Skyra.",
 			"60m 5w Un misterioso juego de Steam",
-			"1d ¡Discord Nitro! --winners=2w"
+			"1d ¡Discord Nitro! --winners=2"
 		]
 	},
 	"giveawayRerollDescription": "Re-elige los ganadores de un sorteo.",


### PR DESCRIPTION
This was mentioned in issue #2017 