### PR TITLE
feat: add `global_name` support

### DIFF
--- a/.yarn/patches/discord.js-npm-13.16.0-03bbf983c5.patch
+++ b/.yarn/patches/discord.js-npm-13.16.0-03bbf983c5.patch
@@ -1,21 +1,12 @@
 diff --git a/src/client/actions/ChannelUpdate.js b/src/client/actions/ChannelUpdate.js
-index 34d1a86a4c0d59317b7d7be69b42cff4fb71e1c7..3695e0b0a2073365378b6d3be9cadff5e718a350 100644
+index 34d1a86a4c0d59317b7d7be69b42cff4fb71e1c7..59bdc5b4858bc036934b82f54f2a6c471e3acdd5 100644
 --- a/src/client/actions/ChannelUpdate.js
 +++ b/src/client/actions/ChannelUpdate.js
-@@ -7,14 +7,23 @@ const { ChannelTypes } = require('../../util/Constants');
- class ChannelUpdateAction extends Action {
-   handle(data) {
-     const client = this.client;
--
-     let channel = client.channels.cache.get(data.id);
-+
-     if (channel) {
-       const old = channel._update(data);
+@@ -14,7 +14,15 @@ class ChannelUpdateAction extends Action {
  
        if (ChannelTypes[channel.type] !== data.type) {
          const newChannel = Channel.create(this.client, data, channel.guild);
 -        for (const [id, message] of channel.messages.cache) newChannel.messages.cache.set(id, message);
-+
 +        if (!newChannel) {
 +          this.client.channels.cache.delete(channel.id);
 +          return {};
@@ -28,3 +19,75 @@ index 34d1a86a4c0d59317b7d7be69b42cff4fb71e1c7..3695e0b0a2073365378b6d3be9cadff5
          channel = newChannel;
          this.client.channels.cache.set(channel.id, channel);
        }
+diff --git a/src/structures/GuildMember.js b/src/structures/GuildMember.js
+index 2fff24990d3702865e28ee88cadd6c7908c49217..7cbd748307f488521665de96724622f1a62ef091 100644
+--- a/src/structures/GuildMember.js
++++ b/src/structures/GuildMember.js
+@@ -259,12 +259,12 @@ class GuildMember extends Base {
+   }
+ 
+   /**
+-   * The nickname of this member, or their username if they don't have one
++   * The nickname of this member, or their user display name if they don't have one
+    * @type {?string}
+    * @readonly
+    */
+   get displayName() {
+-    return this.nickname ?? this.user.username;
++    return this.nickname ?? this.user.displayName;
+   }
+ 
+   /**
+diff --git a/src/structures/User.js b/src/structures/User.js
+index dd1880edec3d5051a3b710f9ec530206f80d6193..c7e5321a3071ff818d582fd54c7a72ac9b1e972d 100644
+--- a/src/structures/User.js
++++ b/src/structures/User.js
+@@ -41,6 +41,16 @@ class User extends Base {
+       this.username ??= null;
+     }
+ 
++    if ('global_name' in data) {
++      /**
++       * The global name of this user
++       * @type {?string}
++       */
++      this.globalName = data.global_name;
++    } else {
++      this.globalName ??= null;
++    }
++
+     if ('bot' in data) {
+       /**
+        * Whether or not the user is a bot
+@@ -201,6 +211,15 @@ class User extends Base {
+     return typeof this.username === 'string' ? `${this.username}#${this.discriminator}` : null;
+   }
+ 
++  /**
++   * The global name of this user, or their username if they don't have one
++   * @type {?string}
++   * @readonly
++   */
++  get displayName() {
++    return this.globalName ?? this.username;
++  }
++
+   /**
+    * The DM between the client's user and this user
+    * @type {?DMChannel}
+diff --git a/typings/index.d.ts b/typings/index.d.ts
+index 42630bb85c963ef8c14764a5e0fb8629e7c07d59..428fd58408f355380bb3d1c16886cb5092a8bb6c 100644
+--- a/typings/index.d.ts
++++ b/typings/index.d.ts
+@@ -2700,9 +2700,11 @@ export class User extends PartialTextBasedChannel(Base) {
+   public readonly createdAt: Date;
+   public readonly createdTimestamp: number;
+   public discriminator: string;
++  public readonly displayName: string;
+   public readonly defaultAvatarURL: string;
+   public readonly dmChannel: DMChannel | null;
+   public flags: Readonly<UserFlags> | null;
++  public globalName: string | null;
+   public readonly hexAccentColor: HexColorString | null | undefined;
+   public id: Snowflake;
+   public readonly partial: false;

--- a/src/commands/Fun/rate.ts
+++ b/src/commands/Fun/rate.ts
@@ -29,14 +29,16 @@ export class UserCommand extends SkyraCommand {
 			rate = 101;
 			[ratewaifu, rateableThing] = args.t(LanguageKeys.Commands.Fun.RateMyOwners);
 		} else {
-			rateableThing = /^(myself|me)$/i.test(rateableThing) ? message.author.username : escapeMarkdown(rateableThing.replace(/\bmy\b/g, 'your'));
+			rateableThing = /^(myself|me)$/i.test(rateableThing)
+				? message.author.displayName
+				: escapeMarkdown(rateableThing.replace(/\bmy\b/g, 'your'));
 
 			const rng = Math.round(Math.random() * 100);
 			[ratewaifu, rate] = [oneToTen((rng / 10) | 0)!.emoji, rng];
 		}
 
 		const content = args.t(LanguageKeys.Commands.Fun.RateOutput, {
-			author: message.author.username,
+			author: message.author.displayName,
 			userToRate: rateableThing,
 			rate,
 			emoji: ratewaifu

--- a/src/commands/System/support.ts
+++ b/src/commands/System/support.ts
@@ -16,7 +16,7 @@ import { Message, MessageEmbed } from 'discord.js';
 export class UserCommand extends SkyraCommand {
 	public messageRun(message: Message, args: SkyraCommand.Args) {
 		const embed = new MessageEmbed()
-			.setTitle(args.t(LanguageKeys.Commands.System.SupportEmbedTitle, { username: message.author.username }))
+			.setTitle(args.t(LanguageKeys.Commands.System.SupportEmbedTitle, { username: message.author.displayName }))
 			.setDescription(args.t(LanguageKeys.Commands.System.SupportEmbedDescription))
 			.setColor(getColor(message));
 		return send(message, { embeds: [embed] });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4927,7 +4927,7 @@ __metadata:
 
 "discord.js@patch:discord.js@npm%3A13.16.0#./.yarn/patches/discord.js-npm-13.16.0-03bbf983c5.patch::locator=skyra%40workspace%3A.":
   version: 13.16.0
-  resolution: "discord.js@patch:discord.js@npm%3A13.16.0#./.yarn/patches/discord.js-npm-13.16.0-03bbf983c5.patch::version=13.16.0&hash=7ec6eb&locator=skyra%40workspace%3A."
+  resolution: "discord.js@patch:discord.js@npm%3A13.16.0#./.yarn/patches/discord.js-npm-13.16.0-03bbf983c5.patch::version=13.16.0&hash=5000f3&locator=skyra%40workspace%3A."
   dependencies:
     "@discordjs/builders": ^0.16.0
     "@discordjs/collection": ^0.7.0
@@ -4938,7 +4938,7 @@ __metadata:
     form-data: ^4.0.0
     node-fetch: ^2.6.7
     ws: ^8.13.0
-  checksum: e7d80a77491d58158cae962844ae3dea239528547461e26c5c8d51ba225c79f1415be45c51092efb03618c28fd3bb8186c6fae944d02abc0103317e7c81f12c8
+  checksum: 2f97aca32172b744a2b614749c3758684c7f263d7254a7a1dff48e47384dc0db20a94cbc477c38b45a243eed39443a8f11de3e2250c8ee08687d9fce667aa1b4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Backports part of https://github.com/discordjs/discord.js/pull/9512 to the yarn patch, introduces support for `global_name` in `dehoist`
