### PR TITLE
fix: warn users of incorrect reaction role hierarchy

### DIFF
--- a/src/languages/en-GB/events/reactions.json
+++ b/src/languages/en-GB/events/reactions.json
@@ -1,5 +1,6 @@
 {
 	"reaction": "Reaction Added",
 	"filterFooter": "Filtered Reaction",
-	"filter": "{{REDCROSS}} Hey {{user}}, please do not add that reaction!"
+	"filter": "{{REDCROSS}} Hey {{user}}, please do not add that reaction!",
+    "selfRoleHierarchy": "{{REDCROSS}} My role needs to be higher than all self-assignable roles, otherwise I can't grant them to people!"
 }

--- a/src/languages/en-US/events/reactions.json
+++ b/src/languages/en-US/events/reactions.json
@@ -1,5 +1,6 @@
 {
 	"reaction": "Reaction Added",
 	"filterFooter": "Filtered Reaction",
-	"filter": "{{REDCROSS}} Hey {{user}}, please do not add that reaction!"
+	"filter": "{{REDCROSS}} Hey {{user}}, please do not add that reaction!",
+    "selfRoleHierarchy": "{{REDCROSS}} My role needs to be higher than all self-assignable roles, otherwise I can't grant them to people!"
 }

--- a/src/lib/i18n/languageKeys/keys/events/reactions/All.ts
+++ b/src/lib/i18n/languageKeys/keys/events/reactions/All.ts
@@ -3,3 +3,4 @@ import { FT, T } from '#lib/types';
 export const Reaction = T<string>('events/reactions:reaction');
 export const Filter = FT<{ user: string }, string>('events/reactions:filter');
 export const FilterFooter = T<string>('events/reactions:filterFooter');
+export const SelfRoleHierarchy = T<string>('events/reactions:selfRoleHierarchy');


### PR DESCRIPTION
# This relates to...

Fixes #1983.

# Changes

- Added a new language key (`events/reactions:selfRoleHierarchy`)
- Added a warning for role hierarchy if a user attempts to claim a role higher than Skyra's
