### PR TITLE
fix(listeners): log manual bans

### DIFF
--- a/src/listeners/guilds/bans/guildBanAdd.ts
+++ b/src/listeners/guilds/bans/guildBanAdd.ts
@@ -2,10 +2,10 @@ import { GuildSettings, readSettings } from '#lib/database';
 import { getModeration } from '#utils/functions';
 import { TypeCodes } from '#utils/moderationConstants';
 import { Listener } from '@sapphire/framework';
-import type { Guild, User } from 'discord.js';
+import type { GuildBan } from 'discord.js';
 
 export class UserListener extends Listener {
-	public async run({ guild, user }: { guild: Guild; user: User }) {
+	public async run({ guild, user }: GuildBan) {
 		if (!guild.available || !(await readSettings(guild, GuildSettings.Events.BanAdd))) return;
 
 		const moderation = getModeration(guild);

--- a/src/listeners/guilds/bans/guildBanAdd.ts
+++ b/src/listeners/guilds/bans/guildBanAdd.ts
@@ -5,7 +5,7 @@ import { Listener } from '@sapphire/framework';
 import type { Guild, User } from 'discord.js';
 
 export class UserListener extends Listener {
-	public async run(guild: Guild, user: User) {
+	public async run({ guild, user }: { guild: Guild; user: User }) {
 		if (!guild.available || !(await readSettings(guild, GuildSettings.Events.BanAdd))) return;
 
 		const moderation = getModeration(guild);

--- a/src/listeners/guilds/bans/guildBanRemove.ts
+++ b/src/listeners/guilds/bans/guildBanRemove.ts
@@ -5,7 +5,7 @@ import { Listener } from '@sapphire/framework';
 import type { Guild, User } from 'discord.js';
 
 export class UserListener extends Listener {
-	public async run(guild: Guild, user: User) {
+	public async run({ guild, user }: { guild: Guild; user: User }) {
 		if (!guild.available || !(await readSettings(guild, GuildSettings.Events.BanRemove))) return;
 
 		const moderation = getModeration(guild);

--- a/src/listeners/guilds/bans/guildBanRemove.ts
+++ b/src/listeners/guilds/bans/guildBanRemove.ts
@@ -2,10 +2,10 @@ import { GuildSettings, readSettings } from '#lib/database';
 import { getModeration } from '#utils/functions';
 import { TypeCodes } from '#utils/moderationConstants';
 import { Listener } from '@sapphire/framework';
-import type { Guild, User } from 'discord.js';
+import type { GuildBan } from 'discord.js';
 
 export class UserListener extends Listener {
-	public async run({ guild, user }: { guild: Guild; user: User }) {
+	public async run({ guild, user }: GuildBan) {
 		if (!guild.available || !(await readSettings(guild, GuildSettings.Events.BanRemove))) return;
 
 		const moderation = getModeration(guild);


### PR DESCRIPTION
Fixes #2184.

Note that for reasons I have yet to determine it will only log every once in a while as opposed to every time when done by the bot. This may be due to use of different handling systems, but from what I can see it should work in the same way.