### PR TITLE
refactor: improved `whois` with interaction support

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,12 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["github>sapphiredev/.github:sapphire-renovate"]
+	"extends": ["github>sapphiredev/.github:sapphire-renovate"],
+	"npm": {
+		"packageRules": [
+			{
+				"matchPackagePatterns": ["@types/node"],
+				"enabled": false
+			}
+		]
+	}
 }

--- a/package.json
+++ b/package.json
@@ -66,8 +66,8 @@
 		"@sapphire/stopwatch": "^1.5.2",
 		"@sapphire/time-utilities": "^1.7.12",
 		"@sapphire/utilities": "^3.15.3",
-		"@sentry/integrations": "^7.94.1",
-		"@sentry/node": "^7.94.1",
+		"@sentry/integrations": "^7.98.0",
+		"@sentry/node": "^7.98.0",
 		"@skyra/ai": "^1.2.0",
 		"@skyra/char": "^1.0.3",
 		"@skyra/env-utilities": "^1.3.0",
@@ -87,8 +87,8 @@
 	},
 	"devDependencies": {
 		"0x": "^5.7.0",
-		"@commitlint/cli": "^18.4.4",
-		"@commitlint/config-conventional": "^18.4.4",
+		"@commitlint/cli": "^18.6.0",
+		"@commitlint/config-conventional": "^18.6.0",
 		"@sapphire/eslint-config": "^5.0.3",
 		"@sapphire/prettier-config": "^2.0.0",
 		"@sapphire/ts-config": "^5.0.0",
@@ -96,10 +96,10 @@
 		"@types/diff": "^5.0.9",
 		"@types/he": "^1.2.3",
 		"@types/node": "^20.11.5",
-		"@types/pg": "^8.10.9",
+		"@types/pg": "^8.11.0",
 		"@types/ws": "^8.5.10",
-		"@typescript-eslint/eslint-plugin": "^6.19.0",
-		"@typescript-eslint/parser": "^6.19.0",
+		"@typescript-eslint/eslint-plugin": "^6.19.1",
+		"@typescript-eslint/parser": "^6.19.1",
 		"@vitest/coverage-v8": "^1.2.1",
 		"cz-conventional-changelog": "^3.3.0",
 		"eslint": "^8.56.0",
@@ -112,6 +112,7 @@
 		"vitest": "^1.2.1"
 	},
 	"resolutions": {
+		"@types/node": "20.11.5",
 		"ansi-regex": "^5.0.1",
 		"minimist": "^1.2.8"
 	},

--- a/src/commands/Management/Helpers/guild-info.ts
+++ b/src/commands/Management/Helpers/guild-info.ts
@@ -84,7 +84,7 @@ export class UserCommand extends SkyraCommand {
 			.setThumbnail(guild.iconURL({ size: 256, extension: 'png' })!)
 			.setTitle(`${guild.name} [${guild.id}]`)
 			.addFields(
-				{ name: args.t(LanguageKeys.Commands.Tools.WhoisMemberRoles, { count: roleCount }), value: this.getSummaryRoles(args, roles) },
+				{ name: args.t(LanguageKeys.Commands.Whois.RolesTitle, { count: roleCount }), value: this.getSummaryRoles(args, roles) },
 				{ name: serverInfoTitles.MEMBERS, value: await this.getSummaryMembers(args), inline: true },
 				{ name: serverInfoTitles.CHANNELS, value: this.getSummaryChannels(args), inline: true },
 				{ name: serverInfoTitles.OTHER, value: this.getSummaryOther(args) }

--- a/src/commands/Tools/whois.ts
+++ b/src/commands/Tools/whois.ts
@@ -1,23 +1,47 @@
 import { SkyraEmbed } from '#lib/discord';
 import { LanguageKeys } from '#lib/i18n/languageKeys';
+import { getSupportedUserLanguageT } from '#lib/i18n/translate';
 import { SkyraCommand } from '#lib/structures';
 import type { GuildMessage } from '#lib/types';
 import { PermissionsBits } from '#utils/bits';
-import { map, months, seconds } from '#utils/common';
-import { Colors, Emojis } from '#utils/constants';
+import { desc, map, maybeParseDate, months, seconds } from '#utils/common';
+import { Colors, EmojiData, Emojis } from '#utils/constants';
 import { getDisplayAvatar, getTag } from '#utils/util';
-import { TimestampStyles, time } from '@discordjs/builders';
+import { ActionRowBuilder, ButtonBuilder, TimestampStyles, time } from '@discordjs/builders';
 import { ApplyOptions } from '@sapphire/decorators';
-import { CommandOptionsRunTypeEnum } from '@sapphire/framework';
+import { ApplicationCommandRegistry, CommandOptionsRunTypeEnum } from '@sapphire/framework';
 import { send } from '@sapphire/plugin-editable-commands';
-import type { TFunction } from '@sapphire/plugin-i18next';
-import { PermissionFlagsBits, type GuildMember, type Role, type User } from 'discord.js';
+import { applyLocalizedBuilder, applyNameLocalizedBuilder, type TFunction } from '@sapphire/plugin-i18next';
+import { isNullishOrEmpty, isNullishOrZero } from '@sapphire/utilities';
+import {
+	ApplicationCommandType,
+	ButtonStyle,
+	ChatInputCommandInteraction,
+	GuildMember,
+	MessageFlags,
+	PermissionFlagsBits,
+	UserContextMenuCommandInteraction,
+	bold,
+	chatInputApplicationCommandMention,
+	inlineCode,
+	roleMention,
+	type APIInteractionDataResolvedGuildMember,
+	type APIInteractionGuildMember,
+	type Role,
+	type Snowflake,
+	type User
+} from 'discord.js';
 
-const sortRanks = (x: Role, y: Role) => Number(y.position > x.position) || Number(x.position === y.position) - 1;
+const sortRanks = (x: Role, y: Role) => desc(x.position, y.position);
+
+const Root = LanguageKeys.Commands.Whois;
+
+type IncomingGuildMember = GuildMember | RawIncomingGuildMember;
+type RawIncomingGuildMember = APIInteractionGuildMember | APIInteractionDataResolvedGuildMember;
 
 @ApplyOptions<SkyraCommand.Options>({
 	aliases: ['userinfo', 'uinfo', 'user'],
-	description: LanguageKeys.Commands.Tools.WhoisDescription,
+	description: Root.Description,
 	detailedDescription: LanguageKeys.Commands.Tools.WhoisExtended,
 	requiredClientPermissions: [PermissionFlagsBits.EmbedLinks],
 	runIn: [CommandOptionsRunTypeEnum.GuildAny]
@@ -40,98 +64,145 @@ export class UserCommand extends SkyraCommand {
 		const user = args.finished ? message.author : await args.pick('userName');
 		const member = await message.guild.members.fetch(user.id).catch(() => null);
 
-		const embed = member ? this.member(args.t, member) : this.user(args.t, user);
-		return send(message, { embeds: [embed] });
+		return send(message, {
+			...this.sharedRun(args.t, user, member),
+			content: args.t(LanguageKeys.Commands.Shared.DeprecatedMessage, {
+				command: chatInputApplicationCommandMention(this.name, this.getGlobalCommandId())
+			})
+		});
+	}
+
+	public override async chatInputRun(interaction: ChatInputCommandInteraction) {
+		const user = interaction.options.getUser('user', true);
+		const member = interaction.options.getMember('user');
+
+		return interaction.reply({
+			...this.sharedRun(getSupportedUserLanguageT(interaction), user, member),
+			flags: MessageFlags.Ephemeral
+		});
+	}
+
+	public override async contextMenuRun(interaction: UserContextMenuCommandInteraction) {
+		const user = interaction.targetUser;
+		const member = interaction.targetMember;
+
+		return interaction.reply({
+			...this.sharedRun(getSupportedUserLanguageT(interaction), user, member),
+			flags: MessageFlags.Ephemeral
+		});
+	}
+
+	public override registerApplicationCommands(registry: ApplicationCommandRegistry) {
+		registry.registerChatInputCommand((builder) =>
+			applyLocalizedBuilder(builder, Root.Name, Root.Description) //
+				.addUserOption((option) => applyLocalizedBuilder(option, Root.User).setRequired(true))
+				.setDMPermission(false)
+		);
+
+		registry.registerContextMenuCommand((builder) =>
+			applyNameLocalizedBuilder(builder, Root.ContextMenuName) //
+				.setType(ApplicationCommandType.User)
+				.setDMPermission(false)
+		);
+	}
+
+	private sharedRun(t: TFunction, user: User, member: IncomingGuildMember | null) {
+		const embed = member ? this.member(t, member, user) : this.user(t, user);
+		return { embeds: [embed], components: [this.getComponentRow(t, user)] };
 	}
 
 	private user(t: TFunction, user: User) {
-		const userCreatedAtTimestampSeconds = seconds.fromMilliseconds(user.createdTimestamp);
-
-		const titles = t(LanguageKeys.Commands.Tools.WhoisUserTitles);
-		const fields = t(LanguageKeys.Commands.Tools.WhoisUserFields, {
-			user,
-			userCreatedAt: time(userCreatedAtTimestampSeconds, TimestampStyles.ShortDateTime),
-			userCreatedAtOffset: time(userCreatedAtTimestampSeconds, TimestampStyles.RelativeTime)
-		});
-
 		return new SkyraEmbed()
 			.setColor(Colors.White)
 			.setThumbnail(getDisplayAvatar(user, { size: 256 }))
-			.setDescription(this.getUserInformation(user))
-			.addFields({ name: titles.createdAt, value: fields.createdAt })
-			.setFooter({ text: fields.footer, iconURL: getDisplayAvatar(this.container.client.user!, { size: 128 }) })
-			.setTimestamp();
+			.setDescription(this.getUserInformation(t, user));
 	}
 
-	private member(t: TFunction, member: GuildMember) {
-		const userCreatedAtTimestampSeconds = seconds.fromMilliseconds(member.user.createdTimestamp);
-		const memberJoinedAtTimestampSeconds = seconds.fromMilliseconds(member.joinedTimestamp!);
-
-		const titles = t(LanguageKeys.Commands.Tools.WhoisMemberTitles);
-		const fields = t(LanguageKeys.Commands.Tools.WhoisMemberFields, {
-			member,
-			memberCreatedAt: time(userCreatedAtTimestampSeconds, TimestampStyles.ShortDateTime),
-			memberCreatedAtOffset: time(userCreatedAtTimestampSeconds, TimestampStyles.RelativeTime),
-			memberJoinedAt: time(memberJoinedAtTimestampSeconds, TimestampStyles.ShortDateTime),
-			memberJoinedAtOffset: time(memberJoinedAtTimestampSeconds, TimestampStyles.RelativeTime)
-		});
-
+	private member(t: TFunction, member: IncomingGuildMember, user: User) {
+		const isCached = member instanceof GuildMember;
+		const displayColor = isCached ? member.displayColor || Colors.White : Colors.White;
 		const embed = new SkyraEmbed()
-			.setColor(member.displayColor || Colors.White)
-			.setThumbnail(getDisplayAvatar(member.user, { size: 256 }))
-			.setDescription(this.getUserInformation(member.user, this.getBoostIcon(member.premiumSinceTimestamp)))
-			.addFields({ name: titles.joined, value: member.joinedTimestamp ? fields.joinedWithTimestamp : fields.joinedUnknown, inline: true })
-			.addFields({ name: titles.createdAt, value: fields.createdAt, inline: true })
-			.setFooter({ text: fields.footer, iconURL: getDisplayAvatar(this.container.client.user!, { size: 128 }) })
-			.setTimestamp();
+			.setColor(displayColor)
+			.setThumbnail(getDisplayAvatar(user, { size: 256 }))
+			.setDescription(this.getMemberInformation(t, member, user));
 
-		this.applyMemberRoles(t, member, embed);
+		this.applyMemberRoles(t, isCached ? this.getGuildMemberRoles(member) : this.getRawMemberRoles(member), embed);
 		this.applyMemberKeyPermissions(t, member, embed);
 		return embed;
 	}
 
-	private getUserInformation(user: User, extras = ''): string {
-		const bot = user.bot ? ` ${Emojis.Bot}` : '';
-		const avatar = `[Avatar ${Emojis.Frame}](${getDisplayAvatar(user, { size: 4096 })})`;
-		return `**${getTag(user)}**${bot} - ${user.toString()}${extras} - ${avatar}`;
+	private getUserInformation(t: TFunction, user: User, extras = ''): string {
+		const bot = user.bot ? ` ${Emojis.IntegrationIcon}` : '';
+		const header = `${user.toString()} - ${bold(getTag(user))}${bot}${extras} (${inlineCode(user.id)})`;
+		const description = t(Root.EmbedDescription, {
+			id: user.id,
+			createdAt: time(seconds.fromMilliseconds(user.createdTimestamp), TimestampStyles.RelativeTime)
+		});
+		return `${header}\n\n${description}`;
 	}
 
-	private applyMemberRoles(t: TFunction, member: GuildMember, embed: SkyraEmbed) {
-		if (member.roles.cache.size <= 1) return;
+	private getMemberInformation(t: TFunction, member: IncomingGuildMember, user: User): string {
+		const isCached = member instanceof GuildMember;
+		const premiumSince = isCached ? member.premiumSinceTimestamp : maybeParseDate(member.premium_since);
+		const joinedAt = isCached ? member.joinedTimestamp : maybeParseDate(member.joined_at);
 
-		const roles = member.roles.cache.sorted(sortRanks);
-		roles.delete(member.guild.id);
-		embed.splitFields(t(LanguageKeys.Commands.Tools.WhoisMemberRoles, { count: roles.size }), [...roles.values()].join(' '));
+		const header = this.getUserInformation(t, user, this.getBoostIcon(premiumSince));
+		const description = t(Root.EmbedMemberDescription, {
+			joinedAt: time(seconds.fromMilliseconds(joinedAt!), TimestampStyles.RelativeTime)
+		});
+		return `${header}\n${description}`;
 	}
 
-	private applyMemberKeyPermissions(t: TFunction, member: GuildMember, embed: SkyraEmbed) {
-		const permissions = member.permissions.bitfield;
+	private applyMemberRoles(t: TFunction, roles: string[] | null, embed: SkyraEmbed) {
+		if (isNullishOrEmpty(roles)) return;
+
+		embed.splitFields(t(Root.RolesTitle, { count: roles.length }), roles.join(' '));
+	}
+
+	private getGuildMemberRoles(member: GuildMember) {
+		const roles = member.roles.cache;
+		// If the member has @everyone or no roles, return null:
+		if (roles.size <= 1) return null;
+
+		const sorted = roles.sorted(sortRanks);
+		sorted.delete(member.guild.id);
+		return sorted.map((role) => role.toString());
+	}
+
+	private getRawMemberRoles(member: RawIncomingGuildMember) {
+		// We cannot sort the roles because we do not have the guild, so we just map them:
+		return member.roles.map((id) => roleMention(id));
+	}
+
+	private applyMemberKeyPermissions(t: TFunction, member: IncomingGuildMember, embed: SkyraEmbed) {
+		const bitfield = this.getMemberPermissions(member);
 
 		// If the member has Administrator, add a field indicating the member
 		// has all permissions and return:
-		if (PermissionsBits.has(permissions, PermissionFlagsBits.Administrator)) {
-			embed.addFields({
-				name: t(LanguageKeys.Commands.Tools.WhoisMemberPermissions),
-				value: t(LanguageKeys.Commands.Tools.WhoisMemberPermissionsAll)
-			});
+		if (PermissionsBits.has(bitfield, PermissionFlagsBits.Administrator)) {
+			embed.addFields({ name: t(Root.PermissionsTitle), value: t(Root.PermissionsAll) });
 			return;
 		}
 
 		// Create an intersection between the permissions the member has and the
 		// key permissions, if there are no permissions, return, else add a field
 		// with the permissions:
-		const intersection = PermissionsBits.intersection(permissions, this.KeyPermissions);
+		const intersection = PermissionsBits.intersection(bitfield, this.KeyPermissions);
 		if (intersection === 0n) return;
 
 		embed.addFields({
-			name: t(LanguageKeys.Commands.Tools.WhoisMemberPermissions),
+			name: t(Root.PermissionsTitle),
 			value: [...map(PermissionsBits.toKeys(intersection), (name) => t(`permissions:${name}`))].join(', ')
 		});
 	}
 
+	private getMemberPermissions(member: IncomingGuildMember): bigint {
+		const { permissions } = member;
+		return typeof permissions === 'string' ? BigInt(permissions) : permissions.bitfield;
+	}
+
 	private getBoostIcon(boostingSince: number | null): string {
-		if (boostingSince === null || boostingSince <= 0) return '';
-		return ` ${this.getBoostEmoji(Date.now() - boostingSince)}`;
+		return isNullishOrZero(boostingSince) ? '' : ` ${this.getBoostEmoji(Date.now() - boostingSince)}`;
 	}
 
 	private getBoostEmoji(duration: number): string {
@@ -144,5 +215,26 @@ export class UserCommand extends SkyraCommand {
 		if (duration >= months(3)) return Emojis.BoostLevel3;
 		if (duration >= months(2)) return Emojis.BoostLevel2;
 		return Emojis.BoostLevel1;
+	}
+
+	private getComponentRow(t: TFunction, user: User) {
+		return new ActionRowBuilder<ButtonBuilder>() //
+			.addComponents(this.getAvatarButton(t, getDisplayAvatar(user, { size: 4096 })), this.getProfileLinkButton(t, user.id));
+	}
+
+	private getAvatarButton(t: TFunction, url: string) {
+		return new ButtonBuilder() //
+			.setStyle(ButtonStyle.Link)
+			.setEmoji(EmojiData.MessageAttachmentIcon)
+			.setLabel(t(Root.ButtonAvatar))
+			.setURL(url);
+	}
+
+	private getProfileLinkButton(t: TFunction, id: Snowflake) {
+		return new ButtonBuilder() //
+			.setStyle(ButtonStyle.Link)
+			.setEmoji(EmojiData.MembersIcon)
+			.setLabel(t(Root.ButtonProfile))
+			.setURL(`discord://-/users/${id}`);
 	}
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,7 @@ import { getHandler } from '#root/languages/index';
 import { minutes, seconds } from '#utils/common';
 import { Emojis, LanguageFormatters, rootFolder } from '#utils/constants';
 import type { ConnectionOptions } from '@influxdata/influxdb-client';
-import { LogLevel } from '@sapphire/framework';
+import { ApplicationCommandRegistries, LogLevel, RegisterBehavior } from '@sapphire/framework';
 import type { ServerOptions, ServerOptionsAuth } from '@sapphire/plugin-api';
 import { i18next, type I18nextFormatter, type InternationalizationOptions } from '@sapphire/plugin-i18next';
 import { envIsDefined, envParseArray, envParseBoolean, envParseInteger, envParseString, setup } from '@skyra/env-utilities';
@@ -257,5 +257,7 @@ function parseWebhookError(): WebhookClientData | null {
 		token: WEBHOOK_ERROR_TOKEN
 	};
 }
+
+ApplicationCommandRegistries.setDefaultBehaviorWhenNotIdentical(RegisterBehavior.BulkOverwrite);
 
 export const WEBHOOK_ERROR = parseWebhookError();

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,7 @@ import { getHandler } from '#root/languages/index';
 import { minutes, seconds } from '#utils/common';
 import { Emojis, LanguageFormatters, rootFolder } from '#utils/constants';
 import type { ConnectionOptions } from '@influxdata/influxdb-client';
-import { ApplicationCommandRegistries, LogLevel, RegisterBehavior } from '@sapphire/framework';
+import { LogLevel } from '@sapphire/framework';
 import type { ServerOptions, ServerOptionsAuth } from '@sapphire/plugin-api';
 import { i18next, type I18nextFormatter, type InternationalizationOptions } from '@sapphire/plugin-i18next';
 import { envIsDefined, envParseArray, envParseBoolean, envParseInteger, envParseString, setup } from '@skyra/env-utilities';
@@ -257,7 +257,5 @@ function parseWebhookError(): WebhookClientData | null {
 		token: WEBHOOK_ERROR_TOKEN
 	};
 }
-
-ApplicationCommandRegistries.setDefaultBehaviorWhenNotIdentical(RegisterBehavior.BulkOverwrite);
 
 export const WEBHOOK_ERROR = parseWebhookError();

--- a/src/languages/en-US/commands/shared.json
+++ b/src/languages/en-US/commands/shared.json
@@ -1,0 +1,3 @@
+{
+	"deprecatedMessage": "Message based commands are **deprecated**, and will be removed in the future. You should use the {{command}} slash command instead!"
+}

--- a/src/languages/en-US/commands/tools.json
+++ b/src/languages/en-US/commands/tools.json
@@ -32,7 +32,6 @@
 	},
 	"voteContentNeeded": "{{REDCROSS}} You must give a topic for the poll.",
 	"voteReactionBlocked": "{{REDCROSS}} I was not able to add the reactions necessary for this command to work because you have me blocked! 😢",
-	"whoisDescription": "Who are you?",
 	"whoisExtended": {
 		"usages": [
 			"",
@@ -46,26 +45,5 @@
 			]
 		]
 	},
-	"whoisMemberFields": {
-		"createdAt": "{{memberCreatedAt}}\n{{memberCreatedAtOffset}}",
-		"footer": "ID: {{member.id}}",
-		"joinedUnknown": "Unknown",
-		"joinedWithTimestamp": "{{memberJoinedAt}}\n{{memberJoinedAtOffset}}"
-	},
-	"whoisMemberPermissions": "Key Permissions",
-	"whoisMemberPermissionsAll": "All Permissions",
-	"whoisMemberRoles_one": "Role [1]",
-	"whoisMemberRoles_other": "Roles [{{count}}]",
-	"whoisMemberRoleListAndMore": "{{count}} more.",
-	"whoisMemberTitles": {
-		"createdAt": "Created At",
-		"joined": "Joined"
-	},
-	"whoisUserFields": {
-		"createdAt": "{{userCreatedAt}}\n{{userCreatedAtOffset}}",
-		"footer": "ID: {{user.id}}"
-	},
-	"whoisUserTitles": {
-		"createdAt": "Created At"
-	}
+	"whoisMemberRoleListAndMore": "{{count}} more."
 }

--- a/src/languages/en-US/commands/whois.json
+++ b/src/languages/en-US/commands/whois.json
@@ -1,0 +1,17 @@
+{
+	"name": "whois",
+	"description": "Provides information about a Discord user",
+	"contextMenuName": "Get Information",
+	"userName": "user",
+	"userDescription": "The user to get information about",
+	"joined": "Joined At",
+	"created": "Created At",
+	"rolesTitle_one": "Role [1]",
+	"rolesTitle_other": "Roles [{{count, number}}]",
+	"permissionsTitle": "Key Permissions",
+	"permissionsAll": "All Permissions",
+	"embedDescription": "**Created At**: {{createdAt}}",
+	"embedMemberDescription": "**Joined At**: {{joinedAt}}",
+	"buttonAvatar": "Avatar",
+	"buttonProfile": "Profile"
+}

--- a/src/lib/database/settings/schema/SchemaKey.ts
+++ b/src/lib/database/settings/schema/SchemaKey.ts
@@ -4,7 +4,7 @@ import type { SchemaGroup } from '#lib/database/settings/schema/SchemaGroup';
 import type { Serializer } from '#lib/database/settings/structures/Serializer';
 import { LanguageKeys } from '#lib/i18n/languageKeys';
 import type { SkyraArgs } from '#lib/structures';
-import type { CustomGet } from '#lib/types';
+import type { TypedT } from '#lib/types';
 import { container } from '@sapphire/framework';
 import type { TFunction } from '@sapphire/plugin-i18next';
 import { isNullish, type NonNullObject } from '@sapphire/utilities';
@@ -13,7 +13,7 @@ export class SchemaKey<K extends keyof GuildEntity = keyof GuildEntity> implemen
 	/**
 	 * The i18n key for the configuration key.
 	 */
-	public description: CustomGet<string, string>;
+	public description: TypedT<string>;
 
 	/**
 	 * The maximum value for the configuration key.

--- a/src/lib/i18n/languageKeys/keys/Commands.ts
+++ b/src/lib/i18n/languageKeys/keys/Commands.ts
@@ -6,6 +6,8 @@ export * as General from '#lib/i18n/languageKeys/keys/commands/General';
 export * as Management from '#lib/i18n/languageKeys/keys/commands/Management';
 export * as Misc from '#lib/i18n/languageKeys/keys/commands/Misc';
 export * as Moderation from '#lib/i18n/languageKeys/keys/commands/Moderation';
+export * as Shared from '#lib/i18n/languageKeys/keys/commands/Shared';
 export * as System from '#lib/i18n/languageKeys/keys/commands/System';
 export * as Tools from '#lib/i18n/languageKeys/keys/commands/Tools';
 export * as Twitch from '#lib/i18n/languageKeys/keys/commands/Twitch';
+export * as Whois from '#lib/i18n/languageKeys/keys/commands/Whois';

--- a/src/lib/i18n/languageKeys/keys/commands/Shared.ts
+++ b/src/lib/i18n/languageKeys/keys/commands/Shared.ts
@@ -1,0 +1,3 @@
+import { FT } from '#lib/types';
+
+export const DeprecatedMessage = FT<{ command: string }>('commands/shared:deprecatedMessage');

--- a/src/lib/i18n/languageKeys/keys/commands/Tools.ts
+++ b/src/lib/i18n/languageKeys/keys/commands/Tools.ts
@@ -1,6 +1,5 @@
 import type { LanguageHelpDisplayOptions } from '#lib/i18n/LanguageHelp';
 import { FT, T } from '#lib/types';
-import type { GuildMember, User } from 'discord.js';
 
 export const AvatarDescription = T('commands/tools:avatarDescription');
 export const AvatarExtended = T<LanguageHelpDisplayOptions>('commands/tools:avatarExtended');
@@ -9,39 +8,5 @@ export const VoteDescription = T('commands/tools:voteDescription');
 export const VoteExtended = T<LanguageHelpDisplayOptions>('commands/tools:voteExtended');
 export const VoteContentNeeded = T('commands/tools:voteContentNeeded');
 export const VoteReactionBlocked = T('commands/tools:voteReactionBlocked');
-export const WhoisDescription = T('commands/tools:whoisDescription');
 export const WhoisExtended = T<LanguageHelpDisplayOptions>('commands/tools:whoisExtended');
-export const WhoisMemberTitles = T<{ joined: string; createdAt: string }>('commands/tools:whoisMemberTitles');
-export const WhoisMemberFields = FT<
-	{
-		member: GuildMember;
-		memberCreatedAt: string;
-		memberCreatedAtOffset: string;
-		memberJoinedAt: string;
-		memberJoinedAtOffset: string;
-	},
-	{
-		joinedUnknown: string;
-		joinedWithTimestamp: string;
-		createdAt: string;
-		footer: string;
-	}
->('commands/tools:whoisMemberFields');
-export const WhoisMemberRoles = FT<{ count: number }, string>('commands/tools:whoisMemberRoles');
 export const WhoisMemberRoleListAndMore = FT<{ count: number }, string>('commands/tools:whoisMemberRoleListAndMore');
-export const WhoisMemberPermissions = T('commands/tools:whoisMemberPermissions');
-export const WhoisMemberPermissionsAll = T('commands/tools:whoisMemberPermissionsAll');
-export const WhoisUserTitles = T<{
-	createdAt: string;
-}>('commands/tools:whoisUserTitles');
-export const WhoisUserFields = FT<
-	{
-		user: User;
-		userCreatedAt: string;
-		userCreatedAtOffset: string;
-	},
-	{
-		createdAt: string;
-		footer: string;
-	}
->('commands/tools:whoisUserFields');

--- a/src/lib/i18n/languageKeys/keys/commands/Whois.ts
+++ b/src/lib/i18n/languageKeys/keys/commands/Whois.ts
@@ -1,0 +1,22 @@
+import { FT, T, type Value } from '#lib/types';
+
+// Root
+export const Name = T('commands/whois:name');
+export const Description = T('commands/whois:description');
+export const ContextMenuName = T('commands/whois:contextMenuName');
+
+// Options
+export const User = 'commands/whois:user';
+
+// Embed
+export const Joined = T('commands/whois:joined');
+export const Created = T('commands/whois:created');
+export const RolesTitle = FT<Value>('commands/whois:rolesTitle');
+export const PermissionsTitle = T('commands/whois:permissionsTitle');
+export const PermissionsAll = T('commands/whois:permissionsAll');
+export const EmbedDescription = FT<{ createdAt: string }>('commands/whois:embedDescription');
+export const EmbedMemberDescription = FT<{ joinedAt: string }>('commands/whois:embedMemberDescription');
+
+// Buttons
+export const ButtonAvatar = T('commands/whois:buttonAvatar');
+export const ButtonProfile = T('commands/whois:buttonProfile');

--- a/src/lib/i18n/translate.ts
+++ b/src/lib/i18n/translate.ts
@@ -4,7 +4,7 @@ import { DecoratorIdentifiers } from '@sapphire/decorators';
 import { Identifiers, container } from '@sapphire/framework';
 import type { InternationalizationContext, TFunction } from '@sapphire/plugin-i18next';
 import type { Nullish } from '@sapphire/utilities';
-import type { LocaleString } from 'discord.js';
+import type { Interaction, LocaleString } from 'discord.js';
 
 export function translate(identifier: string): string {
 	switch (identifier) {
@@ -122,6 +122,16 @@ export function resolveT(t: TResolvable): TFunction {
  */
 export function getT(locale?: LocaleString | Nullish) {
 	return container.i18n.getT(locale ?? 'en-US');
+}
+
+export function getSupportedUserLanguageName(interaction: Interaction): LocaleString {
+	if (container.i18n.languages.has(interaction.locale)) return interaction.locale;
+	if (interaction.guildLocale && container.i18n.languages.has(interaction.guildLocale)) return interaction.guildLocale;
+	return 'en-US';
+}
+
+export function getSupportedUserLanguageT(interaction: Interaction): TFunction {
+	return getT(getSupportedUserLanguageName(interaction));
 }
 
 /**

--- a/src/lib/moderation/structures/ModerationMessageListener.ts
+++ b/src/lib/moderation/structures/ModerationMessageListener.ts
@@ -1,7 +1,7 @@
 import { GuildEntity, GuildSettings, readSettings, type AdderKey, type GuildSettingsOfType } from '#lib/database';
 import type { AdderError } from '#lib/database/utils/Adder';
 import { SelfModeratorBitField, SelfModeratorHardActionFlags } from '#lib/moderation/structures/SelfModeratorBitField';
-import { Events, type CustomFunctionGet, type CustomGet, type GuildMessage } from '#lib/types';
+import { Events, type GuildMessage, type TypedFT, type TypedT } from '#lib/types';
 import { floatPromise, seconds } from '#utils/common';
 import { getModeration, getSecurity, isModerator } from '#utils/functions';
 import { EmbedBuilder } from '@discordjs/builders';
@@ -17,8 +17,8 @@ export abstract class ModerationMessageListener<T = unknown> extends Listener {
 	private readonly ignoredChannelsPath: GuildSettingsOfType<readonly string[]>;
 	private readonly softPunishmentPath: GuildSettingsOfType<number>;
 	private readonly hardPunishmentPath: HardPunishment;
-	private readonly reasonLanguageKey: CustomGet<string, string>;
-	private readonly reasonLanguageKeyWithMaximum: CustomFunctionGet<string, { amount: number; maximum: number }, string>;
+	private readonly reasonLanguageKey: TypedT<string>;
+	private readonly reasonLanguageKeyWithMaximum: TypedFT<{ amount: number; maximum: number }, string>;
 
 	public constructor(context: ModerationMessageListener.Context, options: ModerationMessageListener.Options) {
 		super(context, { ...options, event: Events.GuildUserMessage });
@@ -222,8 +222,8 @@ export namespace ModerationMessageListener {
 		ignoredChannelsPath: GuildSettingsOfType<readonly string[]>;
 		softPunishmentPath: GuildSettingsOfType<number>;
 		hardPunishmentPath: HardPunishment;
-		reasonLanguageKey: CustomGet<string, string>;
-		reasonLanguageKeyWithMaximum: CustomFunctionGet<string, { amount: number; maximum: number }, string>;
+		reasonLanguageKey: TypedT<string>;
+		reasonLanguageKeyWithMaximum: TypedFT<{ amount: number; maximum: number }, string>;
 	}
 	export type JSON = Listener.JSON;
 	export type Context = Listener.Context;

--- a/src/lib/setup/index.ts
+++ b/src/lib/setup/index.ts
@@ -10,8 +10,10 @@ import '@sapphire/plugin-editable-commands/register';
 import '@sapphire/plugin-i18next/register';
 import '@sapphire/plugin-logger/register';
 
+import { ApplicationCommandRegistries, RegisterBehavior } from '@sapphire/framework';
 import * as colorette from 'colorette';
 import { inspect } from 'node:util';
 
 inspect.defaultOptions.depth = 1;
 colorette.createColors({ useColor: true });
+ApplicationCommandRegistries.setDefaultBehaviorWhenNotIdentical(RegisterBehavior.BulkOverwrite);

--- a/src/lib/structures/commands/ChannelConfigurationCommand.ts
+++ b/src/lib/structures/commands/ChannelConfigurationCommand.ts
@@ -2,7 +2,7 @@ import type { GuildSettingsOfType } from '#lib/database';
 import { writeSettings } from '#lib/database/settings';
 import { LanguageKeys } from '#lib/i18n/languageKeys';
 import { SkyraCommand } from '#lib/structures/commands/SkyraCommand';
-import { PermissionLevels, type CustomFunctionGet, type GuildMessage } from '#lib/types';
+import { PermissionLevels, type GuildMessage, type TypedFT } from '#lib/types';
 import { assertNonThread } from '#utils/functions';
 import { Args, Argument, CommandOptionsRunTypeEnum, container } from '@sapphire/framework';
 import { send } from '@sapphire/plugin-editable-commands';
@@ -10,7 +10,7 @@ import type { Nullish } from '@sapphire/utilities';
 import type { TextChannel } from 'discord.js';
 
 export abstract class ChannelConfigurationCommand extends SkyraCommand {
-	private readonly responseKey: CustomFunctionGet<string, { channel: string }, string>;
+	private readonly responseKey: TypedFT<{ channel: string }, string>;
 	private readonly settingsKey: GuildSettingsOfType<string | Nullish>;
 
 	public constructor(context: SkyraCommand.LoaderContext, options: ChannelConfigurationCommand.Options) {
@@ -52,7 +52,7 @@ export namespace ChannelConfigurationCommand {
 	 * The ChannelConfigurationCommand Options
 	 */
 	export type Options = SkyraCommand.Options & {
-		responseKey: CustomFunctionGet<string, { channel: string }, string>;
+		responseKey: TypedFT<{ channel: string }, string>;
 		settingsKey: GuildSettingsOfType<string | Nullish>;
 	};
 

--- a/src/lib/structures/commands/SkyraCommand.ts
+++ b/src/lib/structures/commands/SkyraCommand.ts
@@ -8,9 +8,10 @@ import {
 	implementSkyraCommandPreParse,
 	type ExtendOptions
 } from '#lib/structures/commands/base/BaseSkyraCommandUtilities';
-import { PermissionLevels, type CustomGet } from '#lib/types';
+import { PermissionLevels, type TypedT } from '#lib/types';
+import { first } from '#utils/common';
 import { Command, UserError, type Awaitable, type MessageCommand } from '@sapphire/framework';
-import { type Message } from 'discord.js';
+import { type Message, type Snowflake } from 'discord.js';
 
 /**
  * The base class for all Skyra commands.
@@ -20,8 +21,8 @@ export abstract class SkyraCommand extends Command<SkyraCommand.Args, SkyraComma
 	public readonly guarded: boolean;
 	public readonly hidden: boolean;
 	public readonly permissionLevel: PermissionLevels;
-	public declare readonly detailedDescription: CustomGet<string, LanguageHelpDisplayOptions>;
-	public declare readonly description: CustomGet<string, string>;
+	public declare readonly detailedDescription: TypedT<LanguageHelpDisplayOptions>;
+	public declare readonly description: TypedT<string>;
 
 	public constructor(context: Command.LoaderContext, options: SkyraCommand.Options) {
 		super(context, { ...SkyraCommandConstructorDefaults, ...options });
@@ -49,6 +50,18 @@ export abstract class SkyraCommand extends Command<SkyraCommand.Args, SkyraComma
 	protected override parseConstructorPreConditions(options: SkyraCommand.Options): void {
 		super.parseConstructorPreConditions(options);
 		implementSkyraCommandParseConstructorPreConditionsPermissionLevel(this, options.permissionLevel);
+	}
+
+	/**
+	 * Retrieves the global command id from the application command registry.
+	 *
+	 * @remarks This method is used for slash commands, and will throw an error
+	 * if the global command ids are empty.
+	 */
+	protected getGlobalCommandId(): Snowflake {
+		const ids = this.applicationCommandRegistry.globalChatInputCommandIds;
+		if (ids.size === 0) throw new Error('The global command ids are empty.');
+		return first(ids.values())!;
 	}
 
 	public static readonly PaginatedOptions = implementSkyraCommandPaginatedOptions<SkyraCommand.Options>;

--- a/src/lib/structures/commands/SkyraSubcommand.ts
+++ b/src/lib/structures/commands/SkyraSubcommand.ts
@@ -8,10 +8,11 @@ import {
 	implementSkyraCommandPreParse,
 	type ExtendOptions
 } from '#lib/structures/commands/base/BaseSkyraCommandUtilities';
-import { PermissionLevels, type CustomGet } from '#lib/types';
+import { PermissionLevels, type TypedT } from '#lib/types';
+import { first } from '#utils/common';
 import { Command, UserError, type MessageCommand } from '@sapphire/framework';
 import { Subcommand } from '@sapphire/plugin-subcommands';
-import type { Message } from 'discord.js';
+import type { Message, Snowflake } from 'discord.js';
 
 /**
  * The base class for all Skyra commands with subcommands.
@@ -21,8 +22,8 @@ export class SkyraSubcommand extends Subcommand<SkyraSubcommand.Args, SkyraSubco
 	public readonly guarded: boolean;
 	public readonly hidden: boolean;
 	public readonly permissionLevel: PermissionLevels;
-	public declare readonly detailedDescription: CustomGet<string, LanguageHelpDisplayOptions>;
-	public override readonly description: CustomGet<string, string>;
+	public declare readonly detailedDescription: TypedT<LanguageHelpDisplayOptions>;
+	public override readonly description: TypedT<string>;
 
 	public constructor(context: SkyraSubcommand.LoaderContext, options: SkyraSubcommand.Options) {
 		super(context, { ...SkyraCommandConstructorDefaults, ...options });
@@ -49,6 +50,18 @@ export class SkyraSubcommand extends Subcommand<SkyraSubcommand.Args, SkyraSubco
 	protected override parseConstructorPreConditions(options: SkyraSubcommand.Options): void {
 		super.parseConstructorPreConditions(options);
 		implementSkyraCommandParseConstructorPreConditionsPermissionLevel(this, options.permissionLevel);
+	}
+
+	/**
+	 * Retrieves the global command id from the application command registry.
+	 *
+	 * @remarks This method is used for slash commands, and will throw an error
+	 * if the global command ids are empty.
+	 */
+	protected getGlobalCommandId(): Snowflake {
+		const ids = this.applicationCommandRegistry.globalChatInputCommandIds;
+		if (ids.size === 0) throw new Error('The global command ids are empty.');
+		return first(ids.values())!;
 	}
 
 	public static readonly PaginatedOptions = implementSkyraCommandPaginatedOptions<SkyraSubcommand.Options>;

--- a/src/lib/structures/commands/base/BaseSkyraCommandUtilities.ts
+++ b/src/lib/structures/commands/base/BaseSkyraCommandUtilities.ts
@@ -1,6 +1,6 @@
 import type { LanguageHelpDisplayOptions } from '#lib/i18n/LanguageHelp';
 import { SkyraArgs } from '#lib/structures/commands/SkyraArgs';
-import { PermissionLevels, type CustomGet } from '#lib/types';
+import { PermissionLevels, type TypedT } from '#lib/types';
 import { OWNERS } from '#root/config';
 import { seconds } from '#utils/common';
 import { Command, PreconditionContainerArray, UserError, type MessageCommand } from '@sapphire/framework';
@@ -71,8 +71,8 @@ export function implementSkyraCommandPaginatedOptions<T extends ExtendOptions<Co
 }
 
 export type ExtendOptions<T> = T & {
-	description: CustomGet<string, string>;
-	detailedDescription: CustomGet<string, LanguageHelpDisplayOptions>;
+	description: TypedT<string>;
+	detailedDescription: TypedT<LanguageHelpDisplayOptions>;
 	guarded?: boolean;
 	hidden?: boolean;
 	permissionLevel?: number;

--- a/src/lib/structures/preconditions/PermissionsPrecondition.ts
+++ b/src/lib/structures/preconditions/PermissionsPrecondition.ts
@@ -3,9 +3,9 @@ import { LanguageKeys } from '#lib/i18n/languageKeys';
 import type { SkyraCommand } from '#lib/structures';
 import { PermissionLevels, type GuildMessage } from '#lib/types';
 import { isAdmin, isGuildOwner } from '#utils/functions';
-import { Identifiers, Precondition, type PreconditionOptions } from '@sapphire/framework';
+import { AllFlowsPrecondition, Identifiers, Precondition, type PreconditionOptions } from '@sapphire/framework';
 
-export abstract class PermissionsPrecondition extends Precondition {
+export abstract class PermissionsPrecondition extends AllFlowsPrecondition {
 	private readonly guildOnly: boolean;
 
 	public constructor(context: Precondition.LoaderContext, options: PermissionsPrecondition.Options = {}) {
@@ -29,6 +29,16 @@ export abstract class PermissionsPrecondition extends Precondition {
 
 		// Run the specific precondition's logic:
 		return this.handle(message, command, context);
+	}
+
+	// Handled by Discord's permissions system:
+	public override chatInputRun() {
+		return this.ok();
+	}
+
+	// Handled by Discord's permissions system:
+	public override contextMenuRun() {
+		return this.ok();
 	}
 
 	public abstract handle(message: GuildMessage, command: SkyraCommand, context: PermissionsPrecondition.Context): PermissionsPrecondition.Result;

--- a/src/lib/types/Augments.d.ts
+++ b/src/lib/types/Augments.d.ts
@@ -7,7 +7,7 @@ import type { Events } from '#lib/types';
 import type { TwitchStreamStatus } from '#lib/types/AnalyticsSchema';
 import type { TaskErrorPayload } from '#lib/types/Internals';
 import type { TwitchEventSubEvent, TwitchEventSubOnlineEvent } from '#lib/types/Twitch';
-import type { CustomFunctionGet, CustomGet } from '#lib/types/Utils';
+import type { TypedFT, TypedT } from '#lib/types/Utils';
 import type { LLRCData, LongLivingReactionCollector } from '#utils/LongLivingReactionCollector';
 import type { Twitch } from '#utils/Notifications/Twitch';
 import type { EmojiObject } from '#utils/functions';
@@ -114,8 +114,8 @@ declare module 'i18next' {
 		lng: string;
 		ns?: string;
 
-		<K extends string, TReturn>(key: CustomGet<K, TReturn>): TReturn;
-		<K extends string, TArgs extends object, TReturn>(key: CustomFunctionGet<K, TArgs, TReturn>, options?: TArgs): TReturn;
+		<TReturn>(key: TypedT<TReturn>): TReturn;
+		<TArgs extends object, TReturn>(key: TypedFT<TArgs, TReturn>, options?: TArgs): TReturn;
 	}
 }
 

--- a/src/lib/types/Utils.ts
+++ b/src/lib/types/Utils.ts
@@ -1,14 +1,14 @@
 /* eslint-disable @typescript-eslint/ban-types */
-export type CustomGet<K extends string, TCustom> = K & { __type__: TCustom };
+export type TypedT<TCustom = string> = string & { __type__: TCustom };
 
-export function T<TCustom = string>(k: string): CustomGet<string, TCustom> {
-	return k as CustomGet<string, TCustom>;
+export function T<TCustom = string>(k: string): TypedT<TCustom> {
+	return k as TypedT<TCustom>;
 }
 
-export type CustomFunctionGet<K extends string, TArgs, TReturn> = K & { __args__: TArgs; __return__: TReturn };
+export type TypedFT<TArgs, TReturn> = string & { __args__: TArgs; __return__: TReturn };
 
-export function FT<TArgs, TReturn = string>(k: string): CustomFunctionGet<string, TArgs, TReturn> {
-	return k as CustomFunctionGet<string, TArgs, TReturn>;
+export function FT<TArgs, TReturn = string>(k: string): TypedFT<TArgs, TReturn> {
+	return k as TypedFT<TArgs, TReturn>;
 }
 
 export interface Value<T = string> {

--- a/src/lib/util/common/comparators.ts
+++ b/src/lib/util/common/comparators.ts
@@ -1,3 +1,11 @@
+export function asc(a: number, b: number): -1 | 0 | 1 {
+	return a < b ? -1 : a > b ? 1 : 0;
+}
+
+export function desc(a: number, b: number): -1 | 0 | 1 {
+	return a > b ? -1 : a < b ? 1 : 0;
+}
+
 /**
  * Gets the maximum value.
  * @param values The values to compare.

--- a/src/lib/util/common/index.ts
+++ b/src/lib/util/common/index.ts
@@ -1,5 +1,6 @@
 export * from '#utils/common/comparators';
 export * from '#utils/common/guards';
 export * from '#utils/common/iterators';
+export * from '#utils/common/parse';
 export * from '#utils/common/promises';
 export * from '#utils/common/times';

--- a/src/lib/util/common/iterators.ts
+++ b/src/lib/util/common/iterators.ts
@@ -1,3 +1,7 @@
+export function first<T>(iterator: IterableIterator<T>): T | undefined {
+	return iterator.next().value;
+}
+
 export function* map<T, R>(iterator: IterableIterator<T>, cb: (value: T) => R): IterableIterator<R> {
 	let result: IteratorResult<T> | null = null;
 	while (!(result = iterator.next()).done) {

--- a/src/lib/util/common/parse.ts
+++ b/src/lib/util/common/parse.ts
@@ -1,0 +1,6 @@
+import { isNullishOrEmpty } from '@sapphire/utilities';
+
+export function maybeParseDate(value: string | null | undefined): number | null {
+	if (isNullishOrEmpty(value)) return null;
+	return Date.parse(value);
+}

--- a/src/lib/util/constants.ts
+++ b/src/lib/util/constants.ts
@@ -7,11 +7,11 @@ export const rootFolder = join(mainFolder, '..');
 export const ZeroWidthSpace = '\u200B';
 export const LongWidthSpace = '\u3000';
 
-export const enum Fonts {
-	FamilyFriends = 'Family-Friends, Roboto-Medium, NotoSans-Medium, NotoEmoji-Medium',
-	Medium = 'Roboto-Medium, NotoSans-Medium, NotoEmoji-Medium',
-	Light = 'Roboto-Light, NotoSans-Light, NotoEmoji-Light'
-}
+export const EmojiData = {
+	MessageAttachmentIcon: { id: '1006096566270033940', name: 'MessageAttachmentIcon', animated: false },
+	IntegrationIcon: { id: '1200230554440843264', name: 'IntegrationIcon', animated: false },
+	MembersIcon: { id: '1200212636441260103', name: 'MembersIcon', animated: false }
+} as const;
 
 export const enum Emojis {
 	ArrowB = '<:ArrowB:694594285269680179>',
@@ -32,6 +32,7 @@ export const enum Emojis {
 	BoostLevel8 = '<:boostlvl8:764841388462178344>',
 	BoostLevel9 = '<:boostlvl9:764841388470698014>',
 	Bot = '<:bot:764788923851079702>',
+	IntegrationIcon = '<:IntegrationIcon:1200230554440843264>',
 	Frame = '<:frame:764845055356698644>',
 	GreenTick = '<:greenTick:637706251253317669>',
 	GreenTickSerialized = 's637706251253317669',

--- a/src/lib/util/functions/messages.ts
+++ b/src/lib/util/functions/messages.ts
@@ -1,5 +1,5 @@
 import type { SkyraCommand } from '#lib/structures';
-import type { CustomFunctionGet, CustomGet } from '#lib/types';
+import type { TypedFT, TypedT } from '#lib/types';
 import { floatPromise, minutes, resolveOnErrorCodes } from '#utils/common';
 import { canReact, canRemoveAllReactions } from '@sapphire/discord.js-utilities';
 import { container } from '@sapphire/framework';
@@ -114,7 +114,7 @@ export async function sendLocalizedMessage(message: Message, options: LocalizedS
 	return send(message, { ...options, content });
 }
 
-type LocalizedSimpleKey = CustomGet<string, string>;
+type LocalizedSimpleKey = TypedT<string>;
 type LocalizedMessageOptions<TArgs extends object = NonNullObject> = Omit<MessageCreateOptions, 'content'> &
 	(
 		| {
@@ -122,7 +122,7 @@ type LocalizedMessageOptions<TArgs extends object = NonNullObject> = Omit<Messag
 				formatOptions?: TOptions<TArgs>;
 		  }
 		| {
-				key: CustomFunctionGet<string, TArgs, string>;
+				key: TypedFT<TArgs, string>;
 				formatOptions: TOptions<TArgs>;
 		  }
 	);

--- a/src/listeners/commands/chatInputCommandError.ts
+++ b/src/listeners/commands/chatInputCommandError.ts
@@ -1,0 +1,7 @@
+import { Events, Listener, type ChatInputCommandErrorPayload } from '@sapphire/framework';
+
+export class UserListener extends Listener<typeof Events.ChatInputCommandError> {
+	public run(error: Error, payload: ChatInputCommandErrorPayload) {
+		this.container.logger.fatal(`[COMMAND] ${payload.command.location.full}\n${error.stack || error.message}`);
+	}
+}

--- a/src/listeners/commands/chatInputCommandSuccessAnalytics.ts
+++ b/src/listeners/commands/chatInputCommandSuccessAnalytics.ts
@@ -1,0 +1,12 @@
+import type { SkyraCommand } from '#lib/structures';
+import { Events as SkyraEvents } from '#lib/types';
+import { ApplyOptions } from '@sapphire/decorators';
+import { Events, Listener, type ChatInputCommandSuccessPayload } from '@sapphire/framework';
+
+@ApplyOptions<Listener.Options>({ event: Events.ChatInputCommandSuccess })
+export class UserListener extends Listener<typeof Events.ChatInputCommandSuccess> {
+	public run(payload: ChatInputCommandSuccessPayload) {
+		const command = payload.command as SkyraCommand;
+		this.container.client.emit(SkyraEvents.CommandUsageAnalytics, command.name, command.category);
+	}
+}

--- a/src/listeners/commands/chatInputCommandSuccessLogger.ts
+++ b/src/listeners/commands/chatInputCommandSuccessLogger.ts
@@ -1,0 +1,24 @@
+import { ApplyOptions } from '@sapphire/decorators';
+import { Events, Listener, LogLevel, type ChatInputCommandSuccessPayload } from '@sapphire/framework';
+import { cyan } from 'colorette';
+import type { User } from 'discord.js';
+
+@ApplyOptions<Listener.Options>({ event: Events.ChatInputCommandSuccess })
+export class UserListener extends Listener<typeof Events.ChatInputCommandSuccess> {
+	public run({ interaction }: ChatInputCommandSuccessPayload) {
+		const shard = `[${cyan('0')}]`;
+		const commandName = cyan(`/${interaction.commandName}`);
+		const author = this.author(interaction.user);
+		const sentAt = interaction.guildId ? `${interaction.guild?.name ?? 'Unknown'}[${cyan(interaction.guildId)}]` : cyan('Direct Messages');
+		this.container.logger.debug(`${shard} - ${commandName} ${author} ${sentAt}`);
+	}
+
+	public override onLoad() {
+		this.enabled = this.container.logger.has(LogLevel.Debug);
+		return super.onLoad();
+	}
+
+	private author(author: User) {
+		return `${author.username}[${cyan(author.id)}]`;
+	}
+}

--- a/src/listeners/commands/contextMenuCommandError.ts
+++ b/src/listeners/commands/contextMenuCommandError.ts
@@ -1,0 +1,7 @@
+import { Events, Listener, type ContextMenuCommandErrorPayload } from '@sapphire/framework';
+
+export class UserListener extends Listener<typeof Events.ContextMenuCommandError> {
+	public run(error: Error, payload: ContextMenuCommandErrorPayload) {
+		this.container.logger.fatal(`[COMMAND] ${payload.command.location.full}\n${error.stack || error.message}`);
+	}
+}

--- a/src/listeners/commands/contextMenuCommandSuccessAnalytics.ts
+++ b/src/listeners/commands/contextMenuCommandSuccessAnalytics.ts
@@ -1,0 +1,12 @@
+import type { SkyraCommand } from '#lib/structures';
+import { Events as SkyraEvents } from '#lib/types';
+import { ApplyOptions } from '@sapphire/decorators';
+import { Events, Listener, type ContextMenuCommandSuccessPayload } from '@sapphire/framework';
+
+@ApplyOptions<Listener.Options>({ event: Events.ContextMenuCommandSuccess })
+export class UserListener extends Listener<typeof Events.ContextMenuCommandSuccess> {
+	public run(payload: ContextMenuCommandSuccessPayload) {
+		const command = payload.command as SkyraCommand;
+		this.container.client.emit(SkyraEvents.CommandUsageAnalytics, command.name, command.category);
+	}
+}

--- a/src/listeners/commands/contextMenuCommandSuccessLogger.ts
+++ b/src/listeners/commands/contextMenuCommandSuccessLogger.ts
@@ -1,0 +1,24 @@
+import { ApplyOptions } from '@sapphire/decorators';
+import { Events, Listener, LogLevel, type ContextMenuCommandSuccessPayload } from '@sapphire/framework';
+import { cyan } from 'colorette';
+import type { User } from 'discord.js';
+
+@ApplyOptions<Listener.Options>({ event: Events.ContextMenuCommandSuccess })
+export class UserListener extends Listener<typeof Events.ContextMenuCommandSuccess> {
+	public run({ interaction }: ContextMenuCommandSuccessPayload) {
+		const shard = `[${cyan('0')}]`;
+		const commandName = cyan(interaction.commandName);
+		const author = this.author(interaction.user);
+		const sentAt = interaction.guildId ? `${interaction.guild?.name ?? 'Unknown'}[${cyan(interaction.guildId)}]` : cyan('Direct Messages');
+		this.container.logger.debug(`${shard} - ${commandName} ${author} ${sentAt}`);
+	}
+
+	public override onLoad() {
+		this.enabled = this.container.logger.has(LogLevel.Debug);
+		return super.onLoad();
+	}
+
+	private author(author: User) {
+		return `${author.username}[${cyan(author.id)}]`;
+	}
+}

--- a/src/listeners/commands/messageCommandSuccessLogger.ts
+++ b/src/listeners/commands/messageCommandSuccessLogger.ts
@@ -1,6 +1,5 @@
 import { ApplyOptions } from '@sapphire/decorators';
 import { Command, Events, Listener, LogLevel, type MessageCommandSuccessPayload } from '@sapphire/framework';
-import type { Logger } from '@sapphire/plugin-logger';
 import { cyan } from 'colorette';
 import type { Guild, User } from 'discord.js';
 
@@ -15,7 +14,7 @@ export class UserListener extends Listener<typeof Events.MessageCommandSuccess> 
 	}
 
 	public override onLoad() {
-		this.enabled = (this.container.logger as Logger).level <= LogLevel.Debug;
+		this.enabled = this.container.logger.has(LogLevel.Debug);
 		return super.onLoad();
 	}
 

--- a/src/listeners/userUpdate.ts
+++ b/src/listeners/userUpdate.ts
@@ -1,6 +1,6 @@
 import { GuildSettings, readSettings } from '#lib/database';
 import { LanguageKeys } from '#lib/i18n/languageKeys';
-import { Events, type CustomGet } from '#lib/types';
+import { Events, type TypedT } from '#lib/types';
 import { filter, map } from '#utils/common';
 import { Colors } from '#utils/constants';
 import { getFullEmbedAuthor } from '#utils/util';
@@ -48,7 +48,7 @@ export class UserListener extends Listener {
 		return [t(previous, { previousName }), t(next, { nextName })].join('\n');
 	}
 
-	private buildEmbed(user: User, t: TFunction, description: string, footerKey: CustomGet<string, string>) {
+	private buildEmbed(user: User, t: TFunction, description: string, footerKey: TypedT<string>) {
 		return new EmbedBuilder()
 			.setColor(Colors.Yellow)
 			.setAuthor(getFullEmbedAuthor(user))

--- a/src/preconditions/Enabled.ts
+++ b/src/preconditions/Enabled.ts
@@ -1,36 +1,70 @@
 import { CommandMatcher, GuildEntity, GuildSettings, readSettings } from '#lib/database';
 import type { SkyraCommand } from '#lib/structures';
-import type { GuildMessage } from '#lib/types';
 import { isModerator } from '#utils/functions';
 import { ApplyOptions } from '@sapphire/decorators';
-import { Command, Identifiers, Precondition } from '@sapphire/framework';
-import type { Message } from 'discord.js';
+import {
+	AllFlowsPrecondition,
+	Command,
+	Identifiers,
+	Precondition,
+	type ChatInputCommand,
+	type ContextMenuCommand,
+	type PreconditionContext,
+	type PreconditionResult
+} from '@sapphire/framework';
+import type { CacheType, ChatInputCommandInteraction, ContextMenuCommandInteraction, Guild, GuildMember, Message } from 'discord.js';
 
 @ApplyOptions<Precondition.Options>({ position: 10 })
-export class UserPrecondition extends Precondition {
+export class UserPrecondition extends AllFlowsPrecondition {
 	public override messageRun(message: Message, command: Command, context: Precondition.Context): Precondition.Result {
-		return message.guild ? this.runGuild(message as GuildMessage, command, context) : this.runDM(command, context);
+		return message.guild ? this.runGuild(message.guild!, message.member!, message.channelId, command, context) : this.runDM(command, context);
+	}
+
+	public override chatInputRun(
+		interaction: ChatInputCommandInteraction<CacheType>,
+		command: ChatInputCommand,
+		context: PreconditionContext
+	): PreconditionResult {
+		return interaction.guildId
+			? this.runGuild(interaction.guild!, interaction.member as GuildMember, interaction.channelId, command, context)
+			: this.runDM(command, context);
+	}
+
+	public override contextMenuRun(
+		interaction: ContextMenuCommandInteraction<CacheType>,
+		command: ContextMenuCommand,
+		context: PreconditionContext
+	): PreconditionResult {
+		return interaction.guildId
+			? this.runGuild(interaction.guild!, interaction.member as GuildMember, interaction.channelId, command, context)
+			: this.runDM(command, context);
 	}
 
 	private runDM(command: Command, context: Precondition.Context): Precondition.Result {
 		return command.enabled ? this.ok() : this.error({ identifier: Identifiers.CommandDisabled, context });
 	}
 
-	private async runGuild(message: GuildMessage, command: Command, context: Precondition.Context): Precondition.AsyncResult {
-		const disabled = await readSettings(message.guild, (settings) => this.checkGuildDisabled(settings, message, command as SkyraCommand));
+	private async runGuild(
+		guild: Guild,
+		member: GuildMember,
+		channelId: string,
+		command: Command,
+		context: Precondition.Context
+	): Precondition.AsyncResult {
+		const disabled = await readSettings(guild, (settings) => this.checkGuildDisabled(settings, channelId, command as SkyraCommand));
 		if (disabled) {
-			const canOverride = await isModerator(message.member);
+			const canOverride = await isModerator(member);
 			if (!canOverride) return this.error({ context: { ...context, silent: true } });
 		}
 
 		return this.runDM(command, context);
 	}
 
-	private checkGuildDisabled(settings: GuildEntity, message: GuildMessage, command: SkyraCommand) {
-		if (settings[GuildSettings.DisabledChannels].includes(message.channel.id)) return true;
+	private checkGuildDisabled(settings: GuildEntity, channelId: string, command: SkyraCommand) {
+		if (settings[GuildSettings.DisabledChannels].includes(channelId)) return true;
 		if (CommandMatcher.matchAny(settings[GuildSettings.DisabledCommands], command)) return true;
 
-		const entry = settings[GuildSettings.DisabledCommandChannels].find((d) => d.channel === message.channel.id);
+		const entry = settings[GuildSettings.DisabledCommandChannels].find((d) => d.channel === channelId);
 		if (entry === undefined) return false;
 
 		return CommandMatcher.matchAny(entry.commands, command);

--- a/yarn.lock
+++ b/yarn.lock
@@ -61,12 +61,12 @@ __metadata:
   linkType: hard
 
 "@babel/code-frame@npm:^7.0.0":
-  version: 7.22.13
-  resolution: "@babel/code-frame@npm:7.22.13"
+  version: 7.23.5
+  resolution: "@babel/code-frame@npm:7.23.5"
   dependencies:
-    "@babel/highlight": "npm:^7.22.13"
+    "@babel/highlight": "npm:^7.23.4"
     chalk: "npm:^2.4.2"
-  checksum: bf6ae6ba3a510adfda6a211b4a89b0f1c98ca1352b745c077d113f3b568141e0d44ce750b9ac2a80143ba5c8c4080c50fcfc1aa11d86e194ea6785f62520eb5a
+  checksum: 44e58529c9d93083288dc9e649c553c5ba997475a7b0758cc3ddc4d77b8a7d985dbe78cc39c9bbc61f26d50af6da1ddf0a3427eae8cc222a9370619b671ed8f5
   languageName: node
   linkType: hard
 
@@ -84,43 +84,43 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/highlight@npm:^7.22.13":
-  version: 7.22.20
-  resolution: "@babel/highlight@npm:7.22.20"
+"@babel/highlight@npm:^7.23.4":
+  version: 7.23.4
+  resolution: "@babel/highlight@npm:7.23.4"
   dependencies:
     "@babel/helper-validator-identifier": "npm:^7.22.20"
     chalk: "npm:^2.4.2"
     js-tokens: "npm:^4.0.0"
-  checksum: 1aabc95b2cb7f67adc26c7049554306f1435bfedb76b9731c36ff3d7cdfcb32bd65a6dd06985644124eb2100bd911721d9e5c4f5ac40b7f0da2995a61bf8da92
+  checksum: 62fef9b5bcea7131df4626d009029b1ae85332042f4648a4ce6e740c3fd23112603c740c45575caec62f260c96b11054d3be5987f4981a5479793579c3aac71f
   languageName: node
   linkType: hard
 
 "@babel/parser@npm:^7.23.6":
-  version: 7.23.6
-  resolution: "@babel/parser@npm:7.23.6"
+  version: 7.23.9
+  resolution: "@babel/parser@npm:7.23.9"
   bin:
     parser: ./bin/babel-parser.js
-  checksum: 6be3a63d3c9d07b035b5a79c022327cb7e16cbd530140ecb731f19a650c794c315a72c699a22413ebeafaff14aa8f53435111898d59e01a393d741b85629fa7d
+  checksum: 727a7a807100f6a26df859e2f009c4ddbd0d3363287b45daa50bd082ccd0d431d0c4d0e610a91f806e04a1918726cd0f5a0592c9b902a815337feed12e1cafd9
   languageName: node
   linkType: hard
 
 "@babel/runtime@npm:^7.23.2":
-  version: 7.23.2
-  resolution: "@babel/runtime@npm:7.23.2"
+  version: 7.23.9
+  resolution: "@babel/runtime@npm:7.23.9"
   dependencies:
     regenerator-runtime: "npm:^0.14.0"
-  checksum: abdcbdd590c7e31762e1bdab94dd466823c8bcedd3ff2fde85eeb94dac7cccaef151ac37c428bda7018ededd27c9a82b4dfeb621f978ad934232475a902f8e3a
+  checksum: 9a520fe1bf72249f7dd60ff726434251858de15cccfca7aa831bd19d0d3fb17702e116ead82724659b8da3844977e5e13de2bae01eb8a798f2823a669f122be6
   languageName: node
   linkType: hard
 
 "@babel/types@npm:^7.23.6, @babel/types@npm:^7.8.3":
-  version: 7.23.6
-  resolution: "@babel/types@npm:7.23.6"
+  version: 7.23.9
+  resolution: "@babel/types@npm:7.23.9"
   dependencies:
     "@babel/helper-string-parser": "npm:^7.23.4"
     "@babel/helper-validator-identifier": "npm:^7.22.20"
     to-fast-properties: "npm:^2.0.0"
-  checksum: 07e70bb94d30b0231396b5e9a7726e6d9227a0a62e0a6830c0bd3232f33b024092e3d5a7d1b096a65bbf2bb43a9ab4c721bf618e115bfbb87b454fa060f88cbf
+  checksum: bed9634e5fd0f9dc63c84cfa83316c4cb617192db9fedfea464fca743affe93736d7bf2ebf418ee8358751a9d388e303af87a0c050cb5d87d5870c1b0154f6cb
   languageName: node
   linkType: hard
 
@@ -131,15 +131,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@commitlint/cli@npm:^18.4.4":
-  version: 18.4.4
-  resolution: "@commitlint/cli@npm:18.4.4"
+"@commitlint/cli@npm:^18.6.0":
+  version: 18.6.0
+  resolution: "@commitlint/cli@npm:18.6.0"
   dependencies:
-    "@commitlint/format": "npm:^18.4.4"
-    "@commitlint/lint": "npm:^18.4.4"
-    "@commitlint/load": "npm:^18.4.4"
-    "@commitlint/read": "npm:^18.4.4"
-    "@commitlint/types": "npm:^18.4.4"
+    "@commitlint/format": "npm:^18.6.0"
+    "@commitlint/lint": "npm:^18.6.0"
+    "@commitlint/load": "npm:^18.6.0"
+    "@commitlint/read": "npm:^18.6.0"
+    "@commitlint/types": "npm:^18.6.0"
     execa: "npm:^5.0.0"
     lodash.isfunction: "npm:^3.0.9"
     resolve-from: "npm:5.0.0"
@@ -147,40 +147,40 @@ __metadata:
     yargs: "npm:^17.0.0"
   bin:
     commitlint: cli.js
-  checksum: d7c093fd092f5fb59547f93635875e251cbb92632dc921473815b266e8638a4abb5ab24cf7ed1ca9ec600432ea795fc4c0d8fc5bb48ccf38653a260085f14e47
+  checksum: 525483e521a6340440175f0e2423259737169bcca923e9e39236e76505f3a8432172057a2be0628f8697863af14b56d7dbfc5385e900c66c2ab26f2bd3869a0e
   languageName: node
   linkType: hard
 
-"@commitlint/config-conventional@npm:^18.4.4":
-  version: 18.4.4
-  resolution: "@commitlint/config-conventional@npm:18.4.4"
+"@commitlint/config-conventional@npm:^18.6.0":
+  version: 18.6.0
+  resolution: "@commitlint/config-conventional@npm:18.6.0"
   dependencies:
     conventional-changelog-conventionalcommits: "npm:^7.0.2"
-  checksum: 53238dfac4bef5dcee301cbe1cfc4501054adf9bc1c9bcda47ff0039cf108fd0ffa5e27ff608e62baced9dc976745e7dc2d2a8242704b23251632ed59e303be2
+  checksum: 96f96966efe2dca58fa876668c3ef34326d617a78bc467bd163a232aec7a541e6da5f462bb76b6dcecf0344bec8f82e02ca89b3b64f60527084289c58bfc9b84
   languageName: node
   linkType: hard
 
-"@commitlint/config-validator@npm:^18.4.4":
-  version: 18.4.4
-  resolution: "@commitlint/config-validator@npm:18.4.4"
+"@commitlint/config-validator@npm:^18.6.0":
+  version: 18.6.0
+  resolution: "@commitlint/config-validator@npm:18.6.0"
   dependencies:
-    "@commitlint/types": "npm:^18.4.4"
+    "@commitlint/types": "npm:^18.6.0"
     ajv: "npm:^8.11.0"
-  checksum: 6712b83a12750182ad5d35dd9f9767908df93d950b703c51edf812433249041565aba148221d06f3afd6ac6030d0ddd5d6628c76504c6b01596ac1cd6dd3001c
+  checksum: d1fa98e2fab6454c4974f434381b3435623ed7b481826dffb4311bbd5dabcc45116ab7a862c17bc33792cf1b2f8434063ec6f070a486a292a00217bccacafaa0
   languageName: node
   linkType: hard
 
-"@commitlint/ensure@npm:^18.4.4":
-  version: 18.4.4
-  resolution: "@commitlint/ensure@npm:18.4.4"
+"@commitlint/ensure@npm:^18.6.0":
+  version: 18.6.0
+  resolution: "@commitlint/ensure@npm:18.6.0"
   dependencies:
-    "@commitlint/types": "npm:^18.4.4"
+    "@commitlint/types": "npm:^18.6.0"
     lodash.camelcase: "npm:^4.3.0"
     lodash.kebabcase: "npm:^4.1.1"
     lodash.snakecase: "npm:^4.1.1"
     lodash.startcase: "npm:^4.4.0"
     lodash.upperfirst: "npm:^4.3.1"
-  checksum: 18e30a426b429c6f63b3e2167105189649fd17f3ed7c5d032e8497c38e0d3b2c4587303ea7b01440cce63a66e67a891adafc82f745cea1a8975c4ccd9c8c51c8
+  checksum: 79278621d49a50276bd6b48da4a63a6e29fe31be7794d200e280e632b653bc083f389bcd672a34aa84909ee6ee850db1eb20466659e5a7998784fdb72f323aaa
   languageName: node
   linkType: hard
 
@@ -191,46 +191,46 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@commitlint/format@npm:^18.4.4":
-  version: 18.4.4
-  resolution: "@commitlint/format@npm:18.4.4"
+"@commitlint/format@npm:^18.6.0":
+  version: 18.6.0
+  resolution: "@commitlint/format@npm:18.6.0"
   dependencies:
-    "@commitlint/types": "npm:^18.4.4"
+    "@commitlint/types": "npm:^18.6.0"
     chalk: "npm:^4.1.0"
-  checksum: 3560b3a99c3c13c652af627cc441d763b0bbc2944397cec387d9e673ae84392a87909d5ac8e2568be0603ea63b5f15b39d75b2eda089e7ae25bd579cfefc1218
+  checksum: 68098d426b02b1d3d9a32112663722f787e45c4a79fe9ddf78203ff480f6d89e53ec9ff4c1af2ae36034435f73c2cc602137fb49b2457a2d40345e6cb26fba81
   languageName: node
   linkType: hard
 
-"@commitlint/is-ignored@npm:^18.4.4":
-  version: 18.4.4
-  resolution: "@commitlint/is-ignored@npm:18.4.4"
+"@commitlint/is-ignored@npm:^18.6.0":
+  version: 18.6.0
+  resolution: "@commitlint/is-ignored@npm:18.6.0"
   dependencies:
-    "@commitlint/types": "npm:^18.4.4"
+    "@commitlint/types": "npm:^18.6.0"
     semver: "npm:7.5.4"
-  checksum: d1eebb66c102b97663914af6ac53c93347b0a349bb37be1424caed29f8e14ccc5583e1165ccc926f137f645d9df2ba788939e9eeeb88cf33aff81dcd29c4e32c
+  checksum: 1f85b8ea2ed90cf16c73050b3b7bebb530329ffd0d3a16563b294ead898b540f1f6d6cdd97ece5d9ceab6d9eb2fa8527a73729c50da878ba7eb196ed325d6b73
   languageName: node
   linkType: hard
 
-"@commitlint/lint@npm:^18.4.4":
-  version: 18.4.4
-  resolution: "@commitlint/lint@npm:18.4.4"
+"@commitlint/lint@npm:^18.6.0":
+  version: 18.6.0
+  resolution: "@commitlint/lint@npm:18.6.0"
   dependencies:
-    "@commitlint/is-ignored": "npm:^18.4.4"
-    "@commitlint/parse": "npm:^18.4.4"
-    "@commitlint/rules": "npm:^18.4.4"
-    "@commitlint/types": "npm:^18.4.4"
-  checksum: 7a1dae05369ce714c11e58ad2f13d1e3fc57847be8e15614a39f302961180bcce2488ff9e141ae835dfcf8588a74329efabcb9b7e83cd503632a826c4761ab2a
+    "@commitlint/is-ignored": "npm:^18.6.0"
+    "@commitlint/parse": "npm:^18.6.0"
+    "@commitlint/rules": "npm:^18.6.0"
+    "@commitlint/types": "npm:^18.6.0"
+  checksum: 55bb8eb15d01fcf8970051d1e5186198ec7a6fc30da7faec4a098e18e784438bf494d6b6fc7f6c0c5c3c89bdf907a409213cef512831c41d2256f591f1ac18b9
   languageName: node
   linkType: hard
 
-"@commitlint/load@npm:>6.1.1, @commitlint/load@npm:^18.4.4":
-  version: 18.4.4
-  resolution: "@commitlint/load@npm:18.4.4"
+"@commitlint/load@npm:>6.1.1, @commitlint/load@npm:^18.6.0":
+  version: 18.6.0
+  resolution: "@commitlint/load@npm:18.6.0"
   dependencies:
-    "@commitlint/config-validator": "npm:^18.4.4"
+    "@commitlint/config-validator": "npm:^18.6.0"
     "@commitlint/execute-rule": "npm:^18.4.4"
-    "@commitlint/resolve-extends": "npm:^18.4.4"
-    "@commitlint/types": "npm:^18.4.4"
+    "@commitlint/resolve-extends": "npm:^18.6.0"
+    "@commitlint/types": "npm:^18.6.0"
     chalk: "npm:^4.1.0"
     cosmiconfig: "npm:^8.3.6"
     cosmiconfig-typescript-loader: "npm:^5.0.0"
@@ -238,7 +238,7 @@ __metadata:
     lodash.merge: "npm:^4.6.2"
     lodash.uniq: "npm:^4.5.0"
     resolve-from: "npm:^5.0.0"
-  checksum: 2643f6fdd7f79fc82c14ce88809b69af69c72757e30902ed79d2c26f90035edebf5d5bd10319362e14f7c85dbe36961cb28bc9e376a93e7c83822f24aa37a5a3
+  checksum: 2b28b6756ac46a4b7f63064a45dc4c831b903e8a70d71e2199ce1c8c515863622d5f0f5cf299a539e768c74d52d942c9e66871806b0a7987502e7f249e367a60
   languageName: node
   linkType: hard
 
@@ -249,53 +249,53 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@commitlint/parse@npm:^18.4.4":
-  version: 18.4.4
-  resolution: "@commitlint/parse@npm:18.4.4"
+"@commitlint/parse@npm:^18.6.0":
+  version: 18.6.0
+  resolution: "@commitlint/parse@npm:18.6.0"
   dependencies:
-    "@commitlint/types": "npm:^18.4.4"
+    "@commitlint/types": "npm:^18.6.0"
     conventional-changelog-angular: "npm:^7.0.0"
     conventional-commits-parser: "npm:^5.0.0"
-  checksum: 726fed16a70ecff08ed3c6379885fc3c7e6c5cb47567390175e23cb436fe46a0dea9886da7526cdce52d08594e423621bb5e02d054ee13178d79df3f5c649483
+  checksum: 5e8305fa1eda00f66cd16f386ce0c0848de036d4ba5144509ed34b54b38fba3fadc8798fc33f6c34374590339a5b6cdabaa5a5e9a7bc883e844163fff8a62686
   languageName: node
   linkType: hard
 
-"@commitlint/read@npm:^18.4.4":
-  version: 18.4.4
-  resolution: "@commitlint/read@npm:18.4.4"
+"@commitlint/read@npm:^18.6.0":
+  version: 18.6.0
+  resolution: "@commitlint/read@npm:18.6.0"
   dependencies:
     "@commitlint/top-level": "npm:^18.4.4"
-    "@commitlint/types": "npm:^18.4.4"
+    "@commitlint/types": "npm:^18.6.0"
     git-raw-commits: "npm:^2.0.11"
     minimist: "npm:^1.2.6"
-  checksum: a9fa5eaf345a6f691373e301dbd4a103987d19b821e7b630166de0234e3b4c3d5c2631325c30c3911fc8e0550f08ff9185d8137c2abfe13266d4605c6e22425d
+  checksum: 3d767f15b5eb3eecdca3db5158586b36486ba331fe5fdbe5bad5ce272ee24376514295b9d27eef376688325a7d3c3214304a9c43297ceb66f6c63126845e0e2a
   languageName: node
   linkType: hard
 
-"@commitlint/resolve-extends@npm:^18.4.4":
-  version: 18.4.4
-  resolution: "@commitlint/resolve-extends@npm:18.4.4"
+"@commitlint/resolve-extends@npm:^18.6.0":
+  version: 18.6.0
+  resolution: "@commitlint/resolve-extends@npm:18.6.0"
   dependencies:
-    "@commitlint/config-validator": "npm:^18.4.4"
-    "@commitlint/types": "npm:^18.4.4"
+    "@commitlint/config-validator": "npm:^18.6.0"
+    "@commitlint/types": "npm:^18.6.0"
     import-fresh: "npm:^3.0.0"
     lodash.mergewith: "npm:^4.6.2"
     resolve-from: "npm:^5.0.0"
     resolve-global: "npm:^1.0.0"
-  checksum: b48946fa43cb63149d1771d28d1bdfe81a5b13f5223dbf6958edbe0bcf9635364ba1f07e16a3592069dba4c864a7a403e41af708367472b0d2fd5c9ed38d0997
+  checksum: 9f64f6200d48359b585cf8a1aaadb59b0faf6532edc93b983c63ee08cc7ec48e013cf792a20a0bd4ff42485aaea4e8b774bd0222e04b23c4ee1c295e1337ff88
   languageName: node
   linkType: hard
 
-"@commitlint/rules@npm:^18.4.4":
-  version: 18.4.4
-  resolution: "@commitlint/rules@npm:18.4.4"
+"@commitlint/rules@npm:^18.6.0":
+  version: 18.6.0
+  resolution: "@commitlint/rules@npm:18.6.0"
   dependencies:
-    "@commitlint/ensure": "npm:^18.4.4"
+    "@commitlint/ensure": "npm:^18.6.0"
     "@commitlint/message": "npm:^18.4.4"
     "@commitlint/to-lines": "npm:^18.4.4"
-    "@commitlint/types": "npm:^18.4.4"
+    "@commitlint/types": "npm:^18.6.0"
     execa: "npm:^5.0.0"
-  checksum: ddde4e56a1ffdebc2c8e1d8ca36fe3bdc4285dc7b9aeb4f3087f1853997cedc322531f034eb907ec49ea769d8c2df31242b7df1375812d8826f704c8354faee3
+  checksum: deb8848e69d96810a6b1c5db0a3666c7bef2dab3a98ae19d287a7af8d2738a63d68109f2f4aed80124f0decdc7731f77844734f60997d605995b2ec0a4786116
   languageName: node
   linkType: hard
 
@@ -315,12 +315,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@commitlint/types@npm:^18.4.4":
-  version: 18.4.4
-  resolution: "@commitlint/types@npm:18.4.4"
+"@commitlint/types@npm:^18.6.0":
+  version: 18.6.0
+  resolution: "@commitlint/types@npm:18.6.0"
   dependencies:
     chalk: "npm:^4.1.0"
-  checksum: bda09adc5f4a7d460120891ad85d2950cb3db17ee9ecf93b820c4782c5a9f8cb235b28fb559a3c4f38fbb5ada43b50bab4c2ee1eb87853be4febbcd8da30fd1f
+  checksum: c0b256998d8b5fe8f31f6009efe6953dcd506a625411bd13082d07548f0fe792b4de10ca97eaa78e403bf6e0f254dbd1f5d545a6be2f9a67f36a49a6111eafca
   languageName: node
   linkType: hard
 
@@ -417,156 +417,163 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm64@npm:0.19.5":
-  version: 0.19.5
-  resolution: "@esbuild/android-arm64@npm:0.19.5"
+"@esbuild/aix-ppc64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/aix-ppc64@npm:0.19.12"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/android-arm64@npm:0.19.12"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/android-arm@npm:0.19.5":
-  version: 0.19.5
-  resolution: "@esbuild/android-arm@npm:0.19.5"
+"@esbuild/android-arm@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/android-arm@npm:0.19.12"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"@esbuild/android-x64@npm:0.19.5":
-  version: 0.19.5
-  resolution: "@esbuild/android-x64@npm:0.19.5"
+"@esbuild/android-x64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/android-x64@npm:0.19.12"
   conditions: os=android & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/darwin-arm64@npm:0.19.5":
-  version: 0.19.5
-  resolution: "@esbuild/darwin-arm64@npm:0.19.5"
+"@esbuild/darwin-arm64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/darwin-arm64@npm:0.19.12"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/darwin-x64@npm:0.19.5":
-  version: 0.19.5
-  resolution: "@esbuild/darwin-x64@npm:0.19.5"
+"@esbuild/darwin-x64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/darwin-x64@npm:0.19.12"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/freebsd-arm64@npm:0.19.5":
-  version: 0.19.5
-  resolution: "@esbuild/freebsd-arm64@npm:0.19.5"
+"@esbuild/freebsd-arm64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/freebsd-arm64@npm:0.19.12"
   conditions: os=freebsd & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/freebsd-x64@npm:0.19.5":
-  version: 0.19.5
-  resolution: "@esbuild/freebsd-x64@npm:0.19.5"
+"@esbuild/freebsd-x64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/freebsd-x64@npm:0.19.12"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm64@npm:0.19.5":
-  version: 0.19.5
-  resolution: "@esbuild/linux-arm64@npm:0.19.5"
+"@esbuild/linux-arm64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/linux-arm64@npm:0.19.12"
   conditions: os=linux & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-arm@npm:0.19.5":
-  version: 0.19.5
-  resolution: "@esbuild/linux-arm@npm:0.19.5"
+"@esbuild/linux-arm@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/linux-arm@npm:0.19.12"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@esbuild/linux-ia32@npm:0.19.5":
-  version: 0.19.5
-  resolution: "@esbuild/linux-ia32@npm:0.19.5"
+"@esbuild/linux-ia32@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/linux-ia32@npm:0.19.12"
   conditions: os=linux & cpu=ia32
   languageName: node
   linkType: hard
 
-"@esbuild/linux-loong64@npm:0.19.5":
-  version: 0.19.5
-  resolution: "@esbuild/linux-loong64@npm:0.19.5"
+"@esbuild/linux-loong64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/linux-loong64@npm:0.19.12"
   conditions: os=linux & cpu=loong64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-mips64el@npm:0.19.5":
-  version: 0.19.5
-  resolution: "@esbuild/linux-mips64el@npm:0.19.5"
+"@esbuild/linux-mips64el@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/linux-mips64el@npm:0.19.12"
   conditions: os=linux & cpu=mips64el
   languageName: node
   linkType: hard
 
-"@esbuild/linux-ppc64@npm:0.19.5":
-  version: 0.19.5
-  resolution: "@esbuild/linux-ppc64@npm:0.19.5"
+"@esbuild/linux-ppc64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/linux-ppc64@npm:0.19.12"
   conditions: os=linux & cpu=ppc64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-riscv64@npm:0.19.5":
-  version: 0.19.5
-  resolution: "@esbuild/linux-riscv64@npm:0.19.5"
+"@esbuild/linux-riscv64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/linux-riscv64@npm:0.19.12"
   conditions: os=linux & cpu=riscv64
   languageName: node
   linkType: hard
 
-"@esbuild/linux-s390x@npm:0.19.5":
-  version: 0.19.5
-  resolution: "@esbuild/linux-s390x@npm:0.19.5"
+"@esbuild/linux-s390x@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/linux-s390x@npm:0.19.12"
   conditions: os=linux & cpu=s390x
   languageName: node
   linkType: hard
 
-"@esbuild/linux-x64@npm:0.19.5":
-  version: 0.19.5
-  resolution: "@esbuild/linux-x64@npm:0.19.5"
+"@esbuild/linux-x64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/linux-x64@npm:0.19.12"
   conditions: os=linux & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/netbsd-x64@npm:0.19.5":
-  version: 0.19.5
-  resolution: "@esbuild/netbsd-x64@npm:0.19.5"
+"@esbuild/netbsd-x64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/netbsd-x64@npm:0.19.12"
   conditions: os=netbsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/openbsd-x64@npm:0.19.5":
-  version: 0.19.5
-  resolution: "@esbuild/openbsd-x64@npm:0.19.5"
+"@esbuild/openbsd-x64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/openbsd-x64@npm:0.19.12"
   conditions: os=openbsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/sunos-x64@npm:0.19.5":
-  version: 0.19.5
-  resolution: "@esbuild/sunos-x64@npm:0.19.5"
+"@esbuild/sunos-x64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/sunos-x64@npm:0.19.12"
   conditions: os=sunos & cpu=x64
   languageName: node
   linkType: hard
 
-"@esbuild/win32-arm64@npm:0.19.5":
-  version: 0.19.5
-  resolution: "@esbuild/win32-arm64@npm:0.19.5"
+"@esbuild/win32-arm64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/win32-arm64@npm:0.19.12"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@esbuild/win32-ia32@npm:0.19.5":
-  version: 0.19.5
-  resolution: "@esbuild/win32-ia32@npm:0.19.5"
+"@esbuild/win32-ia32@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/win32-ia32@npm:0.19.12"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@esbuild/win32-x64@npm:0.19.5":
-  version: 0.19.5
-  resolution: "@esbuild/win32-x64@npm:0.19.5"
+"@esbuild/win32-x64@npm:0.19.12":
+  version: 0.19.12
+  resolution: "@esbuild/win32-x64@npm:0.19.12"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -614,20 +621,20 @@ __metadata:
   linkType: hard
 
 "@fastify/busboy@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@fastify/busboy@npm:2.0.0"
-  checksum: 6a2366d06b82aac1069b8323792f76f7a8fca02533cb3745fcd218d8f0f953dc4dbef057287237414658cd43f8dede0846ef33398999e3dbe54ddaeefec71c0a
+  version: 2.1.0
+  resolution: "@fastify/busboy@npm:2.1.0"
+  checksum: f22c1e5c52dc350ddf9ba8be9f87b48d3ea5af00a37fd0a0d1e3e4b37f94d96763e514c68a350c7f570260fdd2f08b55ee090cdd879f92a03249eb0e3fd19113
   languageName: node
   linkType: hard
 
 "@humanwhocodes/config-array@npm:^0.11.13":
-  version: 0.11.13
-  resolution: "@humanwhocodes/config-array@npm:0.11.13"
+  version: 0.11.14
+  resolution: "@humanwhocodes/config-array@npm:0.11.14"
   dependencies:
-    "@humanwhocodes/object-schema": "npm:^2.0.1"
-    debug: "npm:^4.1.1"
+    "@humanwhocodes/object-schema": "npm:^2.0.2"
+    debug: "npm:^4.3.1"
     minimatch: "npm:^3.0.5"
-  checksum: 9f655e1df7efa5a86822cd149ca5cef57240bb8ffd728f0c07cc682cc0a15c6bdce68425fbfd58f9b3e8b16f79b3fd8cb1e96b10c434c9a76f20b2a89f213272
+  checksum: 3ffb24ecdfab64014a230e127118d50a1a04d11080cbb748bc21629393d100850496456bbcb4e8c438957fe0934430d731042f1264d6a167b62d32fc2863580a
   languageName: node
   linkType: hard
 
@@ -638,10 +645,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@humanwhocodes/object-schema@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "@humanwhocodes/object-schema@npm:2.0.1"
-  checksum: dbddfd0465aecf92ed845ec30d06dba3f7bb2496d544b33b53dac7abc40370c0e46b8787b268d24a366730d5eeb5336ac88967232072a183905ee4abf7df4dab
+"@humanwhocodes/object-schema@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "@humanwhocodes/object-schema@npm:2.0.2"
+  checksum: ef915e3e2f34652f3d383b28a9a99cfea476fa991482370889ab14aac8ecd2b38d47cc21932526c6d949da0daf4a4a6bf629d30f41b0caca25e146819cbfa70e
   languageName: node
   linkType: hard
 
@@ -724,12 +731,12 @@ __metadata:
   linkType: hard
 
 "@jridgewell/trace-mapping@npm:^0.3.12, @jridgewell/trace-mapping@npm:^0.3.9":
-  version: 0.3.20
-  resolution: "@jridgewell/trace-mapping@npm:0.3.20"
+  version: 0.3.22
+  resolution: "@jridgewell/trace-mapping@npm:0.3.22"
   dependencies:
     "@jridgewell/resolve-uri": "npm:^3.1.0"
     "@jridgewell/sourcemap-codec": "npm:^1.4.14"
-  checksum: 683117e4e6707ef50c725d6d0ec4234687ff751f36fa46c2b3068931eb6a86b49af374d3030200777666579a992b7470d1bd1c591e9bf64d764dda5295f33093
+  checksum: 48d3e3db00dbecb211613649a1849876ba5544a3f41cf5e6b99ea1130272d6cf18591b5b67389bce20f1c871b4ede5900c3b6446a7aab6d0a3b2fe806a834db7
   languageName: node
   linkType: hard
 
@@ -790,92 +797,99 @@ __metadata:
   linkType: hard
 
 "@pkgr/core@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "@pkgr/core@npm:0.1.0"
-  checksum: eeff0e0e517b1ed10eb4c1a8971413a8349bbfdab727dbe7d4085fd94eab95f0c3beb51b9245fef30562849d2a7a119e07ca48c343c8c4ec4e64ee289f50fe5e
+  version: 0.1.1
+  resolution: "@pkgr/core@npm:0.1.1"
+  checksum: 6f25fd2e3008f259c77207ac9915b02f1628420403b2630c92a07ff963129238c9262afc9e84344c7a23b5cc1f3965e2cd17e3798219f5fd78a63d144d3cceba
   languageName: node
   linkType: hard
 
-"@rollup/rollup-android-arm-eabi@npm:4.3.0":
-  version: 4.3.0
-  resolution: "@rollup/rollup-android-arm-eabi@npm:4.3.0"
+"@rollup/rollup-android-arm-eabi@npm:4.9.6":
+  version: 4.9.6
+  resolution: "@rollup/rollup-android-arm-eabi@npm:4.9.6"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"@rollup/rollup-android-arm64@npm:4.3.0":
-  version: 4.3.0
-  resolution: "@rollup/rollup-android-arm64@npm:4.3.0"
+"@rollup/rollup-android-arm64@npm:4.9.6":
+  version: 4.9.6
+  resolution: "@rollup/rollup-android-arm64@npm:4.9.6"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-darwin-arm64@npm:4.3.0":
-  version: 4.3.0
-  resolution: "@rollup/rollup-darwin-arm64@npm:4.3.0"
+"@rollup/rollup-darwin-arm64@npm:4.9.6":
+  version: 4.9.6
+  resolution: "@rollup/rollup-darwin-arm64@npm:4.9.6"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-darwin-x64@npm:4.3.0":
-  version: 4.3.0
-  resolution: "@rollup/rollup-darwin-x64@npm:4.3.0"
+"@rollup/rollup-darwin-x64@npm:4.9.6":
+  version: 4.9.6
+  resolution: "@rollup/rollup-darwin-x64@npm:4.9.6"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm-gnueabihf@npm:4.3.0":
-  version: 4.3.0
-  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.3.0"
+"@rollup/rollup-linux-arm-gnueabihf@npm:4.9.6":
+  version: 4.9.6
+  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.9.6"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm64-gnu@npm:4.3.0":
-  version: 4.3.0
-  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.3.0"
+"@rollup/rollup-linux-arm64-gnu@npm:4.9.6":
+  version: 4.9.6
+  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.9.6"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm64-musl@npm:4.3.0":
-  version: 4.3.0
-  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.3.0"
+"@rollup/rollup-linux-arm64-musl@npm:4.9.6":
+  version: 4.9.6
+  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.9.6"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-x64-gnu@npm:4.3.0":
-  version: 4.3.0
-  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.3.0"
+"@rollup/rollup-linux-riscv64-gnu@npm:4.9.6":
+  version: 4.9.6
+  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.9.6"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-x64-gnu@npm:4.9.6":
+  version: 4.9.6
+  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.9.6"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-x64-musl@npm:4.3.0":
-  version: 4.3.0
-  resolution: "@rollup/rollup-linux-x64-musl@npm:4.3.0"
+"@rollup/rollup-linux-x64-musl@npm:4.9.6":
+  version: 4.9.6
+  resolution: "@rollup/rollup-linux-x64-musl@npm:4.9.6"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-arm64-msvc@npm:4.3.0":
-  version: 4.3.0
-  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.3.0"
+"@rollup/rollup-win32-arm64-msvc@npm:4.9.6":
+  version: 4.9.6
+  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.9.6"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-ia32-msvc@npm:4.3.0":
-  version: 4.3.0
-  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.3.0"
+"@rollup/rollup-win32-ia32-msvc@npm:4.9.6":
+  version: 4.9.6
+  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.9.6"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-x64-msvc@npm:4.3.0":
-  version: 4.3.0
-  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.3.0"
+"@rollup/rollup-win32-x64-msvc@npm:4.9.6":
+  version: 4.9.6
+  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.9.6"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -1076,12 +1090,12 @@ __metadata:
   linkType: hard
 
 "@sapphire/shapeshift@npm:^3.9.3":
-  version: 3.9.3
-  resolution: "@sapphire/shapeshift@npm:3.9.3"
+  version: 3.9.6
+  resolution: "@sapphire/shapeshift@npm:3.9.6"
   dependencies:
     fast-deep-equal: "npm:^3.1.3"
     lodash: "npm:^4.17.21"
-  checksum: 9fce0135d4b6b2acbab83af078dcc5d9780c83c2cea9094178f19128d78ca7e7fa0d90f5b1c4ed4ab345194eb138415e4c902a1014eff2c5d68b77e75f5774e9
+  checksum: 9d7ab3b3341514363598e48666ec32ec631e0f3b408eb851d4397e479f93c70a471610949d30b9450beaf212df721ffa7c4da3ed3d0fbaffebcb1dfe73ab3f4c
   languageName: node
   linkType: hard
 
@@ -1151,64 +1165,64 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry-internal/tracing@npm:7.94.1":
-  version: 7.94.1
-  resolution: "@sentry-internal/tracing@npm:7.94.1"
+"@sentry-internal/tracing@npm:7.98.0":
+  version: 7.98.0
+  resolution: "@sentry-internal/tracing@npm:7.98.0"
   dependencies:
-    "@sentry/core": "npm:7.94.1"
-    "@sentry/types": "npm:7.94.1"
-    "@sentry/utils": "npm:7.94.1"
-  checksum: cce796b72583680cb119118282ef2463d50ba4b193063978e3927dfd1a722d4fa0bf838887407cb749a6e2a88b5461010f9c0b9c33be692ec8e8914697505f3e
+    "@sentry/core": "npm:7.98.0"
+    "@sentry/types": "npm:7.98.0"
+    "@sentry/utils": "npm:7.98.0"
+  checksum: fbd6cf01f411d5540e5cf1f1d0c6a7054e63b299e9721044a81b36487e51cdc69fad2d0f55567a9b15fc963162b41c6639035640f822f58808ad8e286881aa74
   languageName: node
   linkType: hard
 
-"@sentry/core@npm:7.94.1":
-  version: 7.94.1
-  resolution: "@sentry/core@npm:7.94.1"
+"@sentry/core@npm:7.98.0":
+  version: 7.98.0
+  resolution: "@sentry/core@npm:7.98.0"
   dependencies:
-    "@sentry/types": "npm:7.94.1"
-    "@sentry/utils": "npm:7.94.1"
-  checksum: 758dffd704ddd071beed6aab793be088307ae4dc840121e36c56ddedbb5b4b19138811314656a97e478fc91894e9c7a8dbbc11ff38773923be17c186bd28e45f
+    "@sentry/types": "npm:7.98.0"
+    "@sentry/utils": "npm:7.98.0"
+  checksum: fa2221c5776a8a9331df60c263a78e034b535cec524296af659704215da8d225057fcf1df928e99386d1ac9f55f45a95c43f5ec1f85ebb99317f90f77936aeb8
   languageName: node
   linkType: hard
 
-"@sentry/integrations@npm:^7.94.1":
-  version: 7.94.1
-  resolution: "@sentry/integrations@npm:7.94.1"
+"@sentry/integrations@npm:^7.98.0":
+  version: 7.98.0
+  resolution: "@sentry/integrations@npm:7.98.0"
   dependencies:
-    "@sentry/core": "npm:7.94.1"
-    "@sentry/types": "npm:7.94.1"
-    "@sentry/utils": "npm:7.94.1"
+    "@sentry/core": "npm:7.98.0"
+    "@sentry/types": "npm:7.98.0"
+    "@sentry/utils": "npm:7.98.0"
     localforage: "npm:^1.8.1"
-  checksum: e1f0360d336acba55db1866e63b5151db16753293db414bcb6b0a41a8084e8be049170138ba007ce434843306b4f8b80c19b44fdf12f1c1dfd9ef1e74d18112d
+  checksum: 959cc4dc1dd39592f0b559563559ede2c88e2aa4630b981b5cff07eb59bca0886d4467e3d9e5c3c9ddcccf4aa6f552674ca9cae98e6cca4edf95e8ace0c20abc
   languageName: node
   linkType: hard
 
-"@sentry/node@npm:^7.94.1":
-  version: 7.94.1
-  resolution: "@sentry/node@npm:7.94.1"
+"@sentry/node@npm:^7.98.0":
+  version: 7.98.0
+  resolution: "@sentry/node@npm:7.98.0"
   dependencies:
-    "@sentry-internal/tracing": "npm:7.94.1"
-    "@sentry/core": "npm:7.94.1"
-    "@sentry/types": "npm:7.94.1"
-    "@sentry/utils": "npm:7.94.1"
-  checksum: f2d5b86a0bdfc53dc2b4acdf5373f00ee25a0af38ed47cef7c5e5888c481370dd1dba2a86f50de6b623214815cb6bc36a3582706c2a30742c36280e6f9a7965d
+    "@sentry-internal/tracing": "npm:7.98.0"
+    "@sentry/core": "npm:7.98.0"
+    "@sentry/types": "npm:7.98.0"
+    "@sentry/utils": "npm:7.98.0"
+  checksum: 63e12619f372b56e1ac71ac7706b5b8b37024f15cc47ac4d6d49183947b80f946266f7d3700d7d886c2c739bb16663c11c52399079db69668ea769c2b34cbdbb
   languageName: node
   linkType: hard
 
-"@sentry/types@npm:7.94.1":
-  version: 7.94.1
-  resolution: "@sentry/types@npm:7.94.1"
-  checksum: 1b8ce044ef3d2fe583d98568daf874c2bacba80c2c0fe2549f0f26cb591e3583bfe00315d4aa635e9290bd9aa88504dec03be8e283ff1a755a513c09cfd4f23a
+"@sentry/types@npm:7.98.0":
+  version: 7.98.0
+  resolution: "@sentry/types@npm:7.98.0"
+  checksum: 3b9bd8929b988c4ee70afadb8662e47d22188b2acdf63f58b61a3cabea3be341d63d612aca7b61f0a267659c5eb774ee81347611a47f87e2c9ed71c8123ccae5
   languageName: node
   linkType: hard
 
-"@sentry/utils@npm:7.94.1":
-  version: 7.94.1
-  resolution: "@sentry/utils@npm:7.94.1"
+"@sentry/utils@npm:7.98.0":
+  version: 7.98.0
+  resolution: "@sentry/utils@npm:7.98.0"
   dependencies:
-    "@sentry/types": "npm:7.94.1"
-  checksum: d461a54816a2f0cd19022427b01e21c0fb094ce6095def51df1d0887df71db3310b6e8dbbfdd5c4db3034840b25949f75ee660066e00250b47ccf00f828e5990
+    "@sentry/types": "npm:7.98.0"
+  checksum: b4697bd8a1ad6ee4a7b2d639847e874d0bc6fce7395ee2184618cfe6b3a31f06732483e339c76e9e0dd50c39c97ea598ac42921a2fa3fefd2a786684e0bcb10c
   languageName: node
   linkType: hard
 
@@ -1294,7 +1308,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:^1.0.0":
+"@types/estree@npm:1.0.5, @types/estree@npm:^1.0.0":
   version: 1.0.5
   resolution: "@types/estree@npm:1.0.5"
   checksum: 7de6d928dd4010b0e20c6919e1a6c27b61f8d4567befa89252055fad503d587ecb9a1e3eab1b1901f923964d7019796db810b7fd6430acb26c32866d126fd408
@@ -1329,7 +1343,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:^20.11.5":
+"@types/node@npm:20.11.5":
   version: 20.11.5
   resolution: "@types/node@npm:20.11.5"
   dependencies:
@@ -1345,21 +1359,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/pg@npm:^8.10.9":
-  version: 8.10.9
-  resolution: "@types/pg@npm:8.10.9"
+"@types/pg@npm:^8.11.0":
+  version: 8.11.0
+  resolution: "@types/pg@npm:8.11.0"
   dependencies:
     "@types/node": "npm:*"
     pg-protocol: "npm:*"
     pg-types: "npm:^4.0.1"
-  checksum: 787be5431ae70abe9eadde3bcfec7d1fd227ab401b20f1be6fadc171556d3083802855eeacd6a889237994c8cd01b23f56f1d31ecb3e9a79f8bcfb16b3ee4f0f
+  checksum: 91a7ccc5dc8e162d9d181f48f699eb4628632e75bd9db1c0ca774ec9b055b177875fb4b426279961061912f25fb3948c48c96e63ac9e85efcf7ce6f2567b6485
   languageName: node
   linkType: hard
 
 "@types/semver@npm:^7.5.0":
-  version: 7.5.5
-  resolution: "@types/semver@npm:7.5.5"
-  checksum: 1b0be2c4d830f5ef002a305308e06e3616fc38a41c9a2c5b4267df82a038d9bd0ba32ec1da82a52db84a720be7e4b69bac7593797d8dc1400a69069af8f19219
+  version: 7.5.6
+  resolution: "@types/semver@npm:7.5.6"
+  checksum: e77282b17f74354e17e771c0035cccb54b94cc53d0433fa7e9ba9d23fd5d7edcd14b6c8b7327d58bbd89e83b1c5eda71dfe408e06b929007e2b89586e9b63459
   languageName: node
   linkType: hard
 
@@ -1381,15 +1395,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:^6.13.2, @typescript-eslint/eslint-plugin@npm:^6.19.0":
-  version: 6.19.0
-  resolution: "@typescript-eslint/eslint-plugin@npm:6.19.0"
+"@typescript-eslint/eslint-plugin@npm:^6.13.2, @typescript-eslint/eslint-plugin@npm:^6.19.1":
+  version: 6.19.1
+  resolution: "@typescript-eslint/eslint-plugin@npm:6.19.1"
   dependencies:
     "@eslint-community/regexpp": "npm:^4.5.1"
-    "@typescript-eslint/scope-manager": "npm:6.19.0"
-    "@typescript-eslint/type-utils": "npm:6.19.0"
-    "@typescript-eslint/utils": "npm:6.19.0"
-    "@typescript-eslint/visitor-keys": "npm:6.19.0"
+    "@typescript-eslint/scope-manager": "npm:6.19.1"
+    "@typescript-eslint/type-utils": "npm:6.19.1"
+    "@typescript-eslint/utils": "npm:6.19.1"
+    "@typescript-eslint/visitor-keys": "npm:6.19.1"
     debug: "npm:^4.3.4"
     graphemer: "npm:^1.4.0"
     ignore: "npm:^5.2.4"
@@ -1402,44 +1416,44 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 5ed8483d792c4bc6ed697159c84a47ba5c35cd124949883813f2053b972537de3900a7ae26d4d6f370194f2cc7929baa2d09268e0b90118f20ed961cf6c176b9
+  checksum: e88a35527b066a42d0253d153183a360faedc1cd39867c541ce7cb1f7b22f8446bb913b998fcdeba269d5d4217888af42e6d64da5c0592b1f49ed5648d2e3e84
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:^6.13.2, @typescript-eslint/parser@npm:^6.19.0":
-  version: 6.19.0
-  resolution: "@typescript-eslint/parser@npm:6.19.0"
+"@typescript-eslint/parser@npm:^6.13.2, @typescript-eslint/parser@npm:^6.19.1":
+  version: 6.19.1
+  resolution: "@typescript-eslint/parser@npm:6.19.1"
   dependencies:
-    "@typescript-eslint/scope-manager": "npm:6.19.0"
-    "@typescript-eslint/types": "npm:6.19.0"
-    "@typescript-eslint/typescript-estree": "npm:6.19.0"
-    "@typescript-eslint/visitor-keys": "npm:6.19.0"
+    "@typescript-eslint/scope-manager": "npm:6.19.1"
+    "@typescript-eslint/types": "npm:6.19.1"
+    "@typescript-eslint/typescript-estree": "npm:6.19.1"
+    "@typescript-eslint/visitor-keys": "npm:6.19.1"
     debug: "npm:^4.3.4"
   peerDependencies:
     eslint: ^7.0.0 || ^8.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 0c6280a69127cf521b3403be9877775eecda2b2e4e44a67874b0d9cf82ed95a7971dac2db633e55ec22f8026da2681137110b2924313421a22b7c03eba8cda67
+  checksum: 63ff00a56586879a62e40b27b55c94501173fcf2fb5a620d01e7505851b4bb20feb1e7fbad36010af97aefc0a722267d9ce3aa004abab22cb7eb23eebb0102ce
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:6.19.0":
-  version: 6.19.0
-  resolution: "@typescript-eslint/scope-manager@npm:6.19.0"
+"@typescript-eslint/scope-manager@npm:6.19.1":
+  version: 6.19.1
+  resolution: "@typescript-eslint/scope-manager@npm:6.19.1"
   dependencies:
-    "@typescript-eslint/types": "npm:6.19.0"
-    "@typescript-eslint/visitor-keys": "npm:6.19.0"
-  checksum: d36c51c05e14c51ce13181120eeea46d1edd59ed1ff16dc4ec1f5532a975b5faec5c10a373aaa90545f82a12330c6cba18ecedc734e18288f5874855c48ba808
+    "@typescript-eslint/types": "npm:6.19.1"
+    "@typescript-eslint/visitor-keys": "npm:6.19.1"
+  checksum: 2a17f68d3c41582bfac7ecd192e2c2539cf4d2c9728a7018d842da7a8a23986b8a1f8cfcb59862c909b483140a2d164a4ba44451905e0a141378e5dd0df056cc
   languageName: node
   linkType: hard
 
-"@typescript-eslint/type-utils@npm:6.19.0":
-  version: 6.19.0
-  resolution: "@typescript-eslint/type-utils@npm:6.19.0"
+"@typescript-eslint/type-utils@npm:6.19.1":
+  version: 6.19.1
+  resolution: "@typescript-eslint/type-utils@npm:6.19.1"
   dependencies:
-    "@typescript-eslint/typescript-estree": "npm:6.19.0"
-    "@typescript-eslint/utils": "npm:6.19.0"
+    "@typescript-eslint/typescript-estree": "npm:6.19.1"
+    "@typescript-eslint/utils": "npm:6.19.1"
     debug: "npm:^4.3.4"
     ts-api-utils: "npm:^1.0.1"
   peerDependencies:
@@ -1447,23 +1461,23 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: f1f20ac28c03dd18546050b63ec0b0fd8c67780265ccb9ef566f16441c3de5deb2607a6046fefdebe8a43ac11fecdf0b009f8e5f70a3d15916d855be74b0f3bb
+  checksum: 5150b897d8b3778c549c6b964b031981da1039dfa0fb89a0eb92702735ca55793d2f840af14b340eccbca81669ba3dd02d7f09fb420fb66b18ec9f1f211b3243
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:6.19.0":
-  version: 6.19.0
-  resolution: "@typescript-eslint/types@npm:6.19.0"
-  checksum: 396ad2ad9f2d759dd87bc880a1ffc9d11fda04db8af9402abb4e8eccd58c01fa2d26e38b186526d0b457012f7c912e7afdab2a3798a73aa0ae34abaf50d617ae
+"@typescript-eslint/types@npm:6.19.1":
+  version: 6.19.1
+  resolution: "@typescript-eslint/types@npm:6.19.1"
+  checksum: 93f3ded80b81a1b8686866b93e36ddf9bac04604d09e88d7ed1ec25b6b2f49ff64747d8d194ba1f3215e231fd0790b88fb5ecadcc6ed53ff584f8c0b87423216
   languageName: node
   linkType: hard
 
-"@typescript-eslint/typescript-estree@npm:6.19.0":
-  version: 6.19.0
-  resolution: "@typescript-eslint/typescript-estree@npm:6.19.0"
+"@typescript-eslint/typescript-estree@npm:6.19.1":
+  version: 6.19.1
+  resolution: "@typescript-eslint/typescript-estree@npm:6.19.1"
   dependencies:
-    "@typescript-eslint/types": "npm:6.19.0"
-    "@typescript-eslint/visitor-keys": "npm:6.19.0"
+    "@typescript-eslint/types": "npm:6.19.1"
+    "@typescript-eslint/visitor-keys": "npm:6.19.1"
     debug: "npm:^4.3.4"
     globby: "npm:^11.1.0"
     is-glob: "npm:^4.0.3"
@@ -1473,34 +1487,34 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 06e24bb145a302299a6cf86b36652bd4d7080c4e88517ebc24bdc137c57425a68db256ba628ce16b568bfec8020ae2a748ccee93e304efeded329cb3292b17bf
+  checksum: 3ce91dd477ccb2cc3cf5d07ac8d23792988f4fad78bfd39783292846f32daea5081d3790ba9cc795d9de89ea2e1d55dc9c3d2aeaa8597093b0f6ac3a206195e9
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:6.19.0":
-  version: 6.19.0
-  resolution: "@typescript-eslint/utils@npm:6.19.0"
+"@typescript-eslint/utils@npm:6.19.1":
+  version: 6.19.1
+  resolution: "@typescript-eslint/utils@npm:6.19.1"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.4.0"
     "@types/json-schema": "npm:^7.0.12"
     "@types/semver": "npm:^7.5.0"
-    "@typescript-eslint/scope-manager": "npm:6.19.0"
-    "@typescript-eslint/types": "npm:6.19.0"
-    "@typescript-eslint/typescript-estree": "npm:6.19.0"
+    "@typescript-eslint/scope-manager": "npm:6.19.1"
+    "@typescript-eslint/types": "npm:6.19.1"
+    "@typescript-eslint/typescript-estree": "npm:6.19.1"
     semver: "npm:^7.5.4"
   peerDependencies:
     eslint: ^7.0.0 || ^8.0.0
-  checksum: 4080c36331204ffef9f218e29f43da767f17551fa4d3877c3d3b49194f7c7382dd9ae2124e7b5ebd47d5556946bb6ad195b47d7d215553efabacdebf81b9e74d
+  checksum: f8931df675defa84af373c81bbb13cc34c2fcf0803c687a38b982e85335dbf2fb8415667fbabaa043df0326ba3e98ed974104bbd21f09ec538304fc3adeed0c3
   languageName: node
   linkType: hard
 
-"@typescript-eslint/visitor-keys@npm:6.19.0":
-  version: 6.19.0
-  resolution: "@typescript-eslint/visitor-keys@npm:6.19.0"
+"@typescript-eslint/visitor-keys@npm:6.19.1":
+  version: 6.19.1
+  resolution: "@typescript-eslint/visitor-keys@npm:6.19.1"
   dependencies:
-    "@typescript-eslint/types": "npm:6.19.0"
+    "@typescript-eslint/types": "npm:6.19.1"
     eslint-visitor-keys: "npm:^3.4.1"
-  checksum: 8d51c0b8d94c5df044fde958f62741cef55be97c6a3a16c47e4df9af7b2ff13aa1ee03ca5240777481dca53f3b7a9b00b329e50aff5e3ad829d96bc5f63ca2c3
+  checksum: b41f3247520e1e4d3e43876843b03f0d887e544d4ac8a9e1f4b25d08568da36fedde883fa226488a595f688198859cd0290d0f1351c2ca6cbc30cca2c90adf21
   languageName: node
   linkType: hard
 
@@ -1589,9 +1603,9 @@ __metadata:
   linkType: hard
 
 "@vladfrangu/async_event_emitter@npm:^2.2.2":
-  version: 2.2.2
-  resolution: "@vladfrangu/async_event_emitter@npm:2.2.2"
-  checksum: 1c1fcee04aecfa3cceb05e9bcd3a8aae053ce0512e79e7f878a5d2b8458a926aa3e6da553be0a431e7acb58d9aec3df435a845653a642b864c6b67e2a44ec40c
+  version: 2.2.4
+  resolution: "@vladfrangu/async_event_emitter@npm:2.2.4"
+  checksum: 06de49380dc47fe712768b0e49286e54a114de962da36ef021d4b03fcff7ec8338b46179d8b3eba4c0e02b2926bbf1e6ea0f9c6c08f6f081361947a7f6719ce9
   languageName: node
   linkType: hard
 
@@ -1657,12 +1671,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.10.0, acorn@npm:^8.9.0":
-  version: 8.11.2
-  resolution: "acorn@npm:8.11.2"
+"acorn@npm:^8.10.0, acorn@npm:^8.11.3, acorn@npm:^8.9.0":
+  version: 8.11.3
+  resolution: "acorn@npm:8.11.3"
   bin:
     acorn: bin/acorn
-  checksum: ff559b891382ad4cd34cc3c493511d0a7075a51f5f9f02a03440e92be3705679367238338566c5fbd3521ecadd565d29301bc8e16cb48379206bffbff3d72500
+  checksum: b688e7e3c64d9bfb17b596e1b35e4da9d50553713b3b3630cf5690f2b023a84eac90c56851e6912b483fe60e8b4ea28b254c07e92f17ef83d72d78745a8352dd
   languageName: node
   linkType: hard
 
@@ -2204,22 +2218,22 @@ __metadata:
   linkType: hard
 
 "cacache@npm:^18.0.0":
-  version: 18.0.0
-  resolution: "cacache@npm:18.0.0"
+  version: 18.0.2
+  resolution: "cacache@npm:18.0.2"
   dependencies:
     "@npmcli/fs": "npm:^3.1.0"
     fs-minipass: "npm:^3.0.0"
     glob: "npm:^10.2.2"
     lru-cache: "npm:^10.0.1"
     minipass: "npm:^7.0.3"
-    minipass-collect: "npm:^1.0.2"
+    minipass-collect: "npm:^2.0.1"
     minipass-flush: "npm:^1.0.5"
     minipass-pipeline: "npm:^1.2.4"
     p-map: "npm:^4.0.0"
     ssri: "npm:^10.0.0"
     tar: "npm:^6.1.11"
     unique-filename: "npm:^3.0.0"
-  checksum: b71fefe97b9799a863dc48ac79da2bd57a724ff0922fddd3aef4f3b70395ba00d1ef9547a0594d3d6d3cd57aeaeaf4d938c54f89695053eb2198cf8758b47511
+  checksum: 5ca58464f785d4d64ac2019fcad95451c8c89bea25949f63acd8987fcc3493eaef1beccc0fa39e673506d879d3fc1ab420760f8a14f8ddf46ea2d121805a5e96
   languageName: node
   linkType: hard
 
@@ -2237,7 +2251,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"call-bind@npm:^1.0.0, call-bind@npm:^1.0.2, call-bind@npm:^1.0.4":
+"call-bind@npm:^1.0.0, call-bind@npm:^1.0.2, call-bind@npm:^1.0.4, call-bind@npm:^1.0.5":
   version: 1.0.5
   resolution: "call-bind@npm:1.0.5"
   dependencies:
@@ -2284,8 +2298,8 @@ __metadata:
   linkType: hard
 
 "chai@npm:^4.3.10":
-  version: 4.3.10
-  resolution: "chai@npm:4.3.10"
+  version: 4.4.1
+  resolution: "chai@npm:4.4.1"
   dependencies:
     assertion-error: "npm:^1.1.0"
     check-error: "npm:^1.0.3"
@@ -2294,7 +2308,7 @@ __metadata:
     loupe: "npm:^2.3.6"
     pathval: "npm:^1.1.1"
     type-detect: "npm:^4.0.8"
-  checksum: 9e545fd60f5efee4f06f7ad62f7b1b142932b08fbb3454db69defd511e7c58771ce51843764212da1e129b2c9d1b029fbf5f98da030fe67a95a0853e8679524f
+  checksum: c6d7aba913a67529c68dbec3673f94eb9c586c5474cc5142bd0b587c9c9ec9e5fbaa937e038ecaa6475aea31433752d5fabdd033b9248bde6ae53befcde774ae
   languageName: node
   linkType: hard
 
@@ -2433,9 +2447,9 @@ __metadata:
   linkType: hard
 
 "cli-spinners@npm:^2.5.0":
-  version: 2.9.1
-  resolution: "cli-spinners@npm:2.9.1"
-  checksum: 80b7b21f2e713729041b26afd02cd881a05ba83d0973c60d332e6010261a732a42d039bdf401dec32645cba41a69324880bbbd999c8876b1eb9888451137df01
+  version: 2.9.2
+  resolution: "cli-spinners@npm:2.9.2"
+  checksum: a0a863f442df35ed7294424f5491fa1756bd8d2e4ff0c8736531d886cec0ece4d85e8663b77a5afaf1d296e3cbbebff92e2e99f52bbea89b667cbe789b994794
   languageName: node
   linkType: hard
 
@@ -3016,7 +3030,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:4.3.4, debug@npm:^4.1.1, debug@npm:^4.3.2, debug@npm:^4.3.4":
+"debug@npm:4, debug@npm:4.3.4, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4":
   version: 4.3.4
   resolution: "debug@npm:4.3.4"
   dependencies:
@@ -3088,7 +3102,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"define-properties@npm:^1.1.4":
+"define-properties@npm:^1.2.1":
   version: 1.2.1
   resolution: "define-properties@npm:1.2.1"
   dependencies:
@@ -3260,9 +3274,9 @@ __metadata:
   linkType: hard
 
 "dotenv@npm:^16.0.3, dotenv@npm:^16.3.1":
-  version: 16.3.1
-  resolution: "dotenv@npm:16.3.1"
-  checksum: dbb778237ef8750e9e3cd1473d3c8eaa9cc3600e33a75c0e36415d0fa0848197f56c3800f77924c70e7828f0b03896818cd52f785b07b9ad4d88dba73fbba83f
+  version: 16.4.1
+  resolution: "dotenv@npm:16.4.1"
+  checksum: 8da20250633703686961004df3ea81b1f81e16fbe873372050676f54ca4053172d0589aae902e683eb575884d56b6bc89fe48bbac5e1e0bef606a061389ca33c
   languageName: node
   linkType: hard
 
@@ -3386,32 +3400,35 @@ __metadata:
   linkType: hard
 
 "esbuild@npm:^0.19.3":
-  version: 0.19.5
-  resolution: "esbuild@npm:0.19.5"
+  version: 0.19.12
+  resolution: "esbuild@npm:0.19.12"
   dependencies:
-    "@esbuild/android-arm": "npm:0.19.5"
-    "@esbuild/android-arm64": "npm:0.19.5"
-    "@esbuild/android-x64": "npm:0.19.5"
-    "@esbuild/darwin-arm64": "npm:0.19.5"
-    "@esbuild/darwin-x64": "npm:0.19.5"
-    "@esbuild/freebsd-arm64": "npm:0.19.5"
-    "@esbuild/freebsd-x64": "npm:0.19.5"
-    "@esbuild/linux-arm": "npm:0.19.5"
-    "@esbuild/linux-arm64": "npm:0.19.5"
-    "@esbuild/linux-ia32": "npm:0.19.5"
-    "@esbuild/linux-loong64": "npm:0.19.5"
-    "@esbuild/linux-mips64el": "npm:0.19.5"
-    "@esbuild/linux-ppc64": "npm:0.19.5"
-    "@esbuild/linux-riscv64": "npm:0.19.5"
-    "@esbuild/linux-s390x": "npm:0.19.5"
-    "@esbuild/linux-x64": "npm:0.19.5"
-    "@esbuild/netbsd-x64": "npm:0.19.5"
-    "@esbuild/openbsd-x64": "npm:0.19.5"
-    "@esbuild/sunos-x64": "npm:0.19.5"
-    "@esbuild/win32-arm64": "npm:0.19.5"
-    "@esbuild/win32-ia32": "npm:0.19.5"
-    "@esbuild/win32-x64": "npm:0.19.5"
+    "@esbuild/aix-ppc64": "npm:0.19.12"
+    "@esbuild/android-arm": "npm:0.19.12"
+    "@esbuild/android-arm64": "npm:0.19.12"
+    "@esbuild/android-x64": "npm:0.19.12"
+    "@esbuild/darwin-arm64": "npm:0.19.12"
+    "@esbuild/darwin-x64": "npm:0.19.12"
+    "@esbuild/freebsd-arm64": "npm:0.19.12"
+    "@esbuild/freebsd-x64": "npm:0.19.12"
+    "@esbuild/linux-arm": "npm:0.19.12"
+    "@esbuild/linux-arm64": "npm:0.19.12"
+    "@esbuild/linux-ia32": "npm:0.19.12"
+    "@esbuild/linux-loong64": "npm:0.19.12"
+    "@esbuild/linux-mips64el": "npm:0.19.12"
+    "@esbuild/linux-ppc64": "npm:0.19.12"
+    "@esbuild/linux-riscv64": "npm:0.19.12"
+    "@esbuild/linux-s390x": "npm:0.19.12"
+    "@esbuild/linux-x64": "npm:0.19.12"
+    "@esbuild/netbsd-x64": "npm:0.19.12"
+    "@esbuild/openbsd-x64": "npm:0.19.12"
+    "@esbuild/sunos-x64": "npm:0.19.12"
+    "@esbuild/win32-arm64": "npm:0.19.12"
+    "@esbuild/win32-ia32": "npm:0.19.12"
+    "@esbuild/win32-x64": "npm:0.19.12"
   dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
     "@esbuild/android-arm":
       optional: true
     "@esbuild/android-arm64":
@@ -3458,7 +3475,7 @@ __metadata:
       optional: true
   bin:
     esbuild: bin/esbuild
-  checksum: f8ffe0cbab8a80ec63b6962b7d722da9e3dbe79a57d3cd998e107e35792068facd6f63e58ae19e919891456ed6cb73114a9777f0e7353ec8613b4fc75571d56d
+  checksum: 861fa8eb2428e8d6521a4b7c7930139e3f45e8d51a86985cc29408172a41f6b18df7b3401e7e5e2d528cdf83742da601ddfdc77043ddc4f1c715a8ddb2d8a255
   languageName: node
   linkType: hard
 
@@ -3797,11 +3814,11 @@ __metadata:
   linkType: hard
 
 "fastq@npm:^1.6.0":
-  version: 1.15.0
-  resolution: "fastq@npm:1.15.0"
+  version: 1.16.0
+  resolution: "fastq@npm:1.16.0"
   dependencies:
     reusify: "npm:^1.0.4"
-  checksum: 67c01b1c972e2d5b6fea197a1a39d5d582982aea69ff4c504badac71080d8396d4843b165a9686e907c233048f15a86bbccb0e7f83ba771f6fa24bcde059d0c3
+  checksum: de151543aab9d91900ed5da88860c46987ece925c628df586fac664235f25e020ec20729e1c032edb5fd2520fd4aa5b537d69e39b689e65e82112cfbecb4479e
   languageName: node
   linkType: hard
 
@@ -3889,13 +3906,13 @@ __metadata:
   linkType: hard
 
 "flat-cache@npm:^3.0.4":
-  version: 3.1.1
-  resolution: "flat-cache@npm:3.1.1"
+  version: 3.2.0
+  resolution: "flat-cache@npm:3.2.0"
   dependencies:
     flatted: "npm:^3.2.9"
     keyv: "npm:^4.5.3"
     rimraf: "npm:^3.0.2"
-  checksum: 04b57c7cb4bd54f1e80a335f037bff467cc7b2479ecc015ff7e78fd41aa12777757d55836e99c7e5faca2271eb204a96bf109b4d98c36c20c3b98cf1372b5592
+  checksum: 02381c6ece5e9fa5b826c9bbea481d7fd77645d96e4b0b1395238124d581d10e56f17f723d897b6d133970f7a57f0fab9148cbbb67237a0a0ffe794ba60c0c70
   languageName: node
   linkType: hard
 
@@ -4156,11 +4173,11 @@ __metadata:
   linkType: hard
 
 "globals@npm:^13.19.0":
-  version: 13.23.0
-  resolution: "globals@npm:13.23.0"
+  version: 13.24.0
+  resolution: "globals@npm:13.24.0"
   dependencies:
     type-fest: "npm:^0.20.2"
-  checksum: bf6a8616f4a64959c0b9a8eb4dc8a02e7dd0082385f7f06bc9694d9fceabe39f83f83789322cfe0470914dc8b273b7a29af5570b9e1a0507d3fb7348a64703a3
+  checksum: 62c5b1997d06674fc7191d3e01e324d3eda4d65ac9cc4e78329fa3b5c4fd42a0e1c8722822497a6964eee075255ce21ccf1eec2d83f92ef3f06653af4d0ee28e
   languageName: node
   linkType: hard
 
@@ -4231,7 +4248,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has-property-descriptors@npm:^1.0.0":
+"has-property-descriptors@npm:^1.0.0, has-property-descriptors@npm:^1.0.1":
   version: 1.0.1
   resolution: "has-property-descriptors@npm:1.0.1"
   dependencies:
@@ -4445,11 +4462,11 @@ __metadata:
   linkType: hard
 
 "i18next@npm:^23.7.16":
-  version: 23.7.18
-  resolution: "i18next@npm:23.7.18"
+  version: 23.7.19
+  resolution: "i18next@npm:23.7.19"
   dependencies:
     "@babel/runtime": "npm:^7.23.2"
-  checksum: 35cff337e3ecd407d9b98d3ca0e788bd3a65adf8048d11b80e722be586dff126d9bb6803ccd48efbcc2460f10ec54def08657ac32acee732ea16a96eef7cbbfd
+  checksum: fbfce98aae854ae5c68b784ae36becfb0833b08329a46f9c49396f8af09f25f23611d7cd78dc3666fdead45d697173cf43d97b014cdf7042513ed922054fd515
   languageName: node
   linkType: hard
 
@@ -4479,9 +4496,9 @@ __metadata:
   linkType: hard
 
 "ignore@npm:^5.2.0, ignore@npm:^5.2.4":
-  version: 5.2.4
-  resolution: "ignore@npm:5.2.4"
-  checksum: 4f7caf5d2005da21a382d4bd1d2aa741a3bed51de185c8562dd7f899a81a620ac4fd0619b06f7029a38ae79e4e4c134399db3bd0192c703c3ef54bb82df3086c
+  version: 5.3.0
+  resolution: "ignore@npm:5.3.0"
+  checksum: 51594355cea4c6ad6b28b3b85eb81afa7b988a1871feefd7062baf136c95aa06760ee934fa9590e43d967bd377ce84a4cf6135fbeb6063e063f1182a0e9a3bcd
   languageName: node
   linkType: hard
 
@@ -4971,9 +4988,9 @@ __metadata:
   linkType: hard
 
 "jsonc-parser@npm:^3.2.0":
-  version: 3.2.0
-  resolution: "jsonc-parser@npm:3.2.0"
-  checksum: bd68b902e5f9394f01da97921f49c5084b2dc03a0c5b4fdb2a429f8d6f292686c1bf87badaeb0a8148d024192a88f5ad2e57b2918ba43fe25cf15f3371db64d4
+  version: 3.2.1
+  resolution: "jsonc-parser@npm:3.2.1"
+  checksum: fe2df6f39e21653781d52cae20c5b9e0ab62461918d97f9430b216cea9b6500efc1d8b42c6584cc0a7548b4c996055e9cdc39f09b9782fa6957af2f45306c530
   languageName: node
   linkType: hard
 
@@ -5278,9 +5295,9 @@ __metadata:
   linkType: hard
 
 "lru-cache@npm:^10.0.1, lru-cache@npm:^9.1.1 || ^10.0.0":
-  version: 10.0.1
-  resolution: "lru-cache@npm:10.0.1"
-  checksum: 5bb91a97a342a41fd049c3494b44d9e21a7d4843f9284d0a0b26f00bb0e436f1f627d0641c78f88be16b86b4231546c5ee4f284733fb530c7960f0bcd7579026
+  version: 10.2.0
+  resolution: "lru-cache@npm:10.2.0"
+  checksum: 502ec42c3309c0eae1ce41afca471f831c278566d45a5273a0c51102dee31e0e250a62fa9029c3370988df33a14188a38e682c16143b794de78668de3643e302
   languageName: node
   linkType: hard
 
@@ -5294,9 +5311,9 @@ __metadata:
   linkType: hard
 
 "magic-bytes.js@npm:^1.5.0":
-  version: 1.5.0
-  resolution: "magic-bytes.js@npm:1.5.0"
-  checksum: ffb86aec8f4d05446355433392f5a67882c9cbcd46bc1d53ece4f46f73938ec16a35ad4d53decda661185c92e3007a94243bf48809bc73f111a8a28b63eeee19
+  version: 1.8.0
+  resolution: "magic-bytes.js@npm:1.8.0"
+  checksum: 781c932f649f99f334de61d18cd8dd36a0613f8c524756dcfea657d34e114161ef704ae9bf04287f0c1a5341c1a9bd766907199dfb5e916d1e336de9ff103544
   languageName: node
   linkType: hard
 
@@ -5547,12 +5564,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minipass-collect@npm:^1.0.2":
-  version: 1.0.2
-  resolution: "minipass-collect@npm:1.0.2"
+"minipass-collect@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "minipass-collect@npm:2.0.1"
   dependencies:
-    minipass: "npm:^3.0.0"
-  checksum: 14df761028f3e47293aee72888f2657695ec66bd7d09cae7ad558da30415fdc4752bbfee66287dcc6fd5e6a2fa3466d6c484dc1cbd986525d9393b9523d97f10
+    minipass: "npm:^7.0.3"
+  checksum: b251bceea62090f67a6cced7a446a36f4cd61ee2d5cea9aee7fff79ba8030e416327a1c5aa2908dc22629d06214b46d88fdab8c51ac76bacbf5703851b5ad342
   languageName: node
   linkType: hard
 
@@ -5657,14 +5674,14 @@ __metadata:
   linkType: hard
 
 "mlly@npm:^1.2.0, mlly@npm:^1.4.2":
-  version: 1.4.2
-  resolution: "mlly@npm:1.4.2"
+  version: 1.5.0
+  resolution: "mlly@npm:1.5.0"
   dependencies:
-    acorn: "npm:^8.10.0"
-    pathe: "npm:^1.1.1"
+    acorn: "npm:^8.11.3"
+    pathe: "npm:^1.1.2"
     pkg-types: "npm:^1.0.3"
-    ufo: "npm:^1.3.0"
-  checksum: ea5dc1a6cb2795cd15c6cdc84bbf431e0649917e673ef4de5d5ace6f74f74f02d22cd3c3faf7f868c3857115d33cccaaf5a070123b9a6c997af06ebeb8ab3bb5
+    ufo: "npm:^1.3.2"
+  checksum: c030ecb7f17a9080f04746cc9bf1a73f55a86dcad55c1597d20349737e07ec66a09ea1bcac0d36984cb1d532b79200c235086ab2291d678224f9082946cf530e
   languageName: node
   linkType: hard
 
@@ -5694,9 +5711,9 @@ __metadata:
   linkType: hard
 
 "morphdom@npm:^2.3.3":
-  version: 2.7.1
-  resolution: "morphdom@npm:2.7.1"
-  checksum: 0d25eec572a4383c501e595a3d950d097344e961b3e73fa6e675dc5b620f5169a05258fa9609c692ca5b368d2018ef27762ff8de92f1e305e3196d0e55238005
+  version: 2.7.2
+  resolution: "morphdom@npm:2.7.2"
+  checksum: aa8860bf4a31c9272bfb5ca3ade7db63009a4971d587a369f2e55d669b6ce3e6a674ed0bb16f542cd1f7102b46f2fcafecd9052f8768d7ac11abdd4204bc1e3b
   languageName: node
   linkType: hard
 
@@ -5817,11 +5834,11 @@ __metadata:
   linkType: hard
 
 "node-addon-api@npm:*":
-  version: 7.0.0
-  resolution: "node-addon-api@npm:7.0.0"
+  version: 7.1.0
+  resolution: "node-addon-api@npm:7.1.0"
   dependencies:
     node-gyp: "npm:latest"
-  checksum: f1a54ae38f6cbd4cdfe69d1b2f3f0c4a3d227eb50f5073f0a3b985d29a0c39c94b82c88213e5075ee1bc262f2e869841c733ebe7111a5e376f1732649edf6a93
+  checksum: e20487e98c76660f4957e81e85c45dfb667140d9be0bf872a3b3dfd86b4ea19c0275939116c90efebc0da7fc6af2c7b7b060512ceebe6417b1ed145a26910453
   languageName: node
   linkType: hard
 
@@ -5833,13 +5850,13 @@ __metadata:
   linkType: hard
 
 "node-gyp-build@npm:^4.3.0":
-  version: 4.6.1
-  resolution: "node-gyp-build@npm:4.6.1"
+  version: 4.8.0
+  resolution: "node-gyp-build@npm:4.8.0"
   bin:
     node-gyp-build: bin.js
     node-gyp-build-optional: optional.js
     node-gyp-build-test: build-test.js
-  checksum: 79b948377492ae8e1aa1c18071661e6020c11f8847d5ce822abd67ec02bee5b21715b1b4861041d2b40d16633824476735bc9a60e81c82c49e715d55ee29b206
+  checksum: 80f410ab412df38e84171d3634a5716b6c6f14ecfa4eb971424d289381fb76f8bcbe1b666419ceb2c81060e558fd7c6d70cc0f60832bcca6a1559098925d9657
   languageName: node
   linkType: hard
 
@@ -5922,11 +5939,11 @@ __metadata:
   linkType: hard
 
 "npm-run-path@npm:^5.1.0":
-  version: 5.1.0
-  resolution: "npm-run-path@npm:5.1.0"
+  version: 5.2.0
+  resolution: "npm-run-path@npm:5.2.0"
   dependencies:
     path-key: "npm:^4.0.0"
-  checksum: dc184eb5ec239d6a2b990b43236845332ef12f4e0beaa9701de724aa797fe40b6bbd0157fb7639d24d3ab13f5d5cf22d223a19c6300846b8126f335f788bee66
+  checksum: c5325e016014e715689c4014f7e0be16cc4cbf529f32a1723e511bc4689b5f823b704d2bca61ac152ce2bda65e0205dc8b3ba0ec0f5e4c3e162d302f6f5b9efb
   languageName: node
   linkType: hard
 
@@ -5959,14 +5976,14 @@ __metadata:
   linkType: hard
 
 "object.assign@npm:^4.1.4":
-  version: 4.1.4
-  resolution: "object.assign@npm:4.1.4"
+  version: 4.1.5
+  resolution: "object.assign@npm:4.1.5"
   dependencies:
-    call-bind: "npm:^1.0.2"
-    define-properties: "npm:^1.1.4"
+    call-bind: "npm:^1.0.5"
+    define-properties: "npm:^1.2.1"
     has-symbols: "npm:^1.0.3"
     object-keys: "npm:^1.1.1"
-  checksum: fd82d45289df0a952d772817622ecbaeb4ec933d3abb53267aede083ee38f6a395af8fadfbc569ee575115b0b7c9b286e7cfb2b7a2557b1055f7acbce513bc29
+  checksum: dbb22da4cda82e1658349ea62b80815f587b47131b3dd7a4ab7f84190ab31d206bbd8fe7e26ae3220c55b65725ac4529825f6142154211220302aa6b1518045d
   languageName: node
   linkType: hard
 
@@ -6279,10 +6296,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pathe@npm:^1.1.0, pathe@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "pathe@npm:1.1.1"
-  checksum: 603decdf751d511f0df10acb8807eab8cc25c1af529e6149e27166916f19db57235a7d374b125452ba6da4dd0f697656fdaf5a9236b3594929bb371726d31602
+"pathe@npm:^1.1.0, pathe@npm:^1.1.1, pathe@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "pathe@npm:1.1.2"
+  checksum: f201d796351bf7433d147b92c20eb154a4e0ea83512017bf4ec4e492a5d6e738fb45798be4259a61aa81270179fce11026f6ff0d3fa04173041de044defe9d80
   languageName: node
   linkType: hard
 
@@ -6373,17 +6390,17 @@ __metadata:
   linkType: hard
 
 "pg-types@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "pg-types@npm:4.0.1"
+  version: 4.0.2
+  resolution: "pg-types@npm:4.0.2"
   dependencies:
     pg-int8: "npm:1.0.1"
     pg-numeric: "npm:1.0.2"
     postgres-array: "npm:~3.0.1"
     postgres-bytea: "npm:~3.0.0"
-    postgres-date: "npm:~2.0.1"
+    postgres-date: "npm:~2.1.0"
     postgres-interval: "npm:^3.0.0"
     postgres-range: "npm:^1.1.1"
-  checksum: 2c686ef361856ff9695a40cf34d7bb59bcf2218bd1f121d7fc8b77a75cc4106c09519e9520a82aac8fce4540dec81f695458b8e43bfc420ba74eb9b5005b5619
+  checksum: f4d529da864d4169afab300eb8629a84a6a06aa70c471160a7e46c34b6d4dd0e61cbd57d10d98c3a36e98f474e2ff85d41e4b1c953a321146b4bae09372c58d3
   languageName: node
   linkType: hard
 
@@ -6455,13 +6472,13 @@ __metadata:
   linkType: hard
 
 "postcss@npm:^8.4.32":
-  version: 8.4.32
-  resolution: "postcss@npm:8.4.32"
+  version: 8.4.33
+  resolution: "postcss@npm:8.4.33"
   dependencies:
     nanoid: "npm:^3.3.7"
     picocolors: "npm:^1.0.0"
     source-map-js: "npm:^1.0.2"
-  checksum: 28084864122f29148e1f632261c408444f5ead0e0b9ea9bd9729d0468818ebe73fe5dc0075acd50c1365dbe639b46a79cba27d355ec857723a24bc9af0f18525
+  checksum: e22a4594c255f26117f38419fb494d7ecab0f596cd409f7aadc8a6173abf180ed7ea970cd13fd366ab12b5840be901d2a09b25197700c2ebcb5a8077326bf519
   languageName: node
   linkType: hard
 
@@ -6502,10 +6519,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postgres-date@npm:~2.0.1":
-  version: 2.0.1
-  resolution: "postgres-date@npm:2.0.1"
-  checksum: 908eacec35faf9b6fa4248074e7c8db0fc4ac6a2e0a00eacef9fb9cf44a25fc6f100af7cda09f5d89d076c87923b59e940a309560d86aded4753985c97255be1
+"postgres-date@npm:~2.1.0":
+  version: 2.1.0
+  resolution: "postgres-date@npm:2.1.0"
+  checksum: faa1c70dfad0e35bd4aa7cb6088fcd4e4f039aa25dc42150129178fc2a0baa7e37eca0bf18e4142a40dea18d1955459b08783f78ec487ef27b4b93ab5e854597
   languageName: node
   linkType: hard
 
@@ -6807,16 +6824,16 @@ __metadata:
   linkType: hard
 
 "reflect-metadata@npm:^0.1.13":
-  version: 0.1.13
-  resolution: "reflect-metadata@npm:0.1.13"
-  checksum: 732570da35d2d96f8fdd5aac60fb263aa92f6512eaded5962b052bd9e90f22a9dec5aaf0d7ff4bfe97646c9530e8444e8435c2d80b24d0bdf938b5d47f6f5b83
+  version: 0.1.14
+  resolution: "reflect-metadata@npm:0.1.14"
+  checksum: fcab9c17ec3b9fea0e2f748c2129aceb57c24af6d8d13842b8a77c8c79dde727d7456ce293e76e8d7b267d1dbf93eea4c5b3c9101299a789a075824f2e40f1ee
   languageName: node
   linkType: hard
 
 "regenerator-runtime@npm:^0.14.0":
-  version: 0.14.0
-  resolution: "regenerator-runtime@npm:0.14.0"
-  checksum: 6c19495baefcf5fbb18a281b56a97f0197b5f219f42e571e80877f095320afac0bdb31dab8f8186858e6126950068c3f17a1226437881e3e70446ea66751897c
+  version: 0.14.1
+  resolution: "regenerator-runtime@npm:0.14.1"
+  checksum: 5db3161abb311eef8c45bcf6565f4f378f785900ed3945acf740a9888c792f75b98ecb77f0775f3bf95502ff423529d23e94f41d80c8256e8fa05ed4b07cf471
   languageName: node
   linkType: hard
 
@@ -6928,9 +6945,9 @@ __metadata:
   linkType: hard
 
 "rfdc@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "rfdc@npm:1.3.0"
-  checksum: 76dedd9700cdf132947fde7ce1a8838c9cbb7f3e8f9188af0aaf97194cce745f42094dd2cf547426934cc83252ee2c0e432b2e0222a4415ab0db32de82665c69
+  version: 1.3.1
+  resolution: "rfdc@npm:1.3.1"
+  checksum: 44cc6a82e2fe1db13b7d3c54e9ffd0b40ef070cbde69ffbfbb38dab8cee46bd68ba686784b96365ff08d04798bc121c3465663a0c91f2c421c90546c4366f4a6
   languageName: node
   linkType: hard
 
@@ -6956,21 +6973,23 @@ __metadata:
   linkType: hard
 
 "rollup@npm:^4.2.0":
-  version: 4.3.0
-  resolution: "rollup@npm:4.3.0"
+  version: 4.9.6
+  resolution: "rollup@npm:4.9.6"
   dependencies:
-    "@rollup/rollup-android-arm-eabi": "npm:4.3.0"
-    "@rollup/rollup-android-arm64": "npm:4.3.0"
-    "@rollup/rollup-darwin-arm64": "npm:4.3.0"
-    "@rollup/rollup-darwin-x64": "npm:4.3.0"
-    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.3.0"
-    "@rollup/rollup-linux-arm64-gnu": "npm:4.3.0"
-    "@rollup/rollup-linux-arm64-musl": "npm:4.3.0"
-    "@rollup/rollup-linux-x64-gnu": "npm:4.3.0"
-    "@rollup/rollup-linux-x64-musl": "npm:4.3.0"
-    "@rollup/rollup-win32-arm64-msvc": "npm:4.3.0"
-    "@rollup/rollup-win32-ia32-msvc": "npm:4.3.0"
-    "@rollup/rollup-win32-x64-msvc": "npm:4.3.0"
+    "@rollup/rollup-android-arm-eabi": "npm:4.9.6"
+    "@rollup/rollup-android-arm64": "npm:4.9.6"
+    "@rollup/rollup-darwin-arm64": "npm:4.9.6"
+    "@rollup/rollup-darwin-x64": "npm:4.9.6"
+    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.9.6"
+    "@rollup/rollup-linux-arm64-gnu": "npm:4.9.6"
+    "@rollup/rollup-linux-arm64-musl": "npm:4.9.6"
+    "@rollup/rollup-linux-riscv64-gnu": "npm:4.9.6"
+    "@rollup/rollup-linux-x64-gnu": "npm:4.9.6"
+    "@rollup/rollup-linux-x64-musl": "npm:4.9.6"
+    "@rollup/rollup-win32-arm64-msvc": "npm:4.9.6"
+    "@rollup/rollup-win32-ia32-msvc": "npm:4.9.6"
+    "@rollup/rollup-win32-x64-msvc": "npm:4.9.6"
+    "@types/estree": "npm:1.0.5"
     fsevents: "npm:~2.3.2"
   dependenciesMeta:
     "@rollup/rollup-android-arm-eabi":
@@ -6987,6 +7006,8 @@ __metadata:
       optional: true
     "@rollup/rollup-linux-arm64-musl":
       optional: true
+    "@rollup/rollup-linux-riscv64-gnu":
+      optional: true
     "@rollup/rollup-linux-x64-gnu":
       optional: true
     "@rollup/rollup-linux-x64-musl":
@@ -7001,7 +7022,7 @@ __metadata:
       optional: true
   bin:
     rollup: dist/bin/rollup
-  checksum: b0d8ab6686053260747b6a05ca66b898271ce8dea69e5e3c3570b7ba4f56150798ca3bc3a0159a33fd914e3df2d10502b3b8c89337a4883e85438ab2eee9dac8
+  checksum: 7c343d9d8ece2ebfbde20b62545f7ee16cbba719da94584fef72ad2f0bdea5f2c49cc429839350e7a4181be04e01bfcd1bd45e1654b8b288a612c409eaebdae4
   languageName: node
   linkType: hard
 
@@ -7081,14 +7102,15 @@ __metadata:
   linkType: hard
 
 "set-function-length@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "set-function-length@npm:1.1.1"
+  version: 1.2.0
+  resolution: "set-function-length@npm:1.2.0"
   dependencies:
     define-data-property: "npm:^1.1.1"
-    get-intrinsic: "npm:^1.2.1"
+    function-bind: "npm:^1.1.2"
+    get-intrinsic: "npm:^1.2.2"
     gopd: "npm:^1.0.1"
-    has-property-descriptors: "npm:^1.0.0"
-  checksum: 745ed1d7dc69a6185e0820082fe73838ab3dfd01e75cce83a41e4c1d68bbf34bc5fb38f32ded542ae0b557536b5d2781594499b5dcd19e7db138e06292a76c7b
+    has-property-descriptors: "npm:^1.0.1"
+  checksum: 6d609cd060c488d7d2178a5d4c3689f8a6afa26fa4c48ff4a0516664ff9b84c1c0898915777f5628092dab55c4fcead205525e2edd15c659423bf86f790fdcae
   languageName: node
   linkType: hard
 
@@ -7189,8 +7211,8 @@ __metadata:
   resolution: "skyra@workspace:."
   dependencies:
     0x: "npm:^5.7.0"
-    "@commitlint/cli": "npm:^18.4.4"
-    "@commitlint/config-conventional": "npm:^18.4.4"
+    "@commitlint/cli": "npm:^18.6.0"
+    "@commitlint/config-conventional": "npm:^18.6.0"
     "@discordjs/builders": "npm:^1.7.0"
     "@discordjs/collection": "npm:^2.0.0"
     "@discordjs/core": "npm:^1.1.1"
@@ -7215,8 +7237,8 @@ __metadata:
     "@sapphire/time-utilities": "npm:^1.7.12"
     "@sapphire/ts-config": "npm:^5.0.0"
     "@sapphire/utilities": "npm:^3.15.3"
-    "@sentry/integrations": "npm:^7.94.1"
-    "@sentry/node": "npm:^7.94.1"
+    "@sentry/integrations": "npm:^7.98.0"
+    "@sentry/node": "npm:^7.98.0"
     "@skyra/ai": "npm:^1.2.0"
     "@skyra/char": "npm:^1.0.3"
     "@skyra/env-utilities": "npm:^1.3.0"
@@ -7225,10 +7247,10 @@ __metadata:
     "@types/diff": "npm:^5.0.9"
     "@types/he": "npm:^1.2.3"
     "@types/node": "npm:^20.11.5"
-    "@types/pg": "npm:^8.10.9"
+    "@types/pg": "npm:^8.11.0"
     "@types/ws": "npm:^8.5.10"
-    "@typescript-eslint/eslint-plugin": "npm:^6.19.0"
-    "@typescript-eslint/parser": "npm:^6.19.0"
+    "@typescript-eslint/eslint-plugin": "npm:^6.19.1"
+    "@typescript-eslint/parser": "npm:^6.19.1"
     "@vitest/coverage-v8": "npm:^1.2.1"
     async-rwlock: "npm:^1.1.1"
     bufferutil: "npm:^4.0.8"
@@ -7348,9 +7370,9 @@ __metadata:
   linkType: hard
 
 "spdx-exceptions@npm:^2.1.0":
-  version: 2.3.0
-  resolution: "spdx-exceptions@npm:2.3.0"
-  checksum: cb69a26fa3b46305637123cd37c85f75610e8c477b6476fa7354eb67c08128d159f1d36715f19be6f9daf4b680337deb8c65acdcae7f2608ba51931540687ac0
+  version: 2.4.0
+  resolution: "spdx-exceptions@npm:2.4.0"
+  checksum: b1b650a8d94424473bf9629cf972c86a91c03cccc260f5c901bce0e4b92d831627fec28c9e0a1e9c34c5ebad0a12cf2eab887bec088e0a862abb9d720c2fd0a1
   languageName: node
   linkType: hard
 
@@ -7461,9 +7483,9 @@ __metadata:
   linkType: hard
 
 "stream-shift@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "stream-shift@npm:1.0.1"
-  checksum: 59b82b44b29ec3699b5519a49b3cedcc6db58c72fb40c04e005525dfdcab1c75c4e0c180b923c380f204bed78211b9bad8faecc7b93dece4d004c3f6ec75737b
+  version: 1.0.3
+  resolution: "stream-shift@npm:1.0.3"
+  checksum: a24c0a3f66a8f9024bd1d579a533a53be283b4475d4e6b4b3211b964031447bdf6532dd1f3c2b0ad66752554391b7c62bd7ca4559193381f766534e723d50242
   languageName: node
   linkType: hard
 
@@ -7518,13 +7540,13 @@ __metadata:
   linkType: hard
 
 "string-width@npm:^7.0.0":
-  version: 7.0.0
-  resolution: "string-width@npm:7.0.0"
+  version: 7.1.0
+  resolution: "string-width@npm:7.1.0"
   dependencies:
     emoji-regex: "npm:^10.3.0"
     get-east-asian-width: "npm:^1.0.0"
     strip-ansi: "npm:^7.1.0"
-  checksum: bc0de5700a2690895169fce447ec4ed44bc62de80312c2093d5606bfd48319bb88e48a99e97f269dff2bc9577448b91c26b3804c16e7d9b389699795e4655c3b
+  checksum: a183573fe7209e0d294f661846d33f8caf72aa86d983e5b48a0ed45ab15bcccb02c6f0344b58b571988871105457137b8207855ea536827dbc4a376a0f31bf8f
   languageName: node
   linkType: hard
 
@@ -7789,16 +7811,16 @@ __metadata:
   linkType: hard
 
 "tinybench@npm:^2.5.1":
-  version: 2.5.1
-  resolution: "tinybench@npm:2.5.1"
-  checksum: f64ea142e048edc5010027eca36aff5aef74cd849ab9c6ba6e39475f911309694cb5a7ff894d47216ab4a3abcf4291e4bdc7a57796e96bf5b06e67452b5ac54d
+  version: 2.6.0
+  resolution: "tinybench@npm:2.6.0"
+  checksum: 6d35f0540bbf6208e8f47fa88cad733bc4b35b3bea75ec995004a9a44f70b8947eff3d271a3b4a4f7e787a82211df0dec9370fa566ccf50441067c559382b3ed
   languageName: node
   linkType: hard
 
 "tinypool@npm:^0.8.1":
-  version: 0.8.1
-  resolution: "tinypool@npm:0.8.1"
-  checksum: 3fae8acc22b7d0364eb202b64f61f0d8b10dcead6bef9b8fab1836857dcecd0e34fadc47ab309754ead2cb29bfa4b3467a9fc0daae23669b19ff403ae1364b5c
+  version: 0.8.2
+  resolution: "tinypool@npm:0.8.2"
+  checksum: 5e2cdddc1caf437e3b8d8c56c1c66dffcb46008be4b2e37d457b0921699c6b79930dd8d652e4890c5e1e24688489259da83fd853bc0ce348d8a0375dedefc2ba
   languageName: node
   linkType: hard
 
@@ -7809,21 +7831,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tldts-core@npm:^6.1.2":
-  version: 6.1.2
-  resolution: "tldts-core@npm:6.1.2"
-  checksum: 9ae2f1e0b842d8206daf7c832d2b82a6feba744124df5884ea9f2a49533fb91dc40b400e53190315717b11d2b441a749892d045edf4978c74fc4e89a955dd53e
+"tldts-core@npm:^6.1.3":
+  version: 6.1.3
+  resolution: "tldts-core@npm:6.1.3"
+  checksum: 85bc578d0e8d7eb4935f684fe19cd57b0c748a77fca5462cf188b0af774c3d8ebd4fff1a36f6df9292efd57fc7988b63890cc06ec7a96557f552e9d302cce1cb
   languageName: node
   linkType: hard
 
 "tldts@npm:^6.1.2":
-  version: 6.1.2
-  resolution: "tldts@npm:6.1.2"
+  version: 6.1.3
+  resolution: "tldts@npm:6.1.3"
   dependencies:
-    tldts-core: "npm:^6.1.2"
+    tldts-core: "npm:^6.1.3"
   bin:
     tldts: bin/cli.js
-  checksum: 1abac96e56519b5ba074a5f379373ac6827877d7767994e50bb54b2661449b24d87d7c61e288f11e1a30065c08ace9f1f97359d0952cd73f0480de08584d0747
+  checksum: c0923ce987da356a2972d64cb37da195544edacbba726850714ed801a5acc61749b6b72f05967c454bc424a8929fde4522b2b7364ff3f0a195c6080e67674733
   languageName: node
   linkType: hard
 
@@ -8101,10 +8123,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ufo@npm:^1.3.0":
-  version: 1.3.1
-  resolution: "ufo@npm:1.3.1"
-  checksum: cc10314a5065c50995167a2c4bbe04c3929f6a750f09e5a805cc647e2a16ea5556360b3c22a4cb03fe32cb18877d37c5f833a44930633916a916fac41be25d14
+"ufo@npm:^1.3.2":
+  version: 1.3.2
+  resolution: "ufo@npm:1.3.2"
+  checksum: 7133290d495e2b3f9416de69982019e81cff40d28cfd3a07accff1122ee52f23d9165e495a140a1b34b183244e88fc4001cb649591385ecbad1d3d0d2264fa6e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Implements the base for future interaction-based commands in Skyra, starting with `whois`.

<table>
<tr>
 <td>Old
 <td>New
<tr>
 <td>

![image](https://github.com/skyra-project/skyra/assets/24852502/b1cfd545-bba1-4e1a-bf84-4743b1f132b0)

 <td>

![image](https://github.com/skyra-project/skyra/assets/24852502/13686140-7bde-4ec4-a54e-fff7f67af867)

</table>

As shown above, the response's format has also been tweaked for cleanliness.

The relevant debug logs are added too with this PR, distinguishing from the command type:
![image](https://github.com/skyra-project/skyra/assets/24852502/14219ead-78cb-4e00-9181-db1142b2b5c1)

Furthermore, a deprecation message is sent linking to the slash command when a message command is used:
![image](https://github.com/skyra-project/skyra/assets/24852502/e2ccfb1c-fd21-4934-ae29-04340987fa18)

And lastly, the new i18n files are to slowly accomodate Skyra to the format used in the HTTP bots, slowly migrating her to the same design.