### PR TITLE
fix(twitch): increase maximum length of `message` field in database

### DIFF
--- a/scripts/SetMigrations.sql
+++ b/scripts/SetMigrations.sql
@@ -88,6 +88,7 @@ VALUES
 	(1646161749171, 'V62VersionSevenRemoveGuildSettings1646161749171'),
 	(1646162907066, 'V63VersionSevenRemoveStarboard1646162907066'),
 	(1646163533583, 'V64VersionSevenRemoveSpouses1646163533583'),
-	(1646178098086, 'V65VersionSevenRemoveStaleSchedules1646178098086');
+	(1646178098086, 'V65VersionSevenRemoveStaleSchedules1646178098086'),
+	(1647241680539, 'V66ExpandGuildSubscriptionMessage1647241680539');
 
 COMMIT;

--- a/src/lib/database/entities/GuildSubscriptionEntity.ts
+++ b/src/lib/database/entities/GuildSubscriptionEntity.ts
@@ -13,6 +13,6 @@ export class GuildSubscriptionEntity extends BaseEntity {
 	@PrimaryColumn('varchar', { length: 19 })
 	public channelId!: string;
 
-	@Column('varchar', { nullable: true, length: 50 })
+	@Column('varchar', { nullable: true, length: 200 })
 	public message?: string;
 }

--- a/src/lib/database/migrations/1647241680539-V66_ExpandGuildSubscriptionMessage.ts
+++ b/src/lib/database/migrations/1647241680539-V66_ExpandGuildSubscriptionMessage.ts
@@ -1,0 +1,19 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class V66ExpandGuildSubscriptionMessage1647241680539 implements MigrationInterface {
+	public async up(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(/* sql */ `
+			ALTER TABLE public.guild_subscription
+			ALTER COLUMN message
+				TYPE VARCHAR(200);
+		`);
+	}
+
+	public async down(queryRunner: QueryRunner): Promise<void> {
+		await queryRunner.query(/* sql */ `
+			ALTER TABLE public.guild_subscription
+			ALTER COLUMN message
+				TYPE VARCHAR(50);
+		`);
+	}
+}


### PR DESCRIPTION
The command accepts up to `200` characters, which is long enough, however, the database was always mismatching this length with just a shy maximum length of `50`, which is too short.
