### PR TITLE
fix(logger): check for `ViewChannel` permission

### DIFF
--- a/src/lib/moderation/managers/LoggerManager.ts
+++ b/src/lib/moderation/managers/LoggerManager.ts
@@ -50,7 +50,7 @@ export class LoggerManager {
 
 		const messageOptions = this.#resolveMessageOptions(await options.makeMessage());
 
-		let requiredPermissions = PermissionFlagsBits.SendMessages;
+		let requiredPermissions = PermissionFlagsBits.SendMessages | PermissionFlagsBits.ViewChannel;
 		if (!isNullishOrEmpty(messageOptions.embeds)) requiredPermissions |= PermissionFlagsBits.EmbedLinks;
 		if (!isNullishOrEmpty(messageOptions.files)) requiredPermissions |= PermissionFlagsBits.AttachFiles;
 


### PR DESCRIPTION
This fixes the countless `50001` (MissingAccess) errors.
