### PR TITLE
Fixed a default text implying the wrong filter.

### DIFF
--- a/src/languages/en-US/commands/management.json
+++ b/src/languages/en-US/commands/management.json
@@ -729,7 +729,7 @@
 			"sh/show",
 			""
 		],
-		"extendedHelp": "The inviteMode command manages the behavior of the word filter system.",
+		"extendedHelp": "The inviteMode command manages the behavior of the invite filter system.",
 		"explainedUsage": [
 			[
 				"Enable",


### PR DESCRIPTION
The invite filter extended help text was mentioning the word filter.