### PR TITLE
refactor: change invite links to use Discord URLs instead

### DIFF
--- a/src/commands/General/invite.ts
+++ b/src/commands/General/invite.ts
@@ -1,9 +1,10 @@
 import { LanguageKeys } from '#lib/i18n/languageKeys';
 import { SkyraCommand } from '#lib/structures';
 import { BrandingColors } from '#utils/constants';
+import { hyperlink } from '@discordjs/builders';
 import { ApplyOptions } from '@sapphire/decorators';
 import { send } from '@sapphire/plugin-editable-commands';
-import { PermissionFlagsBits } from 'discord-api-types/v9';
+import { OAuth2Scopes, PermissionFlagsBits } from 'discord-api-types/v9';
 import { Message, MessageEmbed } from 'discord.js';
 import type { TFunction } from 'i18next';
 
@@ -26,22 +27,55 @@ export class UserCommand extends SkyraCommand {
 	}
 
 	private getEmbed(t: TFunction, shouldNotAddPermissions: boolean): MessageEmbed {
+		const embeddedInviteLink = hyperlink(
+			t(LanguageKeys.Commands.General.InvitePermissionInviteText),
+			this.generateInviteLink(shouldNotAddPermissions)
+		);
+		const embeddedJoinLink = hyperlink(t(LanguageKeys.Commands.General.InvitePermissionSupportServerText), 'https://discord.com/invite/6gakFR2');
+
 		return new MessageEmbed() //
 			.setColor(BrandingColors.Primary)
 			.setDescription(
 				[
-					[
-						`[${t(
-							LanguageKeys.Commands.General.InvitePermissionInviteText
-						)}](https://discord.com/oauth2/authorize?client_id=266624760782258186&permissions=${
-							shouldNotAddPermissions ? '0' : '534185897078'
-						}&scope=applications.commands%20bot)`,
-						`[${t(LanguageKeys.Commands.General.InvitePermissionSupportServerText)}](https://discord.com/invite/6gakFR2)`
-					].join(' | '),
+					[embeddedInviteLink, embeddedJoinLink].join(' | '),
 					shouldNotAddPermissions ? undefined : t(LanguageKeys.Commands.General.InvitePermissionsDescription)
 				]
 					.filter(Boolean)
 					.join('\n')
 			);
+	}
+
+	private generateInviteLink(shouldNotAddPermissions: boolean) {
+		return this.container.client.generateInvite({
+			scopes: [OAuth2Scopes.ApplicationsCommands, OAuth2Scopes.Bot],
+			permissions: shouldNotAddPermissions
+				? []
+				: [
+						PermissionFlagsBits.AddReactions,
+						PermissionFlagsBits.AttachFiles,
+						PermissionFlagsBits.BanMembers,
+						PermissionFlagsBits.ChangeNickname,
+						PermissionFlagsBits.CreatePrivateThreads,
+						PermissionFlagsBits.CreatePublicThreads,
+						PermissionFlagsBits.DeafenMembers,
+						PermissionFlagsBits.EmbedLinks,
+						PermissionFlagsBits.KickMembers,
+						PermissionFlagsBits.ManageChannels,
+						PermissionFlagsBits.ManageEmojisAndStickers,
+						PermissionFlagsBits.ManageGuild,
+						PermissionFlagsBits.ManageMessages,
+						PermissionFlagsBits.ManageNicknames,
+						PermissionFlagsBits.ManageRoles,
+						PermissionFlagsBits.ManageThreads,
+						PermissionFlagsBits.MoveMembers,
+						PermissionFlagsBits.MuteMembers,
+						PermissionFlagsBits.ReadMessageHistory,
+						PermissionFlagsBits.SendMessages,
+						PermissionFlagsBits.SendMessagesInThreads,
+						PermissionFlagsBits.UseExternalEmojis,
+						PermissionFlagsBits.UseExternalStickers,
+						PermissionFlagsBits.ViewChannel
+				  ]
+		});
 	}
 }

--- a/src/commands/General/invite.ts
+++ b/src/commands/General/invite.ts
@@ -49,33 +49,31 @@ export class UserCommand extends SkyraCommand {
 		return this.container.client.generateInvite({
 			scopes: [OAuth2Scopes.ApplicationsCommands, OAuth2Scopes.Bot],
 			permissions: shouldNotAddPermissions
-				? []
-				: [
-						PermissionFlagsBits.AddReactions,
-						PermissionFlagsBits.AttachFiles,
-						PermissionFlagsBits.BanMembers,
-						PermissionFlagsBits.ChangeNickname,
-						PermissionFlagsBits.CreatePrivateThreads,
-						PermissionFlagsBits.CreatePublicThreads,
-						PermissionFlagsBits.DeafenMembers,
-						PermissionFlagsBits.EmbedLinks,
-						PermissionFlagsBits.KickMembers,
-						PermissionFlagsBits.ManageChannels,
-						PermissionFlagsBits.ManageEmojisAndStickers,
-						PermissionFlagsBits.ManageGuild,
-						PermissionFlagsBits.ManageMessages,
-						PermissionFlagsBits.ManageNicknames,
-						PermissionFlagsBits.ManageRoles,
-						PermissionFlagsBits.ManageThreads,
-						PermissionFlagsBits.MoveMembers,
-						PermissionFlagsBits.MuteMembers,
-						PermissionFlagsBits.ReadMessageHistory,
-						PermissionFlagsBits.SendMessages,
-						PermissionFlagsBits.SendMessagesInThreads,
-						PermissionFlagsBits.UseExternalEmojis,
-						PermissionFlagsBits.UseExternalStickers,
-						PermissionFlagsBits.ViewChannel
-				  ]
+				? 0n
+				: PermissionFlagsBits.AddReactions |
+				  PermissionFlagsBits.AttachFiles |
+				  PermissionFlagsBits.BanMembers |
+				  PermissionFlagsBits.ChangeNickname |
+				  PermissionFlagsBits.CreatePrivateThreads |
+				  PermissionFlagsBits.CreatePublicThreads |
+				  PermissionFlagsBits.DeafenMembers |
+				  PermissionFlagsBits.EmbedLinks |
+				  PermissionFlagsBits.KickMembers |
+				  PermissionFlagsBits.ManageChannels |
+				  PermissionFlagsBits.ManageEmojisAndStickers |
+				  PermissionFlagsBits.ManageGuild |
+				  PermissionFlagsBits.ManageMessages |
+				  PermissionFlagsBits.ManageNicknames |
+				  PermissionFlagsBits.ManageRoles |
+				  PermissionFlagsBits.ManageThreads |
+				  PermissionFlagsBits.MoveMembers |
+				  PermissionFlagsBits.MuteMembers |
+				  PermissionFlagsBits.ReadMessageHistory |
+				  PermissionFlagsBits.SendMessages |
+				  PermissionFlagsBits.SendMessagesInThreads |
+				  PermissionFlagsBits.UseExternalEmojis |
+				  PermissionFlagsBits.UseExternalStickers |
+				  PermissionFlagsBits.ViewChannel
 		});
 	}
 }

--- a/src/commands/General/invite.ts
+++ b/src/commands/General/invite.ts
@@ -31,10 +31,12 @@ export class UserCommand extends SkyraCommand {
 			.setDescription(
 				[
 					[
-						`[${t(LanguageKeys.Commands.General.InvitePermissionInviteText)}](https://invite.skyra.pw${
-							shouldNotAddPermissions ? '/no-permissions' : ''
-						})`,
-						`[${t(LanguageKeys.Commands.General.InvitePermissionSupportServerText)}](https://join.skyra.pw)`
+						`[${t(
+							LanguageKeys.Commands.General.InvitePermissionInviteText
+						)}](https://discord.com/oauth2/authorize?client_id=266624760782258186&permissions=${
+							shouldNotAddPermissions ? '0' : '534185897078'
+						}&scope=applications.commands%20bot)`,
+						`[${t(LanguageKeys.Commands.General.InvitePermissionSupportServerText)}](https://discord.com/invite/6gakFR2)`
 					].join(' | '),
 					shouldNotAddPermissions ? undefined : t(LanguageKeys.Commands.General.InvitePermissionsDescription)
 				]


### PR DESCRIPTION
This allows the users to invite the bot/join the support server without leaving the Discord client.

![image](https://github.com/skyra-project/skyra/assets/61084101/497647ec-e268-49b5-a9cf-b6260bcf9650)
