### PR TITLE
refactor(deps): remove `utf-8-validate`

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
 		"tslib": "1.14.1",
 		"typeorm": "0.2.28",
 		"typeorm-naming-strategies": "^2.0.0",
-		"utf-8-validate": "^6.0.3",
 		"zlib-sync": "^0.1.8"
 	},
 	"devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9643,7 +9643,6 @@ __metadata:
     typeorm: 0.2.28
     typeorm-naming-strategies: ^2.0.0
     typescript: ~4.7.4
-    utf-8-validate: ^6.0.3
     zlib-sync: ^0.1.8
   languageName: unknown
   linkType: soft
@@ -10579,16 +10578,6 @@ __metadata:
     punycode: 1.3.2
     querystring: 0.2.0
   checksum: 50d100d3dd2d98b9fe3ada48cadb0b08aa6be6d3ac64112b867b56b19be4bfcba03c2a9a0d7922bfd7ac17d4834e88537749fe182430dfd9b68e520175900d90
-  languageName: node
-  linkType: hard
-
-"utf-8-validate@npm:^6.0.3":
-  version: 6.0.3
-  resolution: "utf-8-validate@npm:6.0.3"
-  dependencies:
-    node-gyp: latest
-    node-gyp-build: ^4.3.0
-  checksum: 5e21383c81ff7469c1912119ca69d07202d944c73ddd8a54b84dddcc546b939054e5101c78c294e494d206fe93bd43428adc635a0660816b3ec9c8ec89286ac4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Related: https://github.com/websockets/ws/commit/42d79f60efb739b349b84b020c9d0ee062150633

`ws` will use `utf-8-validate` if `require('buffer').isUtf8` is undefined, said function (<https://nodejs.org/dist/latest-v18.x/docs/api/buffer.html#bufferisutf8input>) was added in v18.14.0, the same version we now run in Docker since <https://github.com/skyra-project/skyra/pull/2471>.
