### PR TITLE
fix: resolved more issues

### DIFF
--- a/src/lib/util/common/promises.ts
+++ b/src/lib/util/common/promises.ts
@@ -1,4 +1,4 @@
-import { container } from '@sapphire/framework';
+import { Result, container, err, ok } from '@sapphire/framework';
 import { isThenable, type Awaitable } from '@sapphire/utilities';
 import { DiscordAPIError, type RESTJSONErrorCodes } from 'discord.js';
 
@@ -7,6 +7,15 @@ export async function resolveOnErrorCodes<T>(promise: Promise<T>, ...codes: read
 		return await promise;
 	} catch (error) {
 		if (error instanceof DiscordAPIError && codes.includes(error.code as RESTJSONErrorCodes)) return null;
+		throw error;
+	}
+}
+
+export async function toErrorCodeResult<T>(promise: Promise<T>): Promise<Result<T, RESTJSONErrorCodes>> {
+	try {
+		return ok(await promise);
+	} catch (error) {
+		if (error instanceof DiscordAPIError) return err(error.code as RESTJSONErrorCodes);
 		throw error;
 	}
 }

--- a/src/lib/util/functions/index.ts
+++ b/src/lib/util/functions/index.ts
@@ -3,3 +3,4 @@ export * from '#lib/util/functions/emojis';
 export * from '#lib/util/functions/guild';
 export * from '#lib/util/functions/messages';
 export * from '#lib/util/functions/permissions';
+export * from '#lib/util/functions/pieces';

--- a/src/lib/util/functions/pieces.ts
+++ b/src/lib/util/functions/pieces.ts
@@ -1,0 +1,10 @@
+import type { Piece } from '@sapphire/framework';
+import { bgBlue, bgRed } from 'colorette';
+
+export function getLogPrefix(piece: Piece) {
+	return bgBlue(`[ ${piece.store.name} => ${piece.name} ]`);
+}
+
+export function getCodeStyle(code: string | number) {
+	return bgRed(`[ ${code} ]`);
+}

--- a/src/listeners/guilds/channels/channelUpdateNotify.ts
+++ b/src/listeners/guilds/channels/channelUpdateNotify.ts
@@ -6,7 +6,13 @@ import { differenceBitField, differenceMap } from '#utils/common/comparators';
 import { Colors, LongWidthSpace } from '#utils/constants';
 import { EmbedBuilder } from '@discordjs/builders';
 import { ApplyOptions } from '@sapphire/decorators';
-import { isDMChannel, isNsfwChannel, type GuildBasedChannelTypes, type NonThreadGuildBasedChannelTypes } from '@sapphire/discord.js-utilities';
+import {
+	canSendMessages,
+	isDMChannel,
+	isNsfwChannel,
+	type GuildBasedChannelTypes,
+	type NonThreadGuildBasedChannelTypes
+} from '@sapphire/discord.js-utilities';
 import { Events, Listener } from '@sapphire/framework';
 import type { TFunction } from '@sapphire/plugin-i18next';
 import { isNullish } from '@sapphire/utilities';
@@ -35,7 +41,7 @@ export class UserListener extends Listener<typeof Events.ChannelUpdate> {
 		if (isNullish(channelId)) return;
 
 		const channel = next.guild.channels.cache.get(channelId) as TextChannel | undefined;
-		if (channel === undefined) {
+		if (isNullish(channel) || !canSendMessages(channel)) {
 			await writeSettings(next.guild, [[GuildSettings.Channels.Logs.ChannelUpdate, null]]);
 			return;
 		}

--- a/src/listeners/guilds/members/notMutedMemberAddInitialRole.ts
+++ b/src/listeners/guilds/members/notMutedMemberAddInitialRole.ts
@@ -1,9 +1,11 @@
 import { GuildSettings, readSettings, writeSettings } from '#lib/database';
 import { Events } from '#lib/types';
+import { toErrorCodeResult } from '#utils/common';
+import { getCodeStyle, getLogPrefix } from '#utils/functions';
 import { ApplyOptions } from '@sapphire/decorators';
 import { Listener } from '@sapphire/framework';
 import { isNullish } from '@sapphire/utilities';
-import { PermissionFlagsBits, type GuildMember } from 'discord.js';
+import { PermissionFlagsBits, RESTJSONErrorCodes, type GuildMember } from 'discord.js';
 
 @ApplyOptions<Listener.Options>({ event: Events.NotMutedMemberAdd })
 export class UserListener extends Listener {
@@ -16,22 +18,23 @@ export class UserListener extends Listener {
 			GuildSettings.Roles.InitialHumans,
 			GuildSettings.Roles.InitialBots
 		]);
-		if (!initial && !initialHumans && !initialBots) return;
 
 		const roleId = initial ?? (member.user.bot ? initialBots : initialHumans);
 		if (!roleId) return;
 
-		const role = member.guild.roles.cache.get(roleId);
-		if (role && role.position < member.guild.members.me!.roles.highest.position) {
-			return member.roles.add(role);
+		const result = await toErrorCodeResult(member.roles.add(roleId));
+		// If the role was not found or the bot can't give the role, remove it from the settings:
+		if (result.isErrAnd((code) => code === RESTJSONErrorCodes.UnknownRole || code === RESTJSONErrorCodes.MissingPermissions)) {
+			const key = initial //
+				? GuildSettings.Roles.Initial
+				: member.user.bot
+					? GuildSettings.Roles.InitialBots
+					: GuildSettings.Roles.InitialHumans;
+			return writeSettings(member, [[key, null]]);
 		}
 
-		const key = role //
-			? GuildSettings.Roles.Initial
-			: member.user.bot
-				? GuildSettings.Roles.InitialBots
-				: GuildSettings.Roles.InitialHumans;
-		return writeSettings(member, [[key, null]]);
+		// In any other case, log the error as unexpected:
+		result.inspectErr((code) => this.container.logger.error(`${getLogPrefix(this)} Failed to give role: ${getCodeStyle(code)}`));
 	}
 
 	private canGiveRoles(member: GuildMember) {


### PR DESCRIPTION
`notMutedMemberAddInitialRole` was reporting errors that indicated outdated cache, which is an uncommon issue in the library. As such, I've updated the event to handle errors reactively rather than relying on the cache. This should fix the issue.

Also fixes an issue in the same event resetting the wrong key, since it was checking `role`'s truthiness rather than `initial`'s like the selection does.
