### PR TITLE
fix: set the correct sweeper values

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -272,8 +272,8 @@ export const CLIENT_OPTIONS: ClientOptions = {
 	sweepers: {
 		...Options.defaultSweeperSettings,
 		messages: {
-			interval: minutes(3),
-			lifetime: minutes(15)
+			interval: minutes.toSeconds(3),
+			lifetime: minutes.toSeconds(15)
 		}
 	},
 	partials: ['CHANNEL'],

--- a/src/lib/util/common/times.ts
+++ b/src/lib/util/common/times.ts
@@ -29,6 +29,15 @@ export function minutes(minutes: number): number {
 }
 
 /**
+ * Converts a number of minutes to seconds.
+ * @param value The amount of minutes
+ * @returns The amount of seconds `value` equals to.
+ */
+minutes.toSeconds = (value: number): number => {
+	return roundNumber(minutes(value) / Time.Second);
+};
+
+/**
  * Converts a number of hours to milliseconds.
  * @param hours The amount of hours
  * @returns The amount of milliseconds `hours` equals to.

--- a/tests/lib/util/common/times.test.ts
+++ b/tests/lib/util/common/times.test.ts
@@ -38,8 +38,14 @@ describe('Time functions', () => {
 	});
 
 	describe('minutes', () => {
-		test('GIVEN 1 hour THEN returns 60000 milliseconds', () => {
+		test('GIVEN 1 minute THEN returns 60000 milliseconds', () => {
 			expect(minutes(1)).toEqual(60_000);
+		});
+	});
+
+	describe('minutes.toSeconds', () => {
+		test('GIVEN 1 minute THEN returns 60 seconds', () => {
+			expect(minutes.toSeconds(1)).toEqual(60);
 		});
 	});
 


### PR DESCRIPTION
Both options expect seconds, but we were passing milliseconds.
