### PR TITLE
feat: add `--dm` and `--no-dm` flags to moderation commands

### DIFF
--- a/src/lib/moderation/structures/ModerationCommand.ts
+++ b/src/lib/moderation/structures/ModerationCommand.ts
@@ -25,7 +25,7 @@ export abstract class ModerationCommand<T = unknown> extends SkyraCommand {
 	protected constructor(context: PieceContext, options: ModerationCommand.Options) {
 		super(context, {
 			cooldownDelay: seconds(5),
-			flags: ['no-author', 'authored'],
+			flags: ['no-author', 'authored', 'no-dm', 'dm'],
 			optionalDuration: false,
 			permissionLevel: PermissionLevels.Moderator,
 			requiredMember: false,
@@ -149,7 +149,7 @@ export abstract class ModerationCommand<T = unknown> extends SkyraCommand {
 
 		return {
 			moderator: args.getFlags('no-author') ? null : args.getFlags('no-authored') || nameDisplay ? message.author : null,
-			send: enabledDM && (await this.container.db.fetchModerationDirectMessageEnabled(target.id))
+			send: (args.getFlags('dm') || (enabledDM && !args.getFlags('no-dm'))) && (await this.container.db.fetchModerationDirectMessageEnabled(target.id))
 		};
 	}
 

--- a/src/lib/moderation/structures/ModerationCommand.ts
+++ b/src/lib/moderation/structures/ModerationCommand.ts
@@ -148,7 +148,7 @@ export abstract class ModerationCommand<T = unknown> extends SkyraCommand {
 		]);
 
 		return {
-			moderator: args.getFlags('no-author') ? null : args.getFlags('no-authored') || nameDisplay ? message.author : null,
+			moderator: args.getFlags('no-author') ? null : args.getFlags('authored') || nameDisplay ? message.author : null,
 			send: (args.getFlags('dm') || (enabledDM && !args.getFlags('no-dm'))) && (await this.container.db.fetchModerationDirectMessageEnabled(target.id))
 		};
 	}

--- a/src/lib/moderation/structures/ModerationCommand.ts
+++ b/src/lib/moderation/structures/ModerationCommand.ts
@@ -151,13 +151,11 @@ export abstract class ModerationCommand<T = unknown> extends SkyraCommand {
 			moderator: args.getFlags('no-author') ? null : args.getFlags('authored') || nameDisplay ? message.author : null,
 			send:
 				// --no-dm disables
-				!args.getFlags('no-dm') && (
-					// --dm and enabledDM enable
-					args.getFlags('dm') || enabledDM
-				) && (
-					// user settings
-					await this.container.db.fetchModerationDirectMessageEnabled(target.id)
-				)
+				!args.getFlags('no-dm') &&
+				// --dm and enabledDM enable
+				(args.getFlags('dm') || enabledDM) &&
+				// user settings
+				(await this.container.db.fetchModerationDirectMessageEnabled(target.id))
 		};
 	}
 

--- a/src/lib/moderation/structures/ModerationCommand.ts
+++ b/src/lib/moderation/structures/ModerationCommand.ts
@@ -149,7 +149,15 @@ export abstract class ModerationCommand<T = unknown> extends SkyraCommand {
 
 		return {
 			moderator: args.getFlags('no-author') ? null : args.getFlags('authored') || nameDisplay ? message.author : null,
-			send: (args.getFlags('dm') || (enabledDM && !args.getFlags('no-dm'))) && (await this.container.db.fetchModerationDirectMessageEnabled(target.id))
+			send:
+				// --no-dm disables
+				!args.getFlags('no-dm') && (
+					// --dm and enabledDM enable
+					args.getFlags('dm') || enabledDM
+				) && (
+					// user settings
+					await this.container.db.fetchModerationDirectMessageEnabled(target.id)
+				)
 		};
 	}
 


### PR DESCRIPTION
this should add the --dm and --no-dm arguments to moderation commands, allowing things like silent warnings to be made by staff.

*I am unable to test this locally at this time.*