### PR TITLE
fix(workflows): update label name

### DIFF
--- a/.github/workflows/update-tlds.yml
+++ b/.github/workflows/update-tlds.yml
@@ -50,5 +50,5 @@ jobs:
             git checkout -b NM-EEA-Y/update-tlds/$(date +%F-%H-%M);
             git commit -sam "chore: update TLDs";
             git push --set-upstream origin $(git rev-parse --abbrev-ref HEAD)
-            ./gh pr create -t "refactor: update TLDs" -b "*bleep bloop* I updated the TLDs file" -l "Meta: Refactor" -r "Favna" -r "Kyranet" -B main;
+            ./gh pr create -t "refactor: update TLDs" -b "*bleep bloop* I updated the TLDs file" -l "refactor" -r "Favna" -r "kyranet" -B main;
           fi

--- a/.github/workflows/update-tlds.yml
+++ b/.github/workflows/update-tlds.yml
@@ -50,5 +50,5 @@ jobs:
             git checkout -b NM-EEA-Y/update-tlds/$(date +%F-%H-%M);
             git commit -sam "chore: update TLDs";
             git push --set-upstream origin $(git rev-parse --abbrev-ref HEAD)
-            ./gh pr create -t "refactor: update TLDs" -b "*bleep bloop* I updated the TLDs file" -l "refactor" -r "Favna" -r "kyranet" -B main;
+            ./gh pr create -t "refactor: update TLDs" -b "*bleep bloop* I updated the TLDs file" -l "refactor" -r "favna" -r "kyranet" -B main;
           fi


### PR DESCRIPTION
We renamed `Meta: Refactor` to `refactor` recently, but we did not update this workflow, causing actions to fail.