### PR TITLE
feat(ban): add units and docs

### DIFF
--- a/src/commands/Moderation/ban.ts
+++ b/src/commands/Moderation/ban.ts
@@ -2,6 +2,7 @@ import { GuildSettings, readSettings } from '#lib/database';
 import { LanguageKeys } from '#lib/i18n/languageKeys';
 import { ModerationCommand } from '#lib/moderation';
 import { getModeration, getSecurity } from '#utils/functions';
+import { TimeOptions, getSeconds } from '#utils/moderation-utilities';
 import type { Unlock } from '#utils/moderationConstants';
 import { getImage } from '#utils/util';
 import { ApplyOptions } from '@sapphire/decorators';
@@ -13,7 +14,7 @@ import { PermissionFlagsBits } from 'discord-api-types/v9';
 	description: LanguageKeys.Commands.Moderation.BanDescription,
 	detailedDescription: LanguageKeys.Commands.Moderation.BanExtended,
 	optionalDuration: true,
-	options: ['d', 'day', 'days'],
+	options: TimeOptions,
 	requiredClientPermissions: [PermissionFlagsBits.BanMembers],
 	requiredMember: false
 })
@@ -31,7 +32,7 @@ export class UserModerationCommand extends ModerationCommand {
 				imageURL: getImage(message),
 				reason: context.reason
 			},
-			await this.getDays(context.args),
+			getSeconds(context.args),
 			await this.getTargetDM(message, context.args, context.target)
 		);
 	}
@@ -44,14 +45,5 @@ export class UserModerationCommand extends ModerationCommand {
 		const member = await super.checkModeratable(message, context);
 		if (member && !member.bannable) throw context.args.t(LanguageKeys.Commands.Moderation.BanNotBannable);
 		return member;
-	}
-
-	private async getDays(args: ModerationCommand.Args) {
-		const value = args.getOption('d', 'day', 'days');
-		if (value === null) return 0;
-
-		const parsed = Number(value);
-		if (Number.isInteger(parsed) && parsed >= 0 && parsed <= 7) return parsed;
-		return 0;
 	}
 }

--- a/src/commands/Moderation/softban.ts
+++ b/src/commands/Moderation/softban.ts
@@ -2,6 +2,7 @@ import { GuildSettings, readSettings } from '#lib/database';
 import { LanguageKeys } from '#lib/i18n/languageKeys';
 import { ModerationCommand } from '#lib/moderation';
 import { getModeration, getSecurity } from '#utils/functions';
+import { TimeOptions, getSeconds } from '#utils/moderation-utilities';
 import type { Unlock } from '#utils/moderationConstants';
 import { getImage } from '#utils/util';
 import { ApplyOptions } from '@sapphire/decorators';
@@ -12,7 +13,7 @@ import { PermissionFlagsBits } from 'discord-api-types/v9';
 	aliases: ['sb'],
 	description: LanguageKeys.Commands.Moderation.SoftBanDescription,
 	detailedDescription: LanguageKeys.Commands.Moderation.SoftBanExtended,
-	options: ['d', 'day', 'days'],
+	options: TimeOptions,
 	requiredClientPermissions: [PermissionFlagsBits.BanMembers],
 	requiredMember: false
 })
@@ -31,7 +32,7 @@ export class UserModerationCommand extends ModerationCommand {
 				reason: context.reason,
 				imageURL: getImage(message)
 			},
-			await this.getDays(context.args),
+			getSeconds(context.args),
 			await this.getTargetDM(message, context.args, context.target)
 		);
 	}
@@ -44,14 +45,5 @@ export class UserModerationCommand extends ModerationCommand {
 		const member = await super.checkModeratable(message, context);
 		if (member && !member.bannable) throw context.args.t(LanguageKeys.Commands.Moderation.BanNotBannable);
 		return member;
-	}
-
-	private async getDays(args: ModerationCommand.Args) {
-		const value = args.getOption('d', 'day', 'days');
-		if (value === null) return 0;
-
-		const parsed = Number(value);
-		if (Number.isInteger(parsed) && parsed >= 0 && parsed <= 7) return parsed;
-		return 0;
 	}
 }

--- a/src/languages/en-US/commands/moderation.json
+++ b/src/languages/en-US/commands/moderation.json
@@ -192,7 +192,7 @@
 			"User1 User2 User3...User10",
 			"User1 Duration",
 			"User1 User2 Duration Reason",
-			"User --days"
+			"User --seconds=S --minutes=M --hours=H --days=D"
 		],
 		"explainedUsage": [
 			[
@@ -208,8 +208,8 @@
 				"The reason for the ban. This will also show in the server's audit logs."
 			],
 			[
-				"--days",
-				"The amount of days of messages to prune. Should be a number between a minimum of 0 and maximum of 7."
+				"--seconds=S --minutes=M --hours=H --days=D",
+				"The amount of time worth of messages to delete, each flag is optional and can be combined. Up to 7 days."
 			]
 		],
 		"extendedHelp": "This command requires **{{BAN_MEMBERS, permissions}}**, and only members with lower role hierarchy position can be banned by me.\nNo, the server's owner cannot be banned.\nThis action can be optionally timed to create a temporary ban.",
@@ -699,7 +699,8 @@
 		"usages": [
 			"User",
 			"User1 User2 User3...User10",
-			"User1 Reason"
+			"User1 Reason",
+			"User --seconds=S --minutes=M --hours=H --days=D"
 		],
 		"explainedUsage": [
 			[
@@ -709,6 +710,10 @@
 			[
 				"Reason",
 				"The reason for the softban. This will also show in the server's audit logs."
+			],
+			[
+				"--seconds=S --minutes=M --hours=H --days=D",
+				"The amount of time worth of messages to delete, each flag is optional and can be combined. Up to 7 days."
 			]
 		],
 		"extendedHelp": "This command requires **{{BAN_MEMBERS, permissions}}**, and only members with lower role hierarchy position can be banned by me.\nNo, the server's owner cannot be banned.\nThe ban feature from Discord has a feature that allows the moderator to remove all messages from all channels that have been sent in the last 'x' days, being a number between 0 (no days) and 7.\nThe user gets unbanned right after the ban, so it is like a kick, but that can prune many many messages.",

--- a/src/lib/moderation/structures/ModerationListener.ts
+++ b/src/lib/moderation/structures/ModerationListener.ts
@@ -1,4 +1,5 @@
 import { GuildEntity, readSettings } from '#lib/database';
+import { seconds } from '#utils/common';
 import { getModeration, getSecurity } from '#utils/functions';
 import { Listener } from '@sapphire/framework';
 import type { PickByValue } from '@sapphire/utilities';
@@ -79,7 +80,7 @@ export abstract class ModerationListener<V extends unknown[], T = unknown> exten
 					moderatorId: process.env.CLIENT_ID,
 					reason: '[Auto-Moderation] Threshold Reached.'
 				},
-				1
+				seconds.fromMinutes(5)
 			)
 		);
 	}
@@ -88,15 +89,12 @@ export abstract class ModerationListener<V extends unknown[], T = unknown> exten
 		const duration = await readSettings(guild, this.hardPunishmentPath.actionDuration);
 
 		await this.createActionAndSend(guild, () =>
-			getSecurity(guild).actions.ban(
-				{
-					userId,
-					moderatorId: process.env.CLIENT_ID,
-					reason: '[Auto-Moderation] Threshold Reached.',
-					duration
-				},
-				0
-			)
+			getSecurity(guild).actions.ban({
+				userId,
+				moderatorId: process.env.CLIENT_ID,
+				reason: '[Auto-Moderation] Threshold Reached.',
+				duration
+			})
 		);
 	}
 

--- a/src/lib/moderation/structures/ModerationMessageListener.ts
+++ b/src/lib/moderation/structures/ModerationMessageListener.ts
@@ -2,9 +2,9 @@ import { AdderKey, GuildEntity, GuildSettings, readSettings } from '#lib/databas
 import type { AdderError } from '#lib/database/utils/Adder';
 import type { CustomFunctionGet, CustomGet, GuildMessage } from '#lib/types';
 import { Events } from '#lib/types/Enums';
-import { floatPromise } from '#utils/common';
+import { floatPromise, seconds } from '#utils/common';
 import { getModeration, getSecurity, isModerator } from '#utils/functions';
-import { canSendMessages, GuildTextBasedChannelTypes } from '@sapphire/discord.js-utilities';
+import { GuildTextBasedChannelTypes, canSendMessages } from '@sapphire/discord.js-utilities';
 import { Listener, ListenerOptions, PieceContext } from '@sapphire/framework';
 import type { Awaitable, Nullish, PickByValue } from '@sapphire/utilities';
 import type { GuildMember, MessageEmbed } from 'discord.js';
@@ -143,22 +143,19 @@ export abstract class ModerationMessageListener<T = unknown> extends Listener {
 					moderatorId: process.env.CLIENT_ID,
 					reason: maximum === 0 ? t(this.reasonLanguageKey) : t(this.reasonLanguageKeyWithMaximum, { amount: points, maximum })
 				},
-				1
+				seconds.fromMinutes(5)
 			)
 		);
 	}
 
 	protected async onBan(message: GuildMessage, t: TFunction, points: number, maximum: number, duration: number | null) {
 		await this.createActionAndSend(message, () =>
-			getSecurity(message.guild).actions.ban(
-				{
-					userId: message.author.id,
-					moderatorId: process.env.CLIENT_ID,
-					reason: maximum === 0 ? t(this.reasonLanguageKey) : t(this.reasonLanguageKeyWithMaximum, { amount: points, maximum }),
-					duration
-				},
-				0
-			)
+			getSecurity(message.guild).actions.ban({
+				userId: message.author.id,
+				moderatorId: process.env.CLIENT_ID,
+				reason: maximum === 0 ? t(this.reasonLanguageKey) : t(this.reasonLanguageKeyWithMaximum, { amount: points, maximum }),
+				duration
+			})
 		);
 	}
 

--- a/src/lib/util/Security/ModerationActions.ts
+++ b/src/lib/util/Security/ModerationActions.ts
@@ -8,9 +8,9 @@ import { resolveOnErrorCodes } from '#utils/common';
 import { getModeration, getStickyRoles, promptConfirmation } from '#utils/functions';
 import { TypeCodes } from '#utils/moderationConstants';
 import { isCategoryChannel, isNewsChannel, isStageChannel, isTextChannel, isVoiceChannel } from '@sapphire/discord.js-utilities';
-import { container, UserError } from '@sapphire/framework';
+import { UserError, container } from '@sapphire/framework';
 import { fetchT, resolveKey } from '@sapphire/plugin-i18next';
-import { isNullish, isNullishOrEmpty, isNullishOrZero, Nullish, PickByValue } from '@sapphire/utilities';
+import { Nullish, PickByValue, isNullish, isNullishOrEmpty, isNullishOrZero } from '@sapphire/utilities';
 import { RESTJSONErrorCodes } from 'discord-api-types/v9';
 import {
 	DiscordAPIError,
@@ -410,7 +410,7 @@ export class ModerationActions {
 		return (await moderationLog.create())!;
 	}
 
-	public async softBan(rawOptions: ModerationActionOptions, days: number, sendOptions?: ModerationActionsSendOptions) {
+	public async softBan(rawOptions: ModerationActionOptions, seconds?: number, sendOptions?: ModerationActionsSendOptions) {
 		const options = ModerationActions.fillOptions(rawOptions, TypeCodes.SoftBan);
 		const moderationLog = getModeration(this.guild).create(options);
 		await this.sendDM(moderationLog, sendOptions);
@@ -421,7 +421,7 @@ export class ModerationActions {
 			.bans(options.userId)
 			.put({
 				data: {
-					delete_message_days: days
+					delete_message_seconds: seconds ?? 0
 				},
 				reason: moderationLog.reason
 					? t(LanguageKeys.Commands.Moderation.ActionSoftBanReason, { reason: moderationLog.reason! })
@@ -438,7 +438,7 @@ export class ModerationActions {
 		return (await moderationLog.create())!;
 	}
 
-	public async ban(rawOptions: ModerationActionOptions, days: number, sendOptions?: ModerationActionsSendOptions) {
+	public async ban(rawOptions: ModerationActionOptions, seconds?: number, sendOptions?: ModerationActionsSendOptions) {
 		const options = ModerationActions.fillOptions(rawOptions, TypeCodes.Ban);
 		const moderationLog = getModeration(this.guild).create(options);
 		await this.sendDM(moderationLog, sendOptions);
@@ -447,7 +447,7 @@ export class ModerationActions {
 			.bans(options.userId)
 			.put({
 				data: {
-					delete_message_days: days
+					delete_message_seconds: seconds ?? 0
 				},
 				reason: await this.getReason('ban', moderationLog.reason)
 			});

--- a/src/lib/util/common/times.ts
+++ b/src/lib/util/common/times.ts
@@ -20,6 +20,33 @@ seconds.fromMilliseconds = (milliseconds: number): number => {
 };
 
 /**
+ * Converts a number of minutes to seconds.
+ * @param minutes The amount of minutes
+ * @returns The amount of seconds `minutes` equals to.
+ */
+seconds.fromMinutes = (minutes: number): number => {
+	return minutes * 60;
+};
+
+/**
+ * Converts a number of hours to seconds.
+ * @param hours The amount of hours
+ * @returns The amount of seconds `hours` equals to.
+ */
+seconds.fromHours = (hours: number): number => {
+	return hours * 60 * 60;
+};
+
+/**
+ * Converts a number of days to seconds.
+ * @param days The amount of days
+ * @returns The amount of seconds `days` equals to.
+ */
+seconds.fromDays = (days: number): number => {
+	return days * 60 * 60 * 24;
+};
+
+/**
  * Converts a number of minutes to milliseconds.
  * @param minutes The amount of minutes
  * @returns The amount of milliseconds `minutes` equals to.

--- a/src/lib/util/moderation-utilities.ts
+++ b/src/lib/util/moderation-utilities.ts
@@ -1,0 +1,27 @@
+import type { SkyraArgs } from '#lib/structures';
+import { seconds } from './common';
+
+export const SecondsOptions = ['s', 'sec', 'secs', 'second', 'seconds'] as const;
+export const MinutesOptions = ['m', 'min', 'mins', 'minute', 'minutes'] as const;
+export const HoursOptions = ['h', 'hr', 'hrs', 'hour', 'hours'] as const;
+export const DaysOptions = ['d', 'day', 'days'] as const;
+export const TimeOptions = [...SecondsOptions, ...MinutesOptions, ...HoursOptions, ...DaysOptions] as const;
+
+const maximum = seconds.fromDays(7);
+
+export function getSeconds(args: SkyraArgs) {
+	const result =
+		getUnit(args, SecondsOptions) +
+		getUnit(args, MinutesOptions, seconds.fromMinutes) +
+		getUnit(args, HoursOptions, seconds.fromHours) +
+		getUnit(args, DaysOptions, seconds.fromDays);
+	return Math.min(result, maximum);
+}
+
+function getUnit(args: SkyraArgs, flags: readonly string[], cb?: (value: number) => number) {
+	const value = args.getOption(...flags);
+	if (value === null) return 0;
+
+	const parsed = Number(value);
+	return Number.isInteger(parsed) ? (cb ? cb(parsed) : parsed) : 0;
+}


### PR DESCRIPTION
Also tweaked the `softban` command, added documentation for the units, and switched the deprecated `delete_message_days` field for the somewhat new `delete_message_seconds` field.

Ref: https://discord.com/developers/docs/resources/guild#create-guild-ban
