### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/lib/database/migrations/1597088981807-V20_UpdateGuildEntityChecks.ts
+++ b/src/lib/database/migrations/1597088981807-V20_UpdateGuildEntityChecks.ts
@@ -217,6 +217,6 @@ export class V20UpdateGuildEntityChecks1597088981807 implements MigrationInterfa
 		const tableName = 'guilds';
 		const replacedTableName = tableName.replace('.', '_');
 		const key = `${replacedTableName}_${expression}`;
-		return `CHK_${RandomGenerator.sha1(key).substr(0, 26)}`;
+		return `CHK_${RandomGenerator.sha1(key).slice(0, 26)}`;
 	}
 }

--- a/src/lib/database/migrations/1597266996401-V21_AddMissingChecks.ts
+++ b/src/lib/database/migrations/1597266996401-V21_AddMissingChecks.ts
@@ -105,6 +105,6 @@ export class V21AddMissingChecks1597266996401 implements MigrationInterface {
 		const tableName = 'guilds';
 		const replacedTableName = tableName.replace('.', '_');
 		const key = `${replacedTableName}_${expression}`;
-		return `CHK_${RandomGenerator.sha1(key).substr(0, 26)}`;
+		return `CHK_${RandomGenerator.sha1(key).slice(0, 26)}`;
 	}
 }

--- a/src/lib/database/migrations/1606411800922-V30_AttachmentModeChecks.ts
+++ b/src/lib/database/migrations/1606411800922-V30_AttachmentModeChecks.ts
@@ -222,6 +222,6 @@ export class V30AttachmentModeChecks1606411800922 implements MigrationInterface 
 		const tableName = 'guilds';
 		const replacedTableName = tableName.replace('.', '_');
 		const key = `${replacedTableName}_${expression}`;
-		return `CHK_${RandomGenerator.sha1(key).substr(0, 26)}`;
+		return `CHK_${RandomGenerator.sha1(key).slice(0, 26)}`;
 	}
 }

--- a/src/listeners/commands/unknownCommand.ts
+++ b/src/listeners/commands/unknownCommand.ts
@@ -38,7 +38,7 @@ export class UserListener extends Listener<typeof Events.UnknownCommand> {
 		const spaceIndex = prefixLess.indexOf(' ');
 
 		// Run the last stage before running the command:
-		const rawParameters = spaceIndex === -1 ? '' : prefixLess.substr(spaceIndex + 1).trim();
+		const rawParameters = spaceIndex === -1 ? '' : prefixLess.slice(spaceIndex + 1).trim();
 		const parameters = rawParameters.length === 0 ? suffix : suffix.length === 0 ? rawParameters : `${suffix} ${rawParameters}`;
 		message.client.emit(Events.PreCommandRun, { message, command, parameters, context: { commandName, commandPrefix, prefix: commandPrefix } });
 	}


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.